### PR TITLE
Added logger with basic debugging info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog
 - added `py.typed` file to signal type checkers that this package is typed
 - added method to update status message for a run
 - added option to set up webhooks for actor builds
+- added logger with basic debugging info
 
 ### Internal changes
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -186,6 +186,25 @@ async def main():
 asyncio.run(main())
 ```
 
+### Logging
+
+The library logs some useful debug information to the `apify_client` logger
+when sending requests to the Apify API.
+To have them printed out to the standard output, you need to add a handler to the logger:
+
+```python
+import logging
+apify_client_logger = logging.getLogger('apify_client')
+apify_client_logger.setLevel(logging.DEBUG)
+apify_client_logger.addHandler(logging.StreamHandler())
+```
+
+The log records have useful properties added with the `extra` argument,
+like `attempt`, `status_code`, `url`, `client_method` and `resource_id`.
+To print those out, you'll need to use a custom log formatter.
+To learn more about log formatters and how to use them,
+please refer to the official Python [documentation on logging](https://docs.python.org/3/howto/logging.html#formatters).
+
 ## API Reference
 
 All public classes, methods and their parameters can be inspected in this API reference.

--- a/docs/res/intro.md
+++ b/docs/res/intro.md
@@ -185,3 +185,22 @@ async def main():
 
 asyncio.run(main())
 ```
+
+### Logging
+
+The library logs some useful debug information to the `apify_client` logger
+when sending requests to the Apify API.
+To have them printed out to the standard output, you need to add a handler to the logger:
+
+```python
+import logging
+apify_client_logger = logging.getLogger('apify_client')
+apify_client_logger.setLevel(logging.DEBUG)
+apify_client_logger.addHandler(logging.StreamHandler())
+```
+
+The log records have useful properties added with the `extra` argument,
+like `attempt`, `status_code`, `url`, `client_method` and `resource_id`.
+To print those out, you'll need to use a custom log formatter.
+To learn more about log formatters and how to use them,
+please refer to the official Python [documentation on logging](https://docs.python.org/3/howto/logging.html#formatters).

--- a/src/apify_client/_logging.py
+++ b/src/apify_client/_logging.py
@@ -1,0 +1,94 @@
+import functools
+import inspect
+import json
+import logging
+from contextvars import ContextVar
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Type, cast
+
+# Conditional import only executed when type checking, otherwise we'd get circular dependency issues
+if TYPE_CHECKING:
+    from .clients.base.base_client import _BaseBaseClient
+
+# Name of the logger used throughout the library
+logger_name = __name__.split('.')[0]
+
+# Logger used throughout the library
+logger = logging.getLogger(logger_name)
+
+
+# Context variables containing the current resource client running in that context
+# Used during logging to inject the resource client context to the log
+ctx_client_method = ContextVar[Optional[str]]('client_method', default=None)
+ctx_resource_id = ContextVar[Optional[str]]('resource_id', default=None)
+ctx_url = ContextVar[Optional[str]]('url', default=None)
+
+
+# Metaclass for resource clients which wraps all their public methods
+# With injection of their details to the log context vars
+class _WithLogDetailsClient(type):
+    def __new__(cls: Type[type], name: str, bases: Tuple, attrs: Dict) -> '_WithLogDetailsClient':
+        for attr_name, attr_value in attrs.items():
+            if not attr_name.startswith('_'):
+                if inspect.isfunction(attr_value):
+                    attrs[attr_name] = _injects_client_details_to_log_context(attr_value)
+
+        return cast(_WithLogDetailsClient, type.__new__(cls, name, bases, attrs))
+
+
+# Wraps an unbound method so that its call will inject the details
+# of the resource client (which is the `self` argument of the method)
+# to the log context vars
+def _injects_client_details_to_log_context(fun: Callable) -> Callable:
+    if inspect.iscoroutinefunction(fun) or inspect.isasyncgenfunction(fun):
+        @functools.wraps(fun)
+        async def async_wrapper(resource_client: '_BaseBaseClient', *args: Any, **kwargs: Any) -> Any:
+            ctx_client_method.set(fun.__qualname__)
+            ctx_resource_id.set(resource_client.resource_id)
+            ctx_url.set(resource_client.url)
+
+            return await fun(resource_client, *args, **kwargs)
+        return async_wrapper
+    else:
+        @functools.wraps(fun)
+        def wrapper(resource_client: '_BaseBaseClient', *args: Any, **kwargs: Any) -> Any:
+            ctx_client_method.set(fun.__qualname__)
+            ctx_resource_id.set(resource_client.resource_id)
+            ctx_url.set(resource_client.url)
+
+            return fun(resource_client, *args, **kwargs)
+        return wrapper
+
+
+# A filter which lets every log record through,
+# but adds the current logging context to the record
+class _ContextInjectingFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.client_method = ctx_client_method.get()
+        record.resource_id = ctx_resource_id.get()
+        record.url = ctx_url.get()
+        return True
+
+
+logger.addFilter(_ContextInjectingFilter())
+
+
+# Log formatter useful for debugging of the client
+# Will print out all the extra fields added to the log record
+class _DebugLogFormatter(logging.Formatter):
+    empty_record = logging.LogRecord('dummy', 0, 'dummy', 0, 'dummy', None, None)
+
+    def _get_extra_fields(self, record: logging.LogRecord) -> Dict[str, Any]:
+        extra_fields: Dict[str, Any] = {}
+        for key, value in record.__dict__.items():
+            if key not in self.empty_record.__dict__:
+                extra_fields[key] = value
+
+        return extra_fields
+
+    def format(self, record: logging.LogRecord) -> str:
+        extra = self._get_extra_fields(record)
+
+        log_string = super().format(record)
+        if extra:
+            log_string = f'{log_string} ({json.dumps(extra)})'
+        return log_string

--- a/src/apify_client/clients/base/base_client.py
+++ b/src/apify_client/clients/base/base_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from ..._http_client import _HTTPClient, _HTTPClientAsync
+from ..._logging import _WithLogDetailsClient
 from ..._utils import _make_async_docs, _to_safe_id
 
 # Conditional import only executed when type checking, otherwise we'd get circular dependency issues
@@ -10,7 +11,8 @@ if TYPE_CHECKING:
     from ...client import ApifyClient, ApifyClientAsync
 
 
-class _BaseBaseClient:
+class _BaseBaseClient(metaclass=_WithLogDetailsClient):
+    resource_id: Optional[str]
     url: str
     params: Dict
     http_client: Union[_HTTPClient, _HTTPClientAsync]


### PR DESCRIPTION
Logging was missing for a long time from the client, and it made it harder to debug the client.

This adds some basic logging to the HTTP calls, using the standard Python logger, enriched by contextual information from the client methods which are doing the HTTP calls by some funky metaclass programming.

There is a `_DebugLogFormatter` class which is great for testing, used like this:

```python
import logging
from apify_client._logging import _DebugLogFormatter

client_logger = logging.getLogger('apify_client')
client_logger.setLevel(logging.DEBUG)
handler = logging.StreamHandler()
handler.setFormatter(_DebugLogFormatter())
client_logger.addHandler(handler)
```