### PR TITLE
Call building of actor images containing this client when doing a new release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,3 +125,23 @@ jobs:
         file: dist/*
         file_glob: true
         tag: ${{ github.ref }}
+
+    - # Get the current package version for use in Docker images
+        name: Parse package version for Docker images
+        id: get-package-version
+        run: |
+          package_version=`python ./.github/scripts/print_current_package_version.py`
+          echo "::set-output name=package_version::$package_version"
+
+    - # Trigger building the docker images in apify/apify-actor-docker repo
+      name: Trigger Docker Image Build
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ secrets.TRIGGER_DOCKER_IMAGE_BUILD_TOKEN }}
+        repository: apify/apify-actor-docker
+        event-type: build-python-images
+        client-payload: >
+          {
+            "release_tag": "${{ env.RELEASE_TAG }}",
+            "apify_client_version": "${{ steps.get-package-version.outputs.package_version }}",
+          }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog
 
 - updated development dependencies
 - enforced unified use of single quotes and double quotes
+- added repository dispatch to build actor images with this client when publishing a new version
 
 [0.0.1](../../releases/tag/v0.0.1) - 2021-05-13
 -----------------------------------------------


### PR DESCRIPTION
There is a [PR in the `apify-actor-docker`](https://github.com/apify/apify-actor-docker/pull/57) repo which adds support for building actor images with this client preinstalled. This PR only adds a few steps to the release workflow of this client to call the build of those actor images when releasing a new version of the client.

This PR should be merged only after the PR in `apify-actor-docker` is merged.