### PR TITLE
Enforce use of single-quotes via lint plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 ### Internal changes
 
 - updated development dependencies
+- enforced unified use of single quotes and double quotes
 
 [0.0.1](../../releases/tag/v0.0.1) - 2021-05-13
 -----------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
             'flake8-commas ~= 2.0.0',
             'flake8-docstrings ~= 1.6.0',
             'flake8-isort ~= 4.0.0',
+            'flake8-quotes ~= 3.2.0',
             'isort ~= 5.8.0',
             'mypy ~= 0.901',
             'pep8-naming ~= 0.11.1',

--- a/src/apify_client/_utils.py
+++ b/src/apify_client/_utils.py
@@ -145,7 +145,7 @@ def _encode_webhook_list_to_base64(webhooks: List[Dict]) -> bytes:
             webhook_representation['payloadTemplate'] = webhook['payload_template']
         data.append(webhook_representation)
 
-    return base64.b64encode(json.dumps(data).encode("utf-8"))
+    return base64.b64encode(json.dumps(data).encode('utf-8'))
 
 
 def _filter_out_none_values(dictionary: Dict) -> Dict:
@@ -182,9 +182,9 @@ def _snake_case_to_camel_case(str_snake_case: str) -> str:
     >>> _snake_case_to_camel_case("making_the_WEB_programmable")
     'makingTheWebProgrammable'
     """
-    return "".join([
+    return ''.join([
         part.capitalize() if i > 0 else part
-        for i, part in enumerate(str_snake_case.split("_"))
+        for i, part in enumerate(str_snake_case.split('_'))
     ])
 
 
@@ -198,7 +198,7 @@ def _encode_key_value_store_record_value(value: Any, content_type: Optional[str]
             content_type = 'application/json; charset=utf-8'
 
     if 'application/json' in content_type and not _is_file_or_bytes(value) and not isinstance(value, str):
-        value = json.dumps(value, ensure_ascii=False, indent=2).encode("utf-8")
+        value = json.dumps(value, ensure_ascii=False, indent=2).encode('utf-8')
 
     return (value, content_type)
 

--- a/src/apify_client/clients/base/base_client.py
+++ b/src/apify_client/clients/base/base_client.py
@@ -60,10 +60,10 @@ class BaseClient:
 
     def _sub_resource_init_options(self, **kwargs: Any) -> Dict:
         options = {
-            "base_url": self.url,
-            "http_client": self.http_client,
-            "params": self.params,
-            "root_client": self.root_client,
+            'base_url': self.url,
+            'http_client': self.http_client,
+            'params': self.params,
+            'root_client': self.root_client,
         }
 
         return {

--- a/src/apify_client/clients/resource_clients/run.py
+++ b/src/apify_client/clients/resource_clients/run.py
@@ -117,7 +117,7 @@ class RunClient(ActorJobBaseClient):
             DatasetClient: A client allowing access to the default dataset of this actor run.
         """
         return DatasetClient(
-            **self._sub_resource_init_options(resource_path="dataset"),
+            **self._sub_resource_init_options(resource_path='dataset'),
         )
 
     def key_value_store(self) -> KeyValueStoreClient:
@@ -129,7 +129,7 @@ class RunClient(ActorJobBaseClient):
             KeyValueStoreClient: A client allowing access to the default key-value store of this actor run.
         """
         return KeyValueStoreClient(
-            **self._sub_resource_init_options(resource_path="key-value-store"),
+            **self._sub_resource_init_options(resource_path='key-value-store'),
         )
 
     def request_queue(self) -> RequestQueueClient:
@@ -141,7 +141,7 @@ class RunClient(ActorJobBaseClient):
             RequestQueueClient: A client allowing access to the default request_queue of this actor run.
         """
         return RequestQueueClient(
-            **self._sub_resource_init_options(resource_path="request-queue"),
+            **self._sub_resource_init_options(resource_path='request-queue'),
         )
 
     def log(self) -> LogClient:
@@ -153,5 +153,5 @@ class RunClient(ActorJobBaseClient):
             LogClient: A client allowing access to the log of this actor run.
         """
         return LogClient(
-            **self._sub_resource_init_options(resource_path="log"),
+            **self._sub_resource_init_options(resource_path='log'),
         )

--- a/src/apify_client/clients/resource_clients/task.py
+++ b/src/apify_client/clients/resource_clients/task.py
@@ -53,13 +53,13 @@ class TaskClient(ResourceClient):
             dict: The updated task
         """
         updated_fields = {
-            "name": name,
-            "options": {
-                "build": build,
-                "memoryMbytes": memory_mbytes,
-                "timeoutSecs": timeout_secs,
+            'name': name,
+            'options': {
+                'build': build,
+                'memoryMbytes': memory_mbytes,
+                'timeoutSecs': timeout_secs,
             },
-            "input": task_input,
+            'input': task_input,
         }
 
         return self._update(_filter_out_none_values_recursively(updated_fields))

--- a/src/apify_client/clients/resource_clients/task_collection.py
+++ b/src/apify_client/clients/resource_clients/task_collection.py
@@ -61,14 +61,14 @@ class TaskCollectionClient(ResourceCollectionClient):
             dict: The created task.
         """
         new_fields = {
-            "actId": actor_id,
-            "name": name,
-            "options": {
-                "build": build,
-                "memoryMbytes": memory_mbytes,
-                "timeoutSecs": timeout_secs,
+            'actId': actor_id,
+            'name': name,
+            'options': {
+                'build': build,
+                'memoryMbytes': memory_mbytes,
+                'timeoutSecs': timeout_secs,
             },
-            "input": task_input,
+            'input': task_input,
         }
 
         return self._create(_filter_out_none_values_recursively(new_fields))

--- a/src/apify_client/clients/resource_clients/webhook.py
+++ b/src/apify_client/clients/resource_clients/webhook.py
@@ -21,7 +21,7 @@ def _prepare_webhook_representation(
     """Prepare webhook dictionary representation for clients."""
     webhook: Dict[str, Any] = {
         _snake_case_to_camel_case(key): value
-        for key, value in locals().items() if value is not None and key not in ["actor_run_id", "actor_task_id", "actor_id"]
+        for key, value in locals().items() if value is not None and key not in ['actor_run_id', 'actor_task_id', 'actor_id']
     }
 
     condition = {}
@@ -35,7 +35,7 @@ def _prepare_webhook_representation(
         condition['actorId'] = actor_id
 
     if condition != {}:
-        webhook["condition"] = condition
+        webhook['condition'] = condition
 
     return webhook
 
@@ -113,5 +113,5 @@ class WebhookClient(ResourceClient):
             WebhookDispatchCollectionClient: A client allowing access to dispatches of this webhook using its list method
         """
         return WebhookDispatchCollectionClient(
-            **self._sub_resource_init_options(resource_path="dispatches"),
+            **self._sub_resource_init_options(resource_path='dispatches'),
         )


### PR DESCRIPTION
I added the package `flake8-quotes` as a development dependency, it enforces the use of single-quotes by default through linting, and I fixed all the violations that were present in the code, as it makes it a bit cleaner and unified.