### PR TITLE
Schedule subclient

### DIFF
--- a/lint_and_test.sh
+++ b/lint_and_test.sh
@@ -18,7 +18,7 @@ type_check() {
 
 unit_tests() {
     echo "👮‍♀️ running unit tests"
-    python3 -m pytest -rA tests
+    python3 -m pytest -rA --doctest-modules src tests
 }
 
 

--- a/src/apify_client/_utils.py
+++ b/src/apify_client/_utils.py
@@ -4,7 +4,7 @@ import re
 import time
 from datetime import datetime, timezone
 from http import HTTPStatus
-from typing import Any, Callable, Dict, TypeVar, cast
+from typing import Any, Callable, Dict, List, TypeVar, cast
 
 from ._errors import ApifyApiError
 
@@ -53,6 +53,13 @@ def _parse_date_fields_internal(data: object, max_depth: int = PARSE_DATE_FIELDS
 def _pluck_data(parsed_response: Any) -> Dict:
     if isinstance(parsed_response, dict) and 'data' in parsed_response:
         return cast(Dict, parsed_response['data'])
+
+    raise ValueError('The "data" property is missing in the response.')
+
+
+def _pluck_data_as_list(parsed_response: Any) -> List:
+    if isinstance(parsed_response, dict) and 'data' in parsed_response:
+        return cast(List, parsed_response['data'])
 
     raise ValueError('The "data" property is missing in the response.')
 

--- a/src/apify_client/_utils.py
+++ b/src/apify_client/_utils.py
@@ -129,3 +129,21 @@ def _catch_not_found_or_throw(exc: ApifyApiError) -> None:
         raise exc
 
     return None
+
+
+def _snake_case_to_camel_case(str_snake_case: str) -> str:
+    """Convert string in snake case to camel case.
+
+    >>> _snake_case_to_camel_case("")
+    ''
+    >>> _snake_case_to_camel_case("making")
+    'making'
+    >>> _snake_case_to_camel_case("making_the_web_programmable")
+    'makingTheWebProgrammable'
+    >>> _snake_case_to_camel_case("making_the_WEB_programmable")
+    'makingTheWebProgrammable'
+    """
+    return "".join([
+        part.capitalize() if i > 0 else part
+        for i, part in enumerate(str_snake_case.split("_"))
+    ])

--- a/src/apify_client/client.py
+++ b/src/apify_client/client.py
@@ -11,6 +11,7 @@ from .clients.resource_clients.log import LogClient
 from .clients.resource_clients.request_queue import RequestQueueClient
 from .clients.resource_clients.request_queue_collection import RequestQueueCollectionClient
 from .clients.resource_clients.schedule import ScheduleClient
+from .clients.resource_clients.schedule_collection import ScheduleCollectionClient
 from .clients.resource_clients.user import UserClient
 
 DEFAULT_BASE_API_URL = 'https://api.apify.com/v2'
@@ -103,8 +104,15 @@ class ApifyClient:
         return RequestQueueCollectionClient(**self._options())
 
     def schedule(self, schedule_id: str) -> ScheduleClient:
-        """Retrieve the sub-client for manipulating single schedule."""
+        """Retrieve the sub-client for manipulating single schedule.
+        Args:
+            schedule_id (str) : ID of the schedule to be manipulated
+        """
         return ScheduleClient(resource_id=schedule_id, **self._options())
+
+    def schedules(self) -> ScheduleCollectionClient:
+        """Retrieve the sub-client for manipulating schedules."""
+        return ScheduleCollectionClient(**self._options())
 
     def log(self, build_or_run_id: str) -> LogClient:
         """Retrieve the sub-client for retrieving logs."""

--- a/src/apify_client/client.py
+++ b/src/apify_client/client.py
@@ -105,6 +105,7 @@ class ApifyClient:
 
     def schedule(self, schedule_id: str) -> ScheduleClient:
         """Retrieve the sub-client for manipulating single schedule.
+
         Args:
             schedule_id (str) : ID of the schedule to be manipulated
         """

--- a/src/apify_client/client.py
+++ b/src/apify_client/client.py
@@ -10,6 +10,7 @@ from .clients.resource_clients.key_value_store_collection import KeyValueStoreCo
 from .clients.resource_clients.log import LogClient
 from .clients.resource_clients.request_queue import RequestQueueClient
 from .clients.resource_clients.request_queue_collection import RequestQueueCollectionClient
+from .clients.resource_clients.schedule import ScheduleClient
 from .clients.resource_clients.user import UserClient
 
 DEFAULT_BASE_API_URL = 'https://api.apify.com/v2'
@@ -100,6 +101,10 @@ class ApifyClient:
     def request_queues(self) -> RequestQueueCollectionClient:
         """Retrieve the sub-client for manipulating request queues."""
         return RequestQueueCollectionClient(**self._options())
+
+    def schedule(self, schedule_id: str) -> ScheduleClient:
+        """Retrieve the sub-client for manipulating single schedule."""
+        return ScheduleClient(resource_id=schedule_id, **self._options())
 
     def log(self, build_or_run_id: str) -> LogClient:
         """Retrieve the sub-client for retrieving logs."""

--- a/src/apify_client/client.py
+++ b/src/apify_client/client.py
@@ -104,7 +104,7 @@ class ApifyClient:
         return RequestQueueCollectionClient(**self._options())
 
     def schedule(self, schedule_id: str) -> ScheduleClient:
-        """Retrieve the sub-client for manipulating single schedule.
+        """Retrieve the sub-client for manipulating a single schedule.
 
         Args:
             schedule_id (str) : ID of the schedule to be manipulated

--- a/src/apify_client/clients/resource_clients/schedule.py
+++ b/src/apify_client/clients/resource_clients/schedule.py
@@ -6,14 +6,14 @@ from ..base.resource_client import ResourceClient
 
 
 class ScheduleClient(ResourceClient):
-    """Sub-client for manipulating schedules."""
+    """Sub-client for manipulating a single schedule."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the ScheduleClient."""
         super().__init__(*args, resource_path='schedules', **kwargs)
 
     def get(self) -> Optional[Dict]:
-        """Return information about schedule.
+        """Return information about the schedule.
 
         https://docs.apify.com/api/v2#/reference/schedules/schedule-object/get-schedule
 
@@ -32,7 +32,7 @@ class ScheduleClient(ResourceClient):
         actions: Optional[List[Dict]] = None,
         description: Optional[str] = None,
         timezone: Optional[str] = None,
-    ) -> Optional[Dict]:
+    ) -> Dict:
         """Update the schedule with specified fields.
 
         https://docs.apify.com/api/v2#/reference/schedules/schedule-object/update-schedule

--- a/src/apify_client/clients/resource_clients/schedule.py
+++ b/src/apify_client/clients/resource_clients/schedule.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional
 
 from ..._errors import ApifyApiError
-from ..._utils import _catch_not_found_or_throw, _parse_date_fields, _pluck_data
+from ..._utils import _catch_not_found_or_throw, _pluck_data_as_list
 from ..base.resource_client import ResourceClient
 
 
@@ -56,7 +56,7 @@ class ScheduleClient(ResourceClient):
                 method='GET',
                 params=self._params(),
             )
-            return _parse_date_fields(_pluck_data(response.json()))
+            return _pluck_data_as_list(response.json())
         except ApifyApiError as exc:
             _catch_not_found_or_throw(exc)
 

--- a/src/apify_client/clients/resource_clients/schedule.py
+++ b/src/apify_client/clients/resource_clients/schedule.py
@@ -43,7 +43,7 @@ class ScheduleClient(ResourceClient):
             is_exclusive: When set to true, don't start actor or actor task if it's still running from the previous schedule.
             name: The name of the schedule to create.
             actions: Actors or tasks that should be run on this schedule. See the API documentation for exact structure.
-            description: Description of this scheedule
+            description: Description of this schedule
             timezone: Timezone in which your cron expression runs (TZ database name from https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
 
         Returns:

--- a/src/apify_client/clients/resource_clients/schedule.py
+++ b/src/apify_client/clients/resource_clients/schedule.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional
 
 from ..._errors import ApifyApiError
-from ..._utils import _catch_not_found_or_throw, _pluck_data_as_list
+from ..._utils import _catch_not_found_or_throw, _pluck_data_as_list, _snake_case_to_camel_case
 from ..base.resource_client import ResourceClient
 
 
@@ -22,18 +22,38 @@ class ScheduleClient(ResourceClient):
         """
         return self._get()
 
-    def update(self, new_fields: Dict) -> Optional[Dict]:
+    def update(
+        self,
+        *,
+        cron_expression: Optional[str] = None,
+        is_enabled: Optional[bool] = None,
+        is_exclusive: Optional[bool] = None,
+        name: Optional[str] = None,
+        actions: Optional[List[Dict]] = None,
+        description: Optional[str] = None,
+        timezone: Optional[str] = None,
+    ) -> Optional[Dict]:
         """Update the schedule with specified fields.
 
         https://docs.apify.com/api/v2#/reference/schedules/schedule-object/update-schedule
 
         Args:
-            new_fields (dict): The fields of the schedule to update
+            cron_expression: The cron expression used by this schedule
+            is_enabled: True if the schedule should be enabled
+            is_exclusive: When set to true, don't start actor or actor task if it's still running from the previous schedule.
+            name: The name of the schedule to create.
+            actions: Actors or tasks that should be run on this schedule. See the API documentation for exact structure.
+            description: Description of this scheedule
+            timezone: Timezone in which your cron expression runs (TZ database name from https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
 
         Returns:
             The updated schedule
         """
-        return self._update(new_fields)
+        updated_kwargs = {
+            _snake_case_to_camel_case(key): value
+            for key, value in locals().items() if key != 'self' and value is not None
+        }
+        return self._update(updated_kwargs)
 
     def delete(self) -> None:
         """Delete the schedule.

--- a/src/apify_client/clients/resource_clients/schedule.py
+++ b/src/apify_client/clients/resource_clients/schedule.py
@@ -1,0 +1,63 @@
+from typing import Any, Dict, List, Optional
+
+from ..._errors import ApifyApiError
+from ..._utils import _catch_not_found_or_throw, _parse_date_fields, _pluck_data
+from ..base.resource_client import ResourceClient
+
+
+class ScheduleClient(ResourceClient):
+    """Sub-client for manipulating schedules."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the ScheduleClient."""
+        super().__init__(*args, resource_path='schedules', **kwargs)
+
+    def get(self) -> Optional[Dict]:
+        """Return information about schedule.
+
+        https://docs.apify.com/api/v2#/reference/schedules/schedule-object/get-schedule
+
+        Returns:
+            The retrieved schedule
+        """
+        return self._get()
+
+    def update(self, new_fields: Dict) -> Optional[Dict]:
+        """Update the schedule with specified fields.
+
+        https://docs.apify.com/api/v2#/reference/schedules/schedule-object/update-schedule
+
+        Args:
+            new_fields (dict): The fields of the schedule to update
+
+        Returns:
+            The updated schedule
+        """
+        return self._update(new_fields)
+
+    def delete(self) -> None:
+        """Delete the schedule.
+
+        https://docs.apify.com/api/v2#/reference/schedules/schedule-object/delete-schedule
+        """
+        self._delete()
+
+    def get_log(self) -> Optional[List]:
+        """Return log for the given schedule.
+
+        https://docs.apify.com/api/v2#/reference/schedules/schedule-log/get-schedule-log
+
+        Returns:
+            Retrieved log of the given schedule
+        """
+        try:
+            response = self.http_client.call(
+                url=self._url('log'),
+                method='GET',
+                params=self._params(),
+            )
+            return _parse_date_fields(_pluck_data(response.json()))
+        except ApifyApiError as exc:
+            _catch_not_found_or_throw(exc)
+
+        return None

--- a/src/apify_client/clients/resource_clients/schedule_collection.py
+++ b/src/apify_client/clients/resource_clients/schedule_collection.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, Optional
 
+from ..._utils import _snake_case_to_camel_case
 from ..base.resource_collection_client import ResourceCollectionClient
 
 
@@ -52,12 +53,8 @@ class ScheduleCollectionClient(ResourceCollectionClient):
         Returns:
             The created schedule.
         """
-        return self._create({
-            "name": name,
-            "isEnabled": is_enabled,
-            "isExclusive": is_exclusive,
-            "cronExpression": cron_expression,
-            "actions": actions,
-            "description": description,
-            "timezone": timezone,
-        })
+        kwargs = {
+            _snake_case_to_camel_case(key): value
+            for key, value in locals().items() if key != 'self' and value is not None
+        }
+        return self._create(kwargs)

--- a/src/apify_client/clients/resource_clients/schedule_collection.py
+++ b/src/apify_client/clients/resource_clients/schedule_collection.py
@@ -46,7 +46,7 @@ class ScheduleCollectionClient(ResourceCollectionClient):
             is_exclusive: When set to true, don't start actor or actor task if it's still running from the previous schedule.
             name: The name of the schedule to create.
             actions: Actors or tasks that should be run on this schedule. See the API documentation for exact structure.
-            description: Description of this scheedule
+            description: Description of this schedule
             timezone: Timezone in which your cron expression runs (TZ database name from https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
 
         Returns:

--- a/src/apify_client/clients/resource_clients/schedule_collection.py
+++ b/src/apify_client/clients/resource_clients/schedule_collection.py
@@ -44,6 +44,7 @@ class ScheduleCollectionClient(ResourceCollectionClient):
             is_exclusive: True if the schedule is exclusive
             name: The name of the schedule to create.
             actions: Actors or tasks that should be run on this schedule. See the API documentation for exact structure.
+
         Returns:
             The created schedule.
         """

--- a/src/apify_client/clients/resource_clients/schedule_collection.py
+++ b/src/apify_client/clients/resource_clients/schedule_collection.py
@@ -1,0 +1,56 @@
+from typing import Any, Dict, List, Optional
+
+from ..base.resource_collection_client import ResourceCollectionClient
+
+
+class ScheduleCollectionClient(ResourceCollectionClient):
+    """Sub-client for manipulating schedules."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the ScheduleCollectionClient with the passed arguments."""
+        super().__init__(*args, resource_path='schedules', **kwargs)
+
+    def list(self, *, limit: Optional[int] = None, offset: Optional[int] = None, desc: Optional[bool] = None) -> Dict:
+        """List the available schedules.
+
+        https://docs.apify.com/api/v2#/reference/schedules/schedules-collection/get-list-of-schedules
+
+        Args:
+            limit: How many schedules to retrieve
+            offset: What schedules to include as first when retrieving the list
+            desc: Whether to sort the schedules in descending order based on their modification date
+
+        Returns:
+            The list of available schedules matching the specified filters.
+        """
+        return self._list(limit=limit, offset=offset, desc=desc)
+
+    def create(
+        self,
+        *,
+        cron_expression: str,
+        is_enabled: bool,
+        is_exclusive: bool,
+        name: Optional[str] = None,
+        actions: List[Dict] = [],
+    ) -> Dict:
+        """Create a new schedule.
+
+        https://docs.apify.com/api/v2#/reference/schedules/schedules-collection/create-schedule
+
+        Args:
+            cron_expression: The cron expression used by this schedule
+            is_enabled: True if the schedule should be enabled
+            is_exclusive: True if the schedule is exclusive
+            name: The name of the schedule to create.
+            actions: Actors or tasks that should be run on this schedule. See the API documentation for exact structure.
+        Returns:
+            The created schedule.
+        """
+        return self._create({
+            "name": name,
+            "isEnabled": is_enabled,
+            "isExclusive": is_exclusive,
+            "cronExpression": cron_expression,
+            "actions": actions,
+        })

--- a/src/apify_client/clients/resource_clients/schedule_collection.py
+++ b/src/apify_client/clients/resource_clients/schedule_collection.py
@@ -33,6 +33,8 @@ class ScheduleCollectionClient(ResourceCollectionClient):
         is_exclusive: bool,
         name: Optional[str] = None,
         actions: List[Dict] = [],
+        description: Optional[str] = None,
+        timezone: Optional[str] = None,
     ) -> Dict:
         """Create a new schedule.
 
@@ -41,9 +43,11 @@ class ScheduleCollectionClient(ResourceCollectionClient):
         Args:
             cron_expression: The cron expression used by this schedule
             is_enabled: True if the schedule should be enabled
-            is_exclusive: True if the schedule is exclusive
+            is_exclusive: When set to true, don't start actor or actor task if it's still running from the previous schedule.
             name: The name of the schedule to create.
             actions: Actors or tasks that should be run on this schedule. See the API documentation for exact structure.
+            description: Description of this scheedule
+            timezone: Timezone in which your cron expression runs (TZ database name from https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
 
         Returns:
             The created schedule.
@@ -54,4 +58,6 @@ class ScheduleCollectionClient(ResourceCollectionClient):
             "isExclusive": is_exclusive,
             "cronExpression": cron_expression,
             "actions": actions,
+            "description": description,
+            "timezone": timezone,
         })


### PR DESCRIPTION
Subclient for manipulating single schedule or schedule collection.

Note that I had to get a bit creative in `create` function in `ScheduleCollectionClient`. The arguments listed in API docs (https://docs.apify.com/api/v2#/reference/schedules/schedules-collection/create-schedule) are not 100% accurate. `cronExpression`, `isEnabled` and `isExclusive` seem to be required and also it seems it doesn't matter what `userId` you pass, it'll be set based on token.