### PR TITLE
Fix keyword-only argument usage in some dataset-client functions

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1420,7 +1420,7 @@ List the items of the dataset.
 
 ***
 
-#### [](#datasetclient-iterate_items) `DatasetClient.iterate_items(offset=0, limit=None, clean=None, desc=None, fields=None, omit=None, unwind=None, skip_empty=None, skip_hidden=None)`
+#### [](#datasetclient-iterate_items) `DatasetClient.iterate_items(*, offset=0, limit=None, clean=None, desc=None, fields=None, omit=None, unwind=None, skip_empty=None, skip_hidden=None)`
 
 Iterate over the items in the dataset.
 
@@ -1467,7 +1467,7 @@ Iterate over the items in the dataset.
 
 ***
 
-#### [](#datasetclient-download_items) `DatasetClient.download_items(item_format='json', *, offset=None, limit=None, desc=None, clean=None, bom=None, delimiter=None, fields=None, omit=None, unwind=None, skip_empty=None, skip_header_row=None, skip_hidden=None, xml_root=None, xml_row=None)`
+#### [](#datasetclient-download_items) `DatasetClient.download_items(*, item_format='json', offset=None, limit=None, desc=None, clean=None, bom=None, delimiter=None, fields=None, omit=None, unwind=None, skip_empty=None, skip_header_row=None, skip_hidden=None, xml_root=None, xml_row=None)`
 
 Download the items in the dataset as raw bytes.
 
@@ -1530,7 +1530,7 @@ Download the items in the dataset as raw bytes.
 
 ***
 
-#### [](#datasetclient-stream_items) `DatasetClient.stream_items(item_format='json', *, offset=None, limit=None, desc=None, clean=None, bom=None, delimiter=None, fields=None, omit=None, unwind=None, skip_empty=None, skip_header_row=None, skip_hidden=None, xml_root=None, xml_row=None)`
+#### [](#datasetclient-stream_items) `DatasetClient.stream_items(*, item_format='json', offset=None, limit=None, desc=None, clean=None, bom=None, delimiter=None, fields=None, omit=None, unwind=None, skip_empty=None, skip_header_row=None, skip_hidden=None, xml_root=None, xml_row=None)`
 
 Retrieve the items in the dataset as a file-like object.
 
@@ -2825,9 +2825,9 @@ A single page of items returned from a list() method.
 Name | Type | Description
 ---- | ---- | -----------
 `items` | `list` | List of returned objects on this page
-`total` | `int` | Total number of objects matching the API call criteria
-`count` | `int` | Count of the returned objects on this page
 `offset` | `int` | The limit on the number of returned objects offset specified in the API call
 `limit` | `int` | The offset of the first object specified in the API call
+`count` | `int` | Count of the returned objects on this page
+`total` | `int` | Total number of objects matching the API call criteria
 
 ***

--- a/src/apify_client/clients/resource_clients/dataset.py
+++ b/src/apify_client/clients/resource_clients/dataset.py
@@ -120,6 +120,7 @@ class DatasetClient(ResourceClient):
 
     def iterate_items(
         self,
+        *,
         offset: int = 0,
         limit: Optional[int] = None,
         clean: Optional[bool] = None,
@@ -195,8 +196,8 @@ class DatasetClient(ResourceClient):
 
     def download_items(
         self,
-        item_format: str = 'json',
         *,
+        item_format: str = 'json',
         offset: Optional[int] = None,
         limit: Optional[int] = None,
         desc: Optional[bool] = None,
@@ -280,8 +281,8 @@ class DatasetClient(ResourceClient):
 
     def stream_items(
         self,
-        item_format: str = 'json',
         *,
+        item_format: str = 'json',
         offset: Optional[int] = None,
         limit: Optional[int] = None,
         desc: Optional[bool] = None,


### PR DESCRIPTION
We're using keyword-only arguments for all arguments in all the complicated functions except these three, let's fix and unify that.