### PR TITLE
Disallowed `NaN` and `Infinity` values in JSONs sent to the Apify API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Changelog
 - added option to set up webhooks for actor builds
 - added logger with basic debugging info
 
+### Fixed
+
+- disallowed `NaN` and `Infinity` values in JSONs sent to the Apify API
+
 ### Internal changes
 
 - simplified retrying with exponential backoff

--- a/src/apify_client/_http_client.py
+++ b/src/apify_client/_http_client.py
@@ -96,7 +96,7 @@ class _BaseHTTPClient:
 
         # dump JSON data to string, so they can be gzipped
         if json:
-            data = jsonlib.dumps(json, ensure_ascii=False, default=str).encode('utf-8')
+            data = jsonlib.dumps(json, ensure_ascii=False, allow_nan=False, default=str).encode('utf-8')
             headers['Content-Type'] = 'application/json'
 
         if isinstance(data, (str, bytes, bytearray)):

--- a/src/apify_client/_utils.py
+++ b/src/apify_client/_utils.py
@@ -211,7 +211,7 @@ def _encode_key_value_store_record_value(value: Any, content_type: Optional[str]
             content_type = 'application/json; charset=utf-8'
 
     if 'application/json' in content_type and not _is_file_or_bytes(value) and not isinstance(value, str):
-        value = json.dumps(value, ensure_ascii=False, indent=2, default=str).encode('utf-8')
+        value = json.dumps(value, ensure_ascii=False, indent=2, allow_nan=False, default=str).encode('utf-8')
 
     return (value, content_type)
 


### PR DESCRIPTION
If you tried to push an item which contained a `NaN` to a dataset, it would return an error from the Apify API, that the JSON you sent to it is invalid.

```python
>>> client.dataset('~nan-testing-dataset').push_items([{ 'a': float('NaN')}])
ApifyApiError: Cannot parse POST payload as JSON: Unexpected token N in JSON at position 7
```

That is because in Python, by default, `json.dumps()` stringifies `NaN` and `Infinity` values. This is against the JSON standard, and `JSON.parse` on the API fails to parse the value.

This fixes it by adding the `allow_nan=False` parameter to `json.dumps()`, so that the error is caught before sending the invalid JSON to the API, and throws an error early.

```python
>>> client.dataset('~nan-testing-dataset').push_items([{ 'a': float('NaN')}])
ValueError: Out of range float values are not JSON compliant: nan
```

By the way, when fixing this, I made my first fix to CPython: https://github.com/python/cpython/pull/99926