### PR TITLE
Fix max_retries and min_delay_between_retries_millis in HTTP client

### DIFF
--- a/src/apify_client/_utils.py
+++ b/src/apify_client/_utils.py
@@ -98,7 +98,7 @@ def _retry_with_exp_backoff(
         swallow = False
         raise exception
 
-    for attempt in range(1, max_retries):
+    for attempt in range(1, max_retries + 1):
         try:
             return func(bail, attempt)
         except Exception as e:
@@ -112,7 +112,7 @@ def _retry_with_exp_backoff(
         sleep_time_secs = random_sleep_factor * backoff_base_secs * backoff_exp_factor
         time.sleep(sleep_time_secs)
 
-    return func(bail, max_retries)
+    return func(bail, max_retries + 1)
 
 
 def _catch_not_found_or_throw(exc: ApifyApiError) -> None:

--- a/src/apify_client/client.py
+++ b/src/apify_client/client.py
@@ -37,7 +37,7 @@ class ApifyClient:
         self.max_retries = max_retries
         self.min_delay_between_retries_millis = min_delay_between_retries_millis
 
-        self.http_client = _HTTPClient()
+        self.http_client = _HTTPClient(max_retries=max_retries, min_delay_between_retries_millis=min_delay_between_retries_millis)
         # TODO statistics
         # TODO logger
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -140,7 +140,7 @@ class UtilsTest(unittest.TestCase):
         # Stops retrying when failed for max_retries times
         attempt_counter = 0
         with self.assertRaises(RetryableException):
-            _retry_with_exp_backoff(returns_on_fifth_attempt, max_retries=4, backoff_base_millis=1)
+            _retry_with_exp_backoff(returns_on_fifth_attempt, max_retries=3, backoff_base_millis=1)
         self.assertEqual(attempt_counter, 4)
 
         # Bails when the bail function is called


### PR DESCRIPTION
I forgot to pass those arguments when I implemented them, oops.