### PR TITLE
Switched underlying HTTP library from `requests` to `httpx`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog
 
 - dropped support for Python 3.7, added support for Python 3.11
 - unified methods for streaming resources
+- switched underlying HTTP library from `requests` to `httpx`
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 ### Breaking changes
 
 - dropped support for Python 3.7, added support for Python 3.11
+- unified methods for streaming resources
 
 ### Added
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -146,7 +146,7 @@ The methods to stream these resources are
 and [`LogClient.stream()`](#logclient-stream).
 
 Instead of the parsed resource, they return a raw, context-managed
-[`Response`](https://requests.readthedocs.io/en/latest/user/advanced/#streaming-requests) object,
+[`httpx.Response`](https://www.python-httpx.org/quickstart/#streaming-responses) object,
 which has to be consumed using the `with` keyword,
 and automatically gets closed once you exit the `with` block, preventing memory leaks and unclosed connections.
 
@@ -1660,7 +1660,7 @@ Retrieve the items in the dataset as a stream.
 
 * **Return type**
 
-  `requests.Response`
+  `httpx.Response`
 
 ***
 
@@ -2248,7 +2248,7 @@ Retrieve the log as a stream.
 
 * **Return type**
 
-  `requests.Response`, optional
+  `httpx.Response`, optional
 
 ***
 

--- a/docs/res/intro.md
+++ b/docs/res/intro.md
@@ -146,7 +146,7 @@ The methods to stream these resources are
 and [`LogClient.stream()`](#logclient-stream).
 
 Instead of the parsed resource, they return a raw, context-managed
-[`Response`](https://requests.readthedocs.io/en/latest/user/advanced/#streaming-requests) object,
+[`httpx.Response`](https://www.python-httpx.org/quickstart/#streaming-responses) object,
 which has to be consumed using the `with` keyword,
 and automatically gets closed once you exit the `with` block, preventing memory leaks and unclosed connections.
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     packages=find_packages(where='src'),
     package_data={'apify_client': ['py.typed']},
     python_requires='>=3.8',
-    install_requires=['requests ~= 2.28.0'],
+    install_requires=['httpx ~= 0.23.0'],
     extras_require={
         'dev': [
             'autopep8 ~= 2.0.0',
@@ -65,7 +65,6 @@ setup(
             'sphinx ~= 5.3.0',
             'sphinx-autodoc-typehints ~= 1.19.5',
             'sphinx-markdown-builder == 0.5.4',  # pinned to 0.5.4, because 0.5.5 has a formatting bug
-            'types-requests ~= 2.28.0',
             'types-setuptools ~= 65.5.0.2',
         ],
     },

--- a/src/apify_client/_http_client.py
+++ b/src/apify_client/_http_client.py
@@ -40,7 +40,7 @@ class _HTTPClient:
         if token is not None:
             headers['Authorization'] = f'Bearer {token}'
 
-        self.httpx_session = httpx.Client(headers=headers, follow_redirects=True, timeout=timeout_secs)
+        self.httpx_client = httpx.Client(headers=headers, follow_redirects=True, timeout=timeout_secs)
 
     def call(
         self,
@@ -61,7 +61,7 @@ class _HTTPClient:
             raise ValueError('Cannot pass both "json" and "data" parameters at the same time!')
 
         request_params = self._parse_params(params)
-        httpx_session = self.httpx_session
+        httpx_client = self.httpx_client
 
         if not headers:
             headers = {}
@@ -82,14 +82,14 @@ class _HTTPClient:
 
         def _make_request(stop_retrying: Callable, attempt: int) -> httpx.Response:
             try:
-                request = httpx_session.build_request(
+                request = httpx_client.build_request(
                     method=method,
                     url=url,
                     headers=headers,
                     params=request_params,
                     content=content,
                 )
-                response = httpx_session.send(
+                response = httpx_client.send(
                     request=request,
                     stream=stream or False,
                 )

--- a/src/apify_client/_http_client.py
+++ b/src/apify_client/_http_client.py
@@ -5,7 +5,7 @@ import sys
 from http import HTTPStatus
 from typing import Any, Callable, Dict, Optional
 
-import requests
+import httpx
 
 from ._errors import ApifyApiError, InvalidResponseBodyError, _is_retryable_error
 from ._types import JSONSerializable
@@ -29,17 +29,18 @@ class _HTTPClient:
         self.min_delay_between_retries_millis = min_delay_between_retries_millis
         self.timeout_secs = timeout_secs
 
-        self.requests_session = requests.Session()
-
-        self.requests_session.headers.update({'Accept': 'application/json, */*'})
+        headers = {'Accept': 'application/json, */*'}
 
         is_at_home = ('APIFY_IS_AT_HOME' in os.environ)
         python_version = '.'.join([str(x) for x in sys.version_info[:3]])
 
         user_agent = f'ApifyClient/{__version__} ({sys.platform}; Python/{python_version}); isAtHome/{is_at_home}'
-        self.requests_session.headers.update({'User-Agent': user_agent})
+        headers['User-Agent'] = user_agent
+
         if token is not None:
-            self.requests_session.headers.update({'Authorization': f'Bearer {token}'})
+            headers['Authorization'] = f'Bearer {token}'
+
+        self.httpx_session = httpx.Client(headers=headers, follow_redirects=True, timeout=timeout_secs)
 
     def call(
         self,
@@ -52,15 +53,21 @@ class _HTTPClient:
         json: Optional[JSONSerializable] = None,
         stream: Optional[bool] = None,
         parse_response: Optional[bool] = True,
-    ) -> requests.models.Response:
+    ) -> httpx.Response:
+        if stream and parse_response:
+            raise ValueError('Cannot stream response and parse it at the same time!')
+
+        if json and data:
+            raise ValueError('Cannot pass both "json" and "data" parameters at the same time!')
+
         request_params = self._parse_params(params)
-        requests_session = self.requests_session
-        timeout = self.timeout_secs
+        httpx_session = self.httpx_session
 
         if not headers:
             headers = {}
 
-        if json and not data:
+        # dump JSON data to string, so they can be gzipped
+        if json:
             data = jsonlib.dumps(json, ensure_ascii=False, default=str).encode('utf-8')
             headers['Content-Type'] = 'application/json'
 
@@ -70,26 +77,31 @@ class _HTTPClient:
             data = gzip.compress(data)
             headers['Content-Encoding'] = 'gzip'
 
-        def _make_request(stop_retrying: Callable, attempt: int) -> requests.models.Response:
+        # httpx uses `content` instead of `data` for binary content, let's rename it here to be clear about it
+        content = data
+
+        def _make_request(stop_retrying: Callable, attempt: int) -> httpx.Response:
             try:
-                response = requests_session.request(
-                    method,
-                    url,
+                request = httpx_session.build_request(
+                    method=method,
+                    url=url,
                     headers=headers,
                     params=request_params,
-                    data=data,
-                    stream=stream,
-                    timeout=timeout,
+                    content=content,
                 )
+                response = httpx_session.send(
+                    request=request,
+                    stream=stream or False,
+                )
+
                 if response.status_code < 300:
-                    if parse_response:
-                        _maybe_parsed_body = self._maybe_parse_response(response)
-                    elif stream:
-                        response.raw.decode_content = True
-                        _maybe_parsed_body = response.raw
-                    else:
-                        _maybe_parsed_body = response.content
-                    setattr(response, '_maybe_parsed_body', _maybe_parsed_body)
+                    if not stream:
+                        if parse_response:
+                            _maybe_parsed_body = self._maybe_parse_response(response)
+                        else:
+                            _maybe_parsed_body = response.content
+                        setattr(response, '_maybe_parsed_body', _maybe_parsed_body)
+
                     return response
 
             except Exception as e:
@@ -110,7 +122,7 @@ class _HTTPClient:
         )
 
     @staticmethod
-    def _maybe_parse_response(response: requests.models.Response) -> Any:
+    def _maybe_parse_response(response: httpx.Response) -> Any:
         if response.status_code == HTTPStatus.NO_CONTENT:
             return None
 
@@ -138,7 +150,7 @@ class _HTTPClient:
             # Our API needs to have boolean parameters passed as 0 or 1, therefore we have to replace them
             if isinstance(value, bool):
                 parsed_params[key] = int(value)
-            else:
+            elif value is not None:
                 parsed_params[key] = value
 
         return parsed_params

--- a/src/apify_client/clients/resource_clients/dataset.py
+++ b/src/apify_client/clients/resource_clients/dataset.py
@@ -2,7 +2,7 @@ import warnings
 from contextlib import contextmanager
 from typing import Any, Dict, Generator, Iterator, List, Optional
 
-import requests
+import httpx
 
 from ..._types import JSONSerializable
 from ..._utils import ListPage, _filter_out_none_values_recursively
@@ -390,7 +390,7 @@ class DatasetClient(ResourceClient):
         skip_hidden: Optional[bool] = None,
         xml_root: Optional[str] = None,
         xml_row: Optional[str] = None,
-    ) -> Iterator[requests.models.Response]:
+    ) -> Iterator[httpx.Response]:
         """Retrieve the items in the dataset as a stream.
 
         https://docs.apify.com/api/v2#/reference/datasets/item-collection/get-items
@@ -428,7 +428,7 @@ class DatasetClient(ResourceClient):
                 By default the element name is item.
 
         Returns:
-            requests.Response: The dataset items as a context-managed streaming Response
+            httpx.Response: The dataset items as a context-managed streaming Response
         """
         response = None
         try:

--- a/src/apify_client/clients/resource_clients/dataset.py
+++ b/src/apify_client/clients/resource_clients/dataset.py
@@ -1,5 +1,8 @@
-import io
-from typing import Any, Dict, Generator, List, Optional, cast
+import warnings
+from contextlib import contextmanager
+from typing import Any, Dict, Generator, Iterator, List, Optional
+
+import requests
 
 from ..._types import JSONSerializable
 from ..._utils import ListPage, _filter_out_none_values_recursively
@@ -214,7 +217,95 @@ class DatasetClient(ResourceClient):
         xml_root: Optional[str] = None,
         xml_row: Optional[str] = None,
     ) -> bytes:
-        """Download the items in the dataset as raw bytes.
+        """Get the items in the dataset as raw bytes.
+
+        Deprecated: this function is a deprecated alias of `get_items_as_bytes`. It will be removed in a future version.
+
+        https://docs.apify.com/api/v2#/reference/datasets/item-collection/get-items
+
+        Args:
+            item_format (str): Format of the results, possible values are: json, jsonl, csv, html, xlsx, xml and rss. The default value is json.
+            offset (int, optional): Number of items that should be skipped at the start. The default value is 0
+            limit (int, optional): Maximum number of items to return. By default there is no limit.
+            desc (bool, optional): By default, results are returned in the same order as they were stored.
+                To reverse the order, set this parameter to True.
+            clean (bool, optional): If True, returns only non-empty items and skips hidden fields (i.e. fields starting with the # character).
+                The clean parameter is just a shortcut for skip_hidden=True and skip_empty=True parameters.
+                Note that since some objects might be skipped from the output, that the result might contain less items than the limit value.
+            bom (bool, optional): All text responses are encoded in UTF-8 encoding.
+                By default, csv files are prefixed with the UTF-8 Byte Order Mark (BOM),
+                while json, jsonl, xml, html and rss files are not. If you want to override this default behavior,
+                specify bom=True query parameter to include the BOM or bom=False to skip it.
+            delimiter (str, optional): A delimiter character for CSV files. The default delimiter is a simple comma (,).
+            fields (list of str, optional): A list of fields which should be picked from the items,
+                only these fields will remain in the resulting record objects.
+                Note that the fields in the outputted items are sorted the same way as they are specified in the fields parameter.
+                You can use this feature to effectively fix the output format.
+            omit (list of str, optional): A list of fields which should be omitted from the items.
+            unwind (str, optional): Name of a field which should be unwound.
+                If the field is an array then every element of the array will become a separate record and merged with parent object.
+                If the unwound field is an object then it is merged with the parent object.
+                If the unwound field is missing or its value is neither an array nor an object and therefore cannot be merged with a parent object,
+                then the item gets preserved as it is. Note that the unwound items ignore the desc parameter.
+            skip_empty (bool, optional): If True, then empty items are skipped from the output.
+                Note that if used, the results might contain less items than the limit value.
+            skip_header_row (bool, optional): If True, then header row in the csv format is skipped.
+            skip_hidden (bool, optional): If True, then hidden fields are skipped from the output, i.e. fields starting with the # character.
+            xml_root (str, optional): Overrides default root element name of xml output. By default the root element is items.
+            xml_row (str, optional): Overrides default element name that wraps each page or page function result object in xml output.
+                By default the element name is item.
+
+        Returns:
+            bytes: The dataset items as raw bytes
+        """
+        # We need to override and then restore the warnings filter so that the warning gets printed out,
+        # Otherwise it would be silently swallowed
+        with warnings.catch_warnings():
+            warnings.simplefilter('always')
+            warnings.warn(
+                '`DatasetClient.download_items()` is deprecated, use `DatasetClient.get_items_as_bytes()` instead.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        return self.get_items_as_bytes(
+            item_format=item_format,
+            offset=offset,
+            limit=limit,
+            desc=desc,
+            clean=clean,
+            bom=bom,
+            delimiter=delimiter,
+            fields=fields,
+            omit=omit,
+            unwind=unwind,
+            skip_empty=skip_empty,
+            skip_header_row=skip_header_row,
+            skip_hidden=skip_hidden,
+            xml_root=xml_root,
+            xml_row=xml_row,
+        )
+
+    def get_items_as_bytes(
+        self,
+        *,
+        item_format: str = 'json',
+        offset: Optional[int] = None,
+        limit: Optional[int] = None,
+        desc: Optional[bool] = None,
+        clean: Optional[bool] = None,
+        bom: Optional[bool] = None,
+        delimiter: Optional[str] = None,
+        fields: Optional[List[str]] = None,
+        omit: Optional[List[str]] = None,
+        unwind: Optional[str] = None,
+        skip_empty: Optional[bool] = None,
+        skip_header_row: Optional[bool] = None,
+        skip_hidden: Optional[bool] = None,
+        xml_root: Optional[str] = None,
+        xml_row: Optional[str] = None,
+    ) -> bytes:
+        """Get the items in the dataset as raw bytes.
 
         https://docs.apify.com/api/v2#/reference/datasets/item-collection/get-items
 
@@ -280,6 +371,7 @@ class DatasetClient(ResourceClient):
 
         return response.content
 
+    @contextmanager
     def stream_items(
         self,
         *,
@@ -298,8 +390,8 @@ class DatasetClient(ResourceClient):
         skip_hidden: Optional[bool] = None,
         xml_root: Optional[str] = None,
         xml_row: Optional[str] = None,
-    ) -> io.IOBase:
-        """Retrieve the items in the dataset as a file-like object.
+    ) -> Iterator[requests.models.Response]:
+        """Retrieve the items in the dataset as a stream.
 
         https://docs.apify.com/api/v2#/reference/datasets/item-collection/get-items
 
@@ -336,37 +428,39 @@ class DatasetClient(ResourceClient):
                 By default the element name is item.
 
         Returns:
-            io.IOBase: The dataset items as a file-like object
+            requests.Response: The dataset items as a context-managed streaming Response
         """
-        request_params = self._params(
-            format=item_format,
-            offset=offset,
-            limit=limit,
-            desc=desc,
-            clean=clean,
-            bom=bom,
-            delimiter=delimiter,
-            fields=fields,
-            omit=omit,
-            unwind=unwind,
-            skipEmpty=skip_empty,
-            skipHeaderRow=skip_header_row,
-            skipHidden=skip_hidden,
-            xmlRoot=xml_root,
-            xmlRow=xml_row,
-        )
+        response = None
+        try:
+            request_params = self._params(
+                format=item_format,
+                offset=offset,
+                limit=limit,
+                desc=desc,
+                clean=clean,
+                bom=bom,
+                delimiter=delimiter,
+                fields=fields,
+                omit=omit,
+                unwind=unwind,
+                skipEmpty=skip_empty,
+                skipHeaderRow=skip_header_row,
+                skipHidden=skip_hidden,
+                xmlRoot=xml_root,
+                xmlRow=xml_row,
+            )
 
-        response = self.http_client.call(
-            url=self._url('items'),
-            method='GET',
-            params=request_params,
-            stream=True,
-            parse_response=False,
-        )
-
-        response.raw.decode_content = True
-        # response.raw is the raw urllib3 response, which subclasses IOBase
-        return cast(io.IOBase, response.raw)
+            response = self.http_client.call(
+                url=self._url('items'),
+                method='GET',
+                params=request_params,
+                stream=True,
+                parse_response=False,
+            )
+            yield response
+        finally:
+            if response:
+                response.close()
 
     def push_items(self, items: JSONSerializable) -> None:
         """Push items to the dataset.

--- a/src/apify_client/clients/resource_clients/key_value_store.py
+++ b/src/apify_client/clients/resource_clients/key_value_store.py
@@ -189,6 +189,7 @@ class KeyValueStoreClient(ResourceClient):
                 method='GET',
                 params=self._params(),
                 parse_response=False,
+                stream=True,
             )
 
             yield {

--- a/src/apify_client/clients/resource_clients/log.py
+++ b/src/apify_client/clients/resource_clients/log.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 from typing import Any, Iterator, Optional
 
-import requests
+import httpx
 
 from ..._errors import ApifyApiError
 from ..._utils import _catch_not_found_or_throw
@@ -62,13 +62,13 @@ class LogClient(ResourceClient):
         return None
 
     @contextmanager
-    def stream(self) -> Iterator[Optional[requests.models.Response]]:
+    def stream(self) -> Iterator[Optional[httpx.Response]]:
         """Retrieve the log as a stream.
 
         https://docs.apify.com/api/v2#/reference/logs/log/get-log
 
         Returns:
-            requests.Response, optional: The retrieved log as a context-managed streaming Response, or None, if it does not exist.
+            httpx.Response, optional: The retrieved log as a context-managed streaming Response, or None, if it does not exist.
         """
         response = None
         try:

--- a/src/apify_client/clients/resource_clients/log.py
+++ b/src/apify_client/clients/resource_clients/log.py
@@ -75,7 +75,7 @@ class LogClient(ResourceClient):
             response = self.http_client.call(
                 url=self.url,
                 method='GET',
-                params=self._params(),
+                params=self._params(stream=True),
                 stream=True,
                 parse_response=False,
             )

--- a/src/apify_client/clients/resource_clients/log.py
+++ b/src/apify_client/clients/resource_clients/log.py
@@ -1,5 +1,7 @@
-import io
-from typing import Any, Optional, cast
+from contextlib import contextmanager
+from typing import Any, Iterator, Optional
+
+import requests
 
 from ..._errors import ApifyApiError
 from ..._utils import _catch_not_found_or_throw
@@ -36,14 +38,39 @@ class LogClient(ResourceClient):
 
         return None
 
-    def stream(self) -> Optional[io.IOBase]:
-        """Retrieve the log as a file-like object.
+    def get_as_bytes(self) -> Optional[bytes]:
+        """Retrieve the log as raw bytes.
 
         https://docs.apify.com/api/v2#/reference/logs/log/get-log
 
         Returns:
-            io.IOBase, optional: The retrieved log as a file-like object, or None, if it does not exist.
+            bytes, optional: The retrieved log as raw bytes, or None, if it does not exist.
         """
+        try:
+            response = self.http_client.call(
+                url=self.url,
+                method='GET',
+                params=self._params(),
+                parse_response=False,
+            )
+
+            return response.content
+
+        except ApifyApiError as exc:
+            _catch_not_found_or_throw(exc)
+
+        return None
+
+    @contextmanager
+    def stream(self) -> Iterator[Optional[requests.models.Response]]:
+        """Retrieve the log as a stream.
+
+        https://docs.apify.com/api/v2#/reference/logs/log/get-log
+
+        Returns:
+            requests.Response, optional: The retrieved log as a context-managed streaming Response, or None, if it does not exist.
+        """
+        response = None
         try:
             response = self.http_client.call(
                 url=self.url,
@@ -53,12 +80,10 @@ class LogClient(ResourceClient):
                 parse_response=False,
             )
 
-            response.raw.decode_content = True
-            # TODO explain response.raw.close()
-            # response.raw is the raw urllib3 response, which subclasses IOBase
-            return cast(io.IOBase, response.raw)
-
+            yield response
         except ApifyApiError as exc:
             _catch_not_found_or_throw(exc)
-
-        return None
+            yield None
+        finally:
+            if response:
+                response.close()


### PR DESCRIPTION
We want to introduce `async` mode to the client, so that users can make non-blocking requests using `asyncio`. To achieve that, we have to replace the underlying HTTP library, since `requests` does not have `async` support.

I'm switching it to [`httpx`](https://github.com/encode/httpx/) here. It's a fairly mature HTTP(S) library, with support for both sync and async operation, and all the features we need, and it has a (mostly) `requests`-compatible interface, so the switch is fairly easy.

There should be basically no functional differences, but still I'm marking the change as breaking, since under the hood it uses `httpcore` on the transport layer, but `requests` uses `urllib3`, so there could be some low level changes which could possibly affect someone.