### PR TITLE
Fix parsing errors from S3

### DIFF
--- a/src/apify_client/_errors.py
+++ b/src/apify_client/_errors.py
@@ -23,17 +23,19 @@ class ApifyApiError(ApifyClientError):
 
         Args:
             response: The response to the failed API call
-            attempt: Which retry was the request that failed
+            attempt: Which attempt was the request that failed
         """
         self.message: Optional[str] = None
         self.type: Optional[str] = None
 
-        response_data = response.json()
-        if 'error' in response_data:
-            self.message = response_data['error']['message']
-            self.type = response_data['error']['type']
-        else:
-            self.message = f'Unexpected error: {response.text}'
+        self.message = f'Unexpected error: {response.text}'
+        try:
+            response_data = response.json()
+            if 'error' in response_data:
+                self.message = response_data['error']['message']
+                self.type = response_data['error']['type']
+        except ValueError:
+            pass
 
         super().__init__(self.message)
 

--- a/src/apify_client/_http_client.py
+++ b/src/apify_client/_http_client.py
@@ -20,6 +20,8 @@ class _HTTPClient:
         self.min_delay_between_retries_millis = min_delay_between_retries_millis
         self.requests_session = requests.Session()
 
+        self.requests_session.headers.update({'Accept': 'application/json, */*'})
+
         # TODO add client version
         is_at_home = ('APIFY_IS_AT_HOME' in os.environ)
         python_version = '.'.join([str(x) for x in sys.version_info[:3]])


### PR DESCRIPTION
When attempting to retrieve a non-existing record from a key-value store, we get an error directly from S3, which is XML-formatted, instead of from our API servers, which return it in JSON. This fixes the parsing of those errors, enabling correct behaviour (returning None) for those missing records.

I've also set the default `Accept` header to `application/json, */*`, in order to prefer JSON responses and maintain compatibility with the JS client.