### PR TITLE
Unified methods for streaming resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 ### Breaking changes
 
 - dropped support for Python 3.7, added support for Python 3.11
+- unified methods for streaming resources
 
 ### Added
 

--- a/src/apify_client/clients/resource_clients/dataset.py
+++ b/src/apify_client/clients/resource_clients/dataset.py
@@ -1,5 +1,8 @@
-import io
-from typing import Any, Dict, Generator, List, Optional, cast
+import warnings
+from contextlib import contextmanager
+from typing import Any, Dict, Generator, Iterator, List, Optional
+
+import requests
 
 from ..._types import JSONSerializable
 from ..._utils import ListPage, _filter_out_none_values_recursively
@@ -214,7 +217,95 @@ class DatasetClient(ResourceClient):
         xml_root: Optional[str] = None,
         xml_row: Optional[str] = None,
     ) -> bytes:
-        """Download the items in the dataset as raw bytes.
+        """Get the items in the dataset as raw bytes.
+
+        Deprecated: this function is a deprecated alias of `get_items_as_bytes`. It will be removed in a future version.
+
+        https://docs.apify.com/api/v2#/reference/datasets/item-collection/get-items
+
+        Args:
+            item_format (str): Format of the results, possible values are: json, jsonl, csv, html, xlsx, xml and rss. The default value is json.
+            offset (int, optional): Number of items that should be skipped at the start. The default value is 0
+            limit (int, optional): Maximum number of items to return. By default there is no limit.
+            desc (bool, optional): By default, results are returned in the same order as they were stored.
+                To reverse the order, set this parameter to True.
+            clean (bool, optional): If True, returns only non-empty items and skips hidden fields (i.e. fields starting with the # character).
+                The clean parameter is just a shortcut for skip_hidden=True and skip_empty=True parameters.
+                Note that since some objects might be skipped from the output, that the result might contain less items than the limit value.
+            bom (bool, optional): All text responses are encoded in UTF-8 encoding.
+                By default, csv files are prefixed with the UTF-8 Byte Order Mark (BOM),
+                while json, jsonl, xml, html and rss files are not. If you want to override this default behavior,
+                specify bom=True query parameter to include the BOM or bom=False to skip it.
+            delimiter (str, optional): A delimiter character for CSV files. The default delimiter is a simple comma (,).
+            fields (list of str, optional): A list of fields which should be picked from the items,
+                only these fields will remain in the resulting record objects.
+                Note that the fields in the outputted items are sorted the same way as they are specified in the fields parameter.
+                You can use this feature to effectively fix the output format.
+            omit (list of str, optional): A list of fields which should be omitted from the items.
+            unwind (str, optional): Name of a field which should be unwound.
+                If the field is an array then every element of the array will become a separate record and merged with parent object.
+                If the unwound field is an object then it is merged with the parent object.
+                If the unwound field is missing or its value is neither an array nor an object and therefore cannot be merged with a parent object,
+                then the item gets preserved as it is. Note that the unwound items ignore the desc parameter.
+            skip_empty (bool, optional): If True, then empty items are skipped from the output.
+                Note that if used, the results might contain less items than the limit value.
+            skip_header_row (bool, optional): If True, then header row in the csv format is skipped.
+            skip_hidden (bool, optional): If True, then hidden fields are skipped from the output, i.e. fields starting with the # character.
+            xml_root (str, optional): Overrides default root element name of xml output. By default the root element is items.
+            xml_row (str, optional): Overrides default element name that wraps each page or page function result object in xml output.
+                By default the element name is item.
+
+        Returns:
+            bytes: The dataset items as raw bytes
+        """
+        # We need to override and then restore the warnings filter so that the warning gets printed out,
+        # Otherwise it would be silently swallowed
+        with warnings.catch_warnings():
+            warnings.simplefilter('always')
+            warnings.warn(
+                '`DatasetClient.download_items()` is deprecated, use `DatasetClient.get_items_as_bytes()` instead.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        return self.get_items_as_bytes(
+            item_format=item_format,
+            offset=offset,
+            limit=limit,
+            desc=desc,
+            clean=clean,
+            bom=bom,
+            delimiter=delimiter,
+            fields=fields,
+            omit=omit,
+            unwind=unwind,
+            skip_empty=skip_empty,
+            skip_header_row=skip_header_row,
+            skip_hidden=skip_hidden,
+            xml_root=xml_root,
+            xml_row=xml_row,
+        )
+
+    def get_items_as_bytes(
+        self,
+        *,
+        item_format: str = 'json',
+        offset: Optional[int] = None,
+        limit: Optional[int] = None,
+        desc: Optional[bool] = None,
+        clean: Optional[bool] = None,
+        bom: Optional[bool] = None,
+        delimiter: Optional[str] = None,
+        fields: Optional[List[str]] = None,
+        omit: Optional[List[str]] = None,
+        unwind: Optional[str] = None,
+        skip_empty: Optional[bool] = None,
+        skip_header_row: Optional[bool] = None,
+        skip_hidden: Optional[bool] = None,
+        xml_root: Optional[str] = None,
+        xml_row: Optional[str] = None,
+    ) -> bytes:
+        """Get the items in the dataset as raw bytes.
 
         https://docs.apify.com/api/v2#/reference/datasets/item-collection/get-items
 
@@ -280,6 +371,7 @@ class DatasetClient(ResourceClient):
 
         return response.content
 
+    @contextmanager
     def stream_items(
         self,
         *,
@@ -298,8 +390,8 @@ class DatasetClient(ResourceClient):
         skip_hidden: Optional[bool] = None,
         xml_root: Optional[str] = None,
         xml_row: Optional[str] = None,
-    ) -> io.IOBase:
-        """Retrieve the items in the dataset as a file-like object.
+    ) -> Iterator[requests.models.Response]:
+        """Retrieve the items in the dataset as a stream.
 
         https://docs.apify.com/api/v2#/reference/datasets/item-collection/get-items
 
@@ -336,37 +428,39 @@ class DatasetClient(ResourceClient):
                 By default the element name is item.
 
         Returns:
-            io.IOBase: The dataset items as a file-like object
+            requests.Response: The dataset items as a context-managed streaming Response
         """
-        request_params = self._params(
-            format=item_format,
-            offset=offset,
-            limit=limit,
-            desc=desc,
-            clean=clean,
-            bom=bom,
-            delimiter=delimiter,
-            fields=fields,
-            omit=omit,
-            unwind=unwind,
-            skipEmpty=skip_empty,
-            skipHeaderRow=skip_header_row,
-            skipHidden=skip_hidden,
-            xmlRoot=xml_root,
-            xmlRow=xml_row,
-        )
+        response = None
+        try:
+            request_params = self._params(
+                format=item_format,
+                offset=offset,
+                limit=limit,
+                desc=desc,
+                clean=clean,
+                bom=bom,
+                delimiter=delimiter,
+                fields=fields,
+                omit=omit,
+                unwind=unwind,
+                skipEmpty=skip_empty,
+                skipHeaderRow=skip_header_row,
+                skipHidden=skip_hidden,
+                xmlRoot=xml_root,
+                xmlRow=xml_row,
+            )
 
-        response = self.http_client.call(
-            url=self._url('items'),
-            method='GET',
-            params=request_params,
-            stream=True,
-            parse_response=False,
-        )
-
-        response.raw.decode_content = True
-        # response.raw is the raw urllib3 response, which subclasses IOBase
-        return cast(io.IOBase, response.raw)
+            response = self.http_client.call(
+                url=self._url('items'),
+                method='GET',
+                params=request_params,
+                stream=True,
+                parse_response=False,
+            )
+            yield response
+        finally:
+            if response:
+                response.close()
 
     def push_items(self, items: JSONSerializable) -> None:
         """Push items to the dataset.

--- a/src/apify_client/clients/resource_clients/key_value_store.py
+++ b/src/apify_client/clients/resource_clients/key_value_store.py
@@ -189,6 +189,7 @@ class KeyValueStoreClient(ResourceClient):
                 method='GET',
                 params=self._params(),
                 parse_response=False,
+                stream=True,
             )
 
             yield {

--- a/src/apify_client/clients/resource_clients/log.py
+++ b/src/apify_client/clients/resource_clients/log.py
@@ -75,7 +75,7 @@ class LogClient(ResourceClient):
             response = self.http_client.call(
                 url=self.url,
                 method='GET',
-                params=self._params(),
+                params=self._params(stream=True),
                 stream=True,
                 parse_response=False,
             )

--- a/src/apify_client/clients/resource_clients/log.py
+++ b/src/apify_client/clients/resource_clients/log.py
@@ -1,5 +1,7 @@
-import io
-from typing import Any, Optional, cast
+from contextlib import contextmanager
+from typing import Any, Iterator, Optional
+
+import requests
 
 from ..._errors import ApifyApiError
 from ..._utils import _catch_not_found_or_throw
@@ -36,14 +38,39 @@ class LogClient(ResourceClient):
 
         return None
 
-    def stream(self) -> Optional[io.IOBase]:
-        """Retrieve the log as a file-like object.
+    def get_as_bytes(self) -> Optional[bytes]:
+        """Retrieve the log as raw bytes.
 
         https://docs.apify.com/api/v2#/reference/logs/log/get-log
 
         Returns:
-            io.IOBase, optional: The retrieved log as a file-like object, or None, if it does not exist.
+            bytes, optional: The retrieved log as raw bytes, or None, if it does not exist.
         """
+        try:
+            response = self.http_client.call(
+                url=self.url,
+                method='GET',
+                params=self._params(),
+                parse_response=False,
+            )
+
+            return response.content
+
+        except ApifyApiError as exc:
+            _catch_not_found_or_throw(exc)
+
+        return None
+
+    @contextmanager
+    def stream(self) -> Iterator[Optional[requests.models.Response]]:
+        """Retrieve the log as a stream.
+
+        https://docs.apify.com/api/v2#/reference/logs/log/get-log
+
+        Returns:
+            requests.Response, optional: The retrieved log as a context-managed streaming Response, or None, if it does not exist.
+        """
+        response = None
         try:
             response = self.http_client.call(
                 url=self.url,
@@ -53,12 +80,10 @@ class LogClient(ResourceClient):
                 parse_response=False,
             )
 
-            response.raw.decode_content = True
-            # TODO explain response.raw.close()
-            # response.raw is the raw urllib3 response, which subclasses IOBase
-            return cast(io.IOBase, response.raw)
-
+            yield response
         except ApifyApiError as exc:
             _catch_not_found_or_throw(exc)
-
-        return None
+            yield None
+        finally:
+            if response:
+                response.close()


### PR DESCRIPTION
With the implementation of the Apify SDK for Python, we will have to do some bigger changes to the Python Client, so now is a good time to take some time and get rid of some old problems, before we are stuck with them forever. One of them is that streaming methods for some resources (dataset items, key-value store records and log contents) are a mess.

This unifies their behavior, and makes them safer by forcing them to return a context-managed object, so the streaming response is automatically closed after use.

It also unifies the naming and behavior of methods for fetching the resource contents as raw bytes, by naming them all in the `get_as_bytes` style, instead of the varying names and usages they had before.