### PR TITLE
Add the `gracefully` parameter to the "Abort run" method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog
 
 - replaced `base_url` with `api_url` in the client constructor
   to enable easier passing of the API server url from environment variables availabl to actors on the Apify platform
+- added the `gracefully` parameter to the "Abort run" method
 
 ### Internal changes
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1020,11 +1020,17 @@ Return information about the actor run.
 
 ***
 
-#### [](#runclient-abort) `RunClient.abort()`
+#### [](#runclient-abort) `RunClient.abort(*, gracefully=None)`
 
 Abort the actor run which is starting or currently running and return its details.
 
 [https://docs.apify.com/api/v2#/reference/actor-runs/abort-run/abort-run](https://docs.apify.com/api/v2#/reference/actor-runs/abort-run/abort-run)
+
+* **Parameters**
+
+  * **gracefully** (`bool`, *optional*) – If True, the actor run will abort gracefully.
+  It will send `aborting` and `persistStates` events into the run and force-stop the run after 30 seconds.
+  It is helpful in cases where you plan to resurrect the run later.
 
 * **Returns**
 

--- a/src/apify_client/clients/base/actor_job_base_client.py
+++ b/src/apify_client/clients/base/actor_job_base_client.py
@@ -59,10 +59,12 @@ class ActorJobBaseClient(ResourceClient):
 
         return job
 
-    def _abort(self) -> Dict:
+    def _abort(self, gracefully: Optional[bool] = None) -> Dict:
         response = self.http_client.call(
             url=self._url('abort'),
             method='POST',
-            params=self._params(),
+            params=self._params(
+                gracefully=gracefully,
+            ),
         )
         return _parse_date_fields(_pluck_data(response.json()))

--- a/src/apify_client/clients/resource_clients/run.py
+++ b/src/apify_client/clients/resource_clients/run.py
@@ -26,15 +26,20 @@ class RunClient(ActorJobBaseClient):
         """
         return self._get()
 
-    def abort(self) -> Dict:
+    def abort(self, *, gracefully: Optional[bool] = None) -> Dict:
         """Abort the actor run which is starting or currently running and return its details.
 
         https://docs.apify.com/api/v2#/reference/actor-runs/abort-run/abort-run
 
+        Args:
+            gracefully (bool, optional): If True, the actor run will abort gracefully.
+                It will send ``aborting`` and ``persistStates`` events into the run and force-stop the run after 30 seconds.
+                It is helpful in cases where you plan to resurrect the run later.
+
         Returns:
             dict: The data of the aborted actor run
         """
-        return self._abort()
+        return self._abort(gracefully=gracefully)
 
     def wait_for_finish(self, *, wait_secs: Optional[int] = None) -> Optional[Dict]:
         """Wait synchronously until the run finishes or the server times out.


### PR DESCRIPTION
The API now supports specifying this parameter, so I'm adding it to the client as well.