### PR TITLE
Send API token in the Authorization header instead of as a request parameter

### DIFF
--- a/src/apify_client/_http_client.py
+++ b/src/apify_client/_http_client.py
@@ -16,7 +16,7 @@ DEFAULT_BACKOFF_RANDOM_FACTOR = 1
 
 
 class _HTTPClient:
-    def __init__(self, max_retries: int = 8, min_delay_between_retries_millis: int = 500) -> None:
+    def __init__(self, *, token: Optional[str] = None, max_retries: int = 8, min_delay_between_retries_millis: int = 500) -> None:
         self.max_retries = max_retries
         self.min_delay_between_retries_millis = min_delay_between_retries_millis
         self.requests_session = requests.Session()
@@ -28,6 +28,8 @@ class _HTTPClient:
 
         user_agent = f'ApifyClient/{__version__} ({sys.platform}; Python/{python_version}); isAtHome/{is_at_home}'
         self.requests_session.headers.update({'User-Agent': user_agent})
+        if token is not None:
+            self.requests_session.headers.update({'Authorization': f'Bearer {token}'})
 
     def call(
         self,

--- a/src/apify_client/client.py
+++ b/src/apify_client/client.py
@@ -50,7 +50,11 @@ class ApifyClient:
         self.max_retries = max_retries
         self.min_delay_between_retries_millis = min_delay_between_retries_millis
 
-        self.http_client = _HTTPClient(max_retries=max_retries, min_delay_between_retries_millis=min_delay_between_retries_millis)
+        self.http_client = _HTTPClient(
+            token=token,
+            max_retries=max_retries,
+            min_delay_between_retries_millis=min_delay_between_retries_millis,
+        )
         # TODO statistics
         # TODO logger
 
@@ -58,9 +62,6 @@ class ApifyClient:
         return {
             'base_url': self.base_url,
             'http_client': self.http_client,
-            'params': {
-                'token': self.token,
-            },
         }
 
     def build(self, build_id: str) -> BuildClient:


### PR DESCRIPTION
The API server now supports authorizing with a token sent in the `Authorization` header for improved security, so this PR adds support for sending it that way.