### PR TITLE
Add names to Github Actions workflow jobs

### DIFF
--- a/.github/workflows/check_docs.yaml
+++ b/.github/workflows/check_docs.yaml
@@ -4,6 +4,7 @@ on: push
 
 jobs:
   check_docs:
+    name: Check whether documentation is up-to-date
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -4,6 +4,7 @@ on: push
 
 jobs:
   lint_and_test:
+    name: Lint, check types and run unit tests
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/pr_toolkit.yml
+++ b/.github/workflows/pr_toolkit.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   apify-pr-toolkit:
+    name: Run the Apify pull request toolkit
     runs-on: ubuntu-20.04
     steps:
       - name: clone pull-request-toolkit-action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changelog
 
 - fixed return type in the `DatasetClient.list_items()` method docs
 
+### Internal changes
+
+- added human-friendly names to the jobs in Github Action workflows
+
 [0.2.0](../../releases/tag/v0.2.0) - 2021-08-09
 -----------------------------------------------
 


### PR DESCRIPTION
Hopefully this will solve the extra 'build' checks that every PR to master waits for.