### PR TITLE
Fix wrong value in `time.sleep` between successive requests in the `wait_for_finish` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog
 
 - improved retrying broken API server connections
 
+### Fixed
+
+- fixed timeout value in actively waiting for a run to finish
+
 [0.4.0](../../releases/tag/v0.4.0) - 2021-09-07
 -----------------------------------------------
 

--- a/src/apify_client/clients/base/actor_job_base_client.py
+++ b/src/apify_client/clients/base/actor_job_base_client.py
@@ -55,7 +55,7 @@ class ActorJobBaseClient(ResourceClient):
                     return None
 
             # It might take some time for database replicas to get up-to-date so sleep a bit before retrying
-            time.sleep(250)
+            time.sleep(0.25)
 
         return job
 


### PR DESCRIPTION
It slept 250 seconds instead of 250 milliseconds.