### PR TITLE
Change tags for actor images to align with Apify SDK Node.js images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
 
     - # Determine if this is a beta or latest release
       name: Determine release type
-      run: echo "RELEASE_TYPE=$(if [ ${{ github.event_name }} = release ]; then echo stable; else echo beta; fi)" >> $GITHUB_ENV
+      run: echo "RELEASE_TYPE=$(if [ ${{ github.event_name }} = release ]; then echo latest; else echo beta; fi)" >> $GITHUB_ENV
 
     - # Check whether the released version is listed in CHANGELOG.md
       name: Check whether the released version is listed in the changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Changelog
 - replaced `base_url` with `api_url` in the client constructor
   to enable easier passing of the API server url from environment variables availabl to actors on the Apify platform
 
+### Internal changes
+
+- changed tags for actor images with this client on Docker Hub to be aligned with the Apify SDK Node.js images
+
 [0.1.0](../../releases/tag/v0.1.0) - 2021-08-02
 -----------------------------------------------
 


### PR DESCRIPTION
Apify SDK uses `latest` and `beta` tags, but this client used `stable` and `beta` tags.
I've changed it so that this client uses the same tags as the Apify SDK (which is the correct way since `latest` has a special meaning in Docker repos).