### PR TITLE
Converted `unittest`-style tests to `pytest`-style tests

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -3,4 +3,5 @@ include_trailing_comma = True
 line_length = 150
 use_parentheses = True
 multi_line_output = 3
-sections = FUTURE,STDLIB,FIRSTPARTY,THIRDPARTY,LOCALFOLDER
+sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+known_first_party = apify_client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Changelog
 - improved type hints across codebase
 - added option to manually publish the package with a workflow dispatch
 - added `pre-commit` to run code quality checks before committing
+- converted `unittest`-style tests to `pytest`-style tests
 
 [0.6.0](../../releases/tag/v0.6.0) - 2022-06-27
 -----------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
             'pep8-naming ~= 0.13.2',
             'pre-commit ~= 2.20.0',
             'pytest ~= 7.2.0',
+            'pytest-asyncio ~= 0.20.3',
             'sphinx ~= 5.3.0',
             'sphinx-autodoc-typehints ~= 1.19.5',
             'sphinx-markdown-builder == 0.5.4',  # pinned to 0.5.4, because 0.5.5 has a formatting bug

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,9 +1,10 @@
 import io
 import time
-import unittest
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Callable
+
+import pytest
 
 from apify_client._utils import (
     _encode_webhook_list_to_base64,
@@ -24,267 +25,244 @@ from apify_client._utils import (
 from apify_client.consts import WebhookEventType
 
 
-class UtilsTest(unittest.IsolatedAsyncioTestCase):
-    def test__to_safe_id(self) -> None:
-        self.assertEqual(_to_safe_id('abc'), 'abc')
-        self.assertEqual(_to_safe_id('abc/def'), 'abc~def')
-        self.assertEqual(_to_safe_id('abc~def'), 'abc~def')
+def test__to_safe_id() -> None:
+    assert _to_safe_id('abc') == 'abc'
+    assert _to_safe_id('abc/def') == 'abc~def'
+    assert _to_safe_id('abc~def') == 'abc~def'
 
-    def test__parse_date_fields(self) -> None:
-        # works correctly on empty dicts
-        self.assertEqual(_parse_date_fields({}), {})
 
-        # correctly parses dates on fields ending with -At
-        expected_datetime = datetime(2016, 11, 14, 11, 10, 52, 425000, timezone.utc)
-        self.assertEqual(_parse_date_fields({'createdAt': '2016-11-14T11:10:52.425Z'}), {'createdAt': expected_datetime})
+def test__parse_date_fields() -> None:
+    # works correctly on empty dicts
+    assert _parse_date_fields({}) == {}
 
-        # doesn't parse dates on fields not ending with -At
-        self.assertEqual(_parse_date_fields({'saveUntil': '2016-11-14T11:10:52.425Z'}), {'saveUntil': '2016-11-14T11:10:52.425Z'})
+    # correctly parses dates on fields ending with -At
+    expected_datetime = datetime(2016, 11, 14, 11, 10, 52, 425000, timezone.utc)
+    assert _parse_date_fields({'createdAt': '2016-11-14T11:10:52.425Z'}) == {'createdAt': expected_datetime}
 
-        # parses dates in dicts in lists
-        expected_datetime = datetime(2016, 11, 14, 11, 10, 52, 425000, timezone.utc)
-        self.assertEqual(_parse_date_fields([{'createdAt': '2016-11-14T11:10:52.425Z'}]), [{'createdAt': expected_datetime}])
+    # doesn't parse dates on fields not ending with -At
+    assert _parse_date_fields({'saveUntil': '2016-11-14T11:10:52.425Z'}) == {'saveUntil': '2016-11-14T11:10:52.425Z'}
 
-        # parses nested dates
-        expected_datetime = datetime(2020, 2, 29, 10, 9, 8, 100000, timezone.utc)
-        self.assertEqual(
-            _parse_date_fields({'a': {'b': {'c': {'createdAt': '2020-02-29T10:09:08.100Z'}}}}),
-            {'a': {'b': {'c': {'createdAt': expected_datetime}}}},
-        )
+    # parses dates in dicts in lists
+    expected_datetime = datetime(2016, 11, 14, 11, 10, 52, 425000, timezone.utc)
+    assert _parse_date_fields([{'createdAt': '2016-11-14T11:10:52.425Z'}]) == [{'createdAt': expected_datetime}]
 
-        # doesn't parse dates nested too deep
-        expected_datetime = datetime(2020, 2, 29, 10, 9, 8, 100000, timezone.utc)
-        self.assertEqual(
-            _parse_date_fields({'a': {'b': {'c': {'d': {'createdAt': '2020-02-29T10:09:08.100Z'}}}}}),
-            {'a': {'b': {'c': {'d': {'createdAt': '2020-02-29T10:09:08.100Z'}}}}},
-        )
+    # parses nested dates
+    expected_datetime = datetime(2020, 2, 29, 10, 9, 8, 100000, timezone.utc)
+    assert _parse_date_fields({'a': {'b': {'c': {'createdAt': '2020-02-29T10:09:08.100Z'}}}}) \
+        == {'a': {'b': {'c': {'createdAt': expected_datetime}}}}
 
-        # doesn't die when the date can't be parsed
-        self.assertEqual(_parse_date_fields({'createdAt': 'NOT_A_DATE'}), {'createdAt': 'NOT_A_DATE'})
+    # doesn't parse dates nested too deep
+    expected_datetime = datetime(2020, 2, 29, 10, 9, 8, 100000, timezone.utc)
+    assert _parse_date_fields({'a': {'b': {'c': {'d': {'createdAt': '2020-02-29T10:09:08.100Z'}}}}}) \
+        == {'a': {'b': {'c': {'d': {'createdAt': '2020-02-29T10:09:08.100Z'}}}}}
 
-    def test__pluck_data(self) -> None:
-        # works correctly when data is present
-        self.assertEqual(_pluck_data({'data': {}}), {})
-        self.assertEqual(_pluck_data({'a': 'b', 'data': {'b': 'c'}}), {'b': 'c'})
+    # doesn't die when the date can't be parsed
+    assert _parse_date_fields({'createdAt': 'NOT_A_DATE'}) == {'createdAt': 'NOT_A_DATE'}
 
-        # throws the right error when it is not
-        with self.assertRaises(ValueError):
-            _pluck_data({'a': 'b'})
-        with self.assertRaises(ValueError):
-            _pluck_data(None)
-        with self.assertRaises(ValueError):
-            _pluck_data('{"a": "b"}')
 
-    def test__is_content_type_json(self) -> None:
-        # returns True for the right content types
-        self.assertEqual(_is_content_type_json('application/json'), True)
-        self.assertEqual(_is_content_type_json('application/jsonc'), True)
-        # returns False for bad content types
-        self.assertEqual(_is_content_type_json('application/xml'), False)
-        self.assertEqual(_is_content_type_json('application/ld+json'), False)
+def test__pluck_data() -> None:
+    # works correctly when data is present
+    assert _pluck_data({'data': {}}) == {}
+    assert _pluck_data({'a': 'b', 'data': {'b': 'c'}}) == {'b': 'c'}
 
-    def test__is_content_type_xml(self) -> None:
-        # returns True for the right content types
-        self.assertEqual(_is_content_type_xml('application/xml'), True)
-        self.assertEqual(_is_content_type_xml('application/xhtml+xml'), True)
-        # returns False for bad content types
-        self.assertEqual(_is_content_type_xml('application/json'), False)
-        self.assertEqual(_is_content_type_xml('text/html'), False)
+    # throws the right error when it is not
+    with pytest.raises(ValueError):
+        _pluck_data({'a': 'b'})
+    with pytest.raises(ValueError):
+        _pluck_data(None)
+    with pytest.raises(ValueError):
+        _pluck_data('{"a": "b"}')
 
-    def test__is_content_type_text(self) -> None:
-        # returns True for the right content types
-        self.assertEqual(_is_content_type_text('text/html'), True)
-        self.assertEqual(_is_content_type_text('text/plain'), True)
-        # returns False for bad content types
-        self.assertEqual(_is_content_type_text('application/json'), False)
-        self.assertEqual(_is_content_type_text('application/text'), False)
 
-    def test__is_file_or_bytes(self) -> None:
-        # returns True for the right value types
-        self.assertEqual(_is_file_or_bytes(b'abc'), True)
-        self.assertEqual(_is_file_or_bytes(bytearray.fromhex('F0F1F2')), True)
-        self.assertEqual(_is_file_or_bytes(io.BytesIO(b'\x00\x01\x02')), True)
+def test__is_content_type_json() -> None:
+    # returns True for the right content types
+    assert _is_content_type_json('application/json') is True
+    assert _is_content_type_json('application/jsonc') is True
+    # returns False for bad content types
+    assert _is_content_type_json('application/xml') is False
+    assert _is_content_type_json('application/ld+json') is False
 
-        # returns False for bad value types
-        self.assertEqual(_is_file_or_bytes('abc'), False)
-        self.assertEqual(_is_file_or_bytes(['a', 'b', 'c']), False)
-        self.assertEqual(_is_file_or_bytes({'a': 'b'}), False)
-        self.assertEqual(_is_file_or_bytes(None), False)
 
-    def test__retry_with_exp_backoff(self) -> None:
-        attempt_counter = 0
+def test__is_content_type_xml() -> None:
+    # returns True for the right content types
+    assert _is_content_type_xml('application/xml') is True
+    assert _is_content_type_xml('application/xhtml+xml') is True
+    # returns False for bad content types
+    assert _is_content_type_xml('application/json') is False
+    assert _is_content_type_xml('text/html') is False
 
-        class RetryableError(Exception):
-            pass
 
-        class NonRetryableError(Exception):
-            pass
+def test__is_content_type_text() -> None:
+    # returns True for the right content types
+    assert _is_content_type_text('text/html') is True
+    assert _is_content_type_text('text/plain') is True
+    # returns False for bad content types
+    assert _is_content_type_text('application/json') is False
+    assert _is_content_type_text('application/text') is False
 
-        def returns_on_fifth_attempt(_stop_retrying: Callable, attempt: int) -> Any:
-            nonlocal attempt_counter
-            attempt_counter += 1
 
-            if attempt == 5:
-                return 'SUCCESS'
+def test__is_file_or_bytes() -> None:
+    # returns True for the right value types
+    assert _is_file_or_bytes(b'abc') is True
+    assert _is_file_or_bytes(bytearray.fromhex('F0F1F2')) is True
+    assert _is_file_or_bytes(io.BytesIO(b'\x00\x01\x02')) is True
+
+    # returns False for bad value types
+    assert _is_file_or_bytes('abc') is False
+    assert _is_file_or_bytes(['a', 'b', 'c']) is False
+    assert _is_file_or_bytes({'a': 'b'}) is False
+    assert _is_file_or_bytes(None) is False
+
+
+def test__retry_with_exp_backoff() -> None:
+    attempt_counter = 0
+
+    class RetryableError(Exception):
+        pass
+
+    class NonRetryableError(Exception):
+        pass
+
+    def returns_on_fifth_attempt(_stop_retrying: Callable, attempt: int) -> Any:
+        nonlocal attempt_counter
+        attempt_counter += 1
+
+        if attempt == 5:
+            return 'SUCCESS'
+        raise RetryableError()
+
+    def bails_on_third_attempt(stop_retrying: Callable, attempt: int) -> Any:
+        nonlocal attempt_counter
+        attempt_counter += 1
+
+        if attempt == 3:
+            stop_retrying()
+            raise NonRetryableError()
+        else:
             raise RetryableError()
 
-        def bails_on_third_attempt(stop_retrying: Callable, attempt: int) -> Any:
-            nonlocal attempt_counter
-            attempt_counter += 1
+    # Returns the correct result after the correct time (should take 100 + 200 + 400 + 800 = 1500 ms)
+    start = time.time()
+    result = _retry_with_exp_backoff(returns_on_fifth_attempt, backoff_base_millis=100, backoff_factor=2, random_factor=0)
+    elapsed_time_seconds = time.time() - start
+    assert result == 'SUCCESS'
+    assert attempt_counter == 5
+    assert elapsed_time_seconds > 1.4
+    assert elapsed_time_seconds < 2.0
 
-            if attempt == 3:
-                stop_retrying()
-                raise NonRetryableError()
-            else:
-                raise RetryableError()
+    # Stops retrying when failed for max_retries times
+    attempt_counter = 0
+    with pytest.raises(RetryableError):
+        _retry_with_exp_backoff(returns_on_fifth_attempt, max_retries=3, backoff_base_millis=1)
+    assert attempt_counter == 4
 
-        # Returns the correct result after the correct time (should take 100 + 200 + 400 + 800 = 1500 ms)
-        start = time.time()
-        result = _retry_with_exp_backoff(returns_on_fifth_attempt, backoff_base_millis=100, backoff_factor=2, random_factor=0)
-        elapsed_time_seconds = time.time() - start
-        self.assertEqual(result, 'SUCCESS')
-        self.assertEqual(attempt_counter, 5)
-        self.assertGreater(elapsed_time_seconds, 1.4)
-        self.assertLess(elapsed_time_seconds, 2.0)
+    # Bails when the bail function is called
+    attempt_counter = 0
+    with pytest.raises(NonRetryableError):
+        _retry_with_exp_backoff(bails_on_third_attempt, backoff_base_millis=1)
+    assert attempt_counter == 3
 
-        # Stops retrying when failed for max_retries times
-        attempt_counter = 0
-        with self.assertRaises(RetryableError):
-            _retry_with_exp_backoff(returns_on_fifth_attempt, max_retries=3, backoff_base_millis=1)
-        self.assertEqual(attempt_counter, 4)
 
-        # Bails when the bail function is called
-        attempt_counter = 0
-        with self.assertRaises(NonRetryableError):
-            _retry_with_exp_backoff(bails_on_third_attempt, backoff_base_millis=1)
-        self.assertEqual(attempt_counter, 3)
+@pytest.mark.asyncio
+async def test__retry_with_exp_backoff_async() -> None:
+    attempt_counter = 0
 
-    async def test__retry_with_exp_backoff_async(self) -> None:
-        attempt_counter = 0
+    class RetryableError(Exception):
+        pass
 
-        class RetryableError(Exception):
-            pass
+    class NonRetryableError(Exception):
+        pass
 
-        class NonRetryableError(Exception):
-            pass
+    async def returns_on_fifth_attempt(_stop_retrying: Callable, attempt: int) -> Any:
+        nonlocal attempt_counter
+        attempt_counter += 1
 
-        async def returns_on_fifth_attempt(_stop_retrying: Callable, attempt: int) -> Any:
-            nonlocal attempt_counter
-            attempt_counter += 1
+        if attempt == 5:
+            return 'SUCCESS'
+        raise RetryableError()
 
-            if attempt == 5:
-                return 'SUCCESS'
+    async def bails_on_third_attempt(stop_retrying: Callable, attempt: int) -> Any:
+        nonlocal attempt_counter
+        attempt_counter += 1
+
+        if attempt == 3:
+            stop_retrying()
+            raise NonRetryableError()
+        else:
             raise RetryableError()
 
-        async def bails_on_third_attempt(stop_retrying: Callable, attempt: int) -> Any:
-            nonlocal attempt_counter
-            attempt_counter += 1
+    # Returns the correct result after the correct time (should take 100 + 200 + 400 + 800 = 1500 ms)
+    start = time.time()
+    result = await _retry_with_exp_backoff_async(returns_on_fifth_attempt, backoff_base_millis=100, backoff_factor=2, random_factor=0)
+    elapsed_time_seconds = time.time() - start
+    assert result == 'SUCCESS'
+    assert attempt_counter == 5
+    assert elapsed_time_seconds > 1.4
+    assert elapsed_time_seconds < 2.0
 
-            if attempt == 3:
-                stop_retrying()
-                raise NonRetryableError()
-            else:
-                raise RetryableError()
+    # Stops retrying when failed for max_retries times
+    attempt_counter = 0
+    with pytest.raises(RetryableError):
+        await _retry_with_exp_backoff_async(returns_on_fifth_attempt, max_retries=3, backoff_base_millis=1)
+    assert attempt_counter == 4
 
-        # Returns the correct result after the correct time (should take 100 + 200 + 400 + 800 = 1500 ms)
-        start = time.time()
-        result = await _retry_with_exp_backoff_async(returns_on_fifth_attempt, backoff_base_millis=100, backoff_factor=2, random_factor=0)
-        elapsed_time_seconds = time.time() - start
-        self.assertEqual(result, 'SUCCESS')
-        self.assertEqual(attempt_counter, 5)
-        self.assertGreater(elapsed_time_seconds, 1.4)
-        self.assertLess(elapsed_time_seconds, 2.0)
+    # Bails when the bail function is called
+    attempt_counter = 0
+    with pytest.raises(NonRetryableError):
+        await _retry_with_exp_backoff_async(bails_on_third_attempt, backoff_base_millis=1)
+    assert attempt_counter == 3
 
-        # Stops retrying when failed for max_retries times
-        attempt_counter = 0
-        with self.assertRaises(RetryableError):
-            await _retry_with_exp_backoff_async(returns_on_fifth_attempt, max_retries=3, backoff_base_millis=1)
-        self.assertEqual(attempt_counter, 4)
 
-        # Bails when the bail function is called
-        attempt_counter = 0
-        with self.assertRaises(NonRetryableError):
-            await _retry_with_exp_backoff_async(bails_on_third_attempt, backoff_base_millis=1)
-        self.assertEqual(attempt_counter, 3)
+def test__encode_webhook_list_to_base64() -> None:
+    assert _encode_webhook_list_to_base64([]) == b'W10='
+    assert _encode_webhook_list_to_base64([
+        {
+            'event_types': [WebhookEventType.ACTOR_RUN_CREATED],
+            'request_url': 'https://example.com/run-created',
+        },
+        {
+            'event_types': [WebhookEventType.ACTOR_RUN_SUCCEEDED],
+            'request_url': 'https://example.com/run-succeeded',
+            'payload_template': '{"hello": "world", "resource":{{resource}}}',
+        },
+    ]) == b'W3siZXZlbnRUeXBlcyI6IFsiQUNUT1IuUlVOLkNSRUFURUQiXSwgInJlcXVlc3RVcmwiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9ydW4tY3JlYXRlZCJ9LCB7ImV2ZW50VHlwZXMiOiBbIkFDVE9SLlJVTi5TVUNDRUVERUQiXSwgInJlcXVlc3RVcmwiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9ydW4tc3VjY2VlZGVkIiwgInBheWxvYWRUZW1wbGF0ZSI6ICJ7XCJoZWxsb1wiOiBcIndvcmxkXCIsIFwicmVzb3VyY2VcIjp7e3Jlc291cmNlfX19In1d'  # noqa: E501
 
-    def test__encode_webhook_list_to_base64(self) -> None:
-        self.assertEqual(_encode_webhook_list_to_base64([]), b'W10=')
-        self.assertEqual(
-            _encode_webhook_list_to_base64([
-                {
-                    'event_types': [WebhookEventType.ACTOR_RUN_CREATED],
-                    'request_url': 'https://example.com/run-created',
-                },
-                {
-                    'event_types': [WebhookEventType.ACTOR_RUN_SUCCEEDED],
-                    'request_url': 'https://example.com/run-succeeded',
-                    'payload_template': '{"hello": "world", "resource":{{resource}}}',
-                },
-            ]),
-            b'W3siZXZlbnRUeXBlcyI6IFsiQUNUT1IuUlVOLkNSRUFURUQiXSwgInJlcXVlc3RVcmwiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9ydW4tY3JlYXRlZCJ9LCB7ImV2ZW50VHlwZXMiOiBbIkFDVE9SLlJVTi5TVUNDRUVERUQiXSwgInJlcXVlc3RVcmwiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9ydW4tc3VjY2VlZGVkIiwgInBheWxvYWRUZW1wbGF0ZSI6ICJ7XCJoZWxsb1wiOiBcIndvcmxkXCIsIFwicmVzb3VyY2VcIjp7e3Jlc291cmNlfX19In1d',  # noqa: E501
-        )
 
-    def test__maybe_extract_enum_member_value(self) -> None:
-        class TestEnum(Enum):
-            A = 'A'
-            B = 'B'
+def test__maybe_extract_enum_member_value() -> None:
+    class TestEnum(Enum):
+        A = 'A'
+        B = 'B'
 
-        self.assertEqual(_maybe_extract_enum_member_value(TestEnum.A), 'A')
-        self.assertEqual(_maybe_extract_enum_member_value(TestEnum.B), 'B')
-        self.assertEqual(_maybe_extract_enum_member_value('C'), 'C')
-        self.assertEqual(_maybe_extract_enum_member_value(1), 1)
-        self.assertEqual(_maybe_extract_enum_member_value(None), None)
+    assert _maybe_extract_enum_member_value(TestEnum.A) == 'A'
+    assert _maybe_extract_enum_member_value(TestEnum.B) == 'B'
+    assert _maybe_extract_enum_member_value('C') == 'C'
+    assert _maybe_extract_enum_member_value(1) == 1
+    assert _maybe_extract_enum_member_value(None) is None
 
-    def test__filter_out_none_values_recursively(self) -> None:
-        self.assertEqual(
-            _filter_out_none_values_recursively({'k1': 'v1'}),
-            {'k1': 'v1'},
-        )
-        self.assertEqual(
-            _filter_out_none_values_recursively({'k1': None}),
-            {},
-        )
-        self.assertEqual(
-            _filter_out_none_values_recursively({'k1': 'v1', 'k2': None, 'k3': {'k4': 'v4', 'k5': None}, 'k6': {'k7': None}}),
-            {'k1': 'v1', 'k3': {'k4': 'v4'}},
-        )
 
-    def test__filter_out_none_values_recursively_internal(self) -> None:
-        self.assertEqual(
-            _filter_out_none_values_recursively_internal({}),
-            {},
-        )
-        self.assertEqual(
-            _filter_out_none_values_recursively_internal({'k1': {}}),
-            {},
-        )
-        self.assertEqual(
-            _filter_out_none_values_recursively_internal({}, False),
-            {},
-        )
-        self.assertEqual(
-            _filter_out_none_values_recursively_internal({'k1': {}}, False),
-            {'k1': {}},
-        )
-        self.assertEqual(
-            _filter_out_none_values_recursively_internal({}, True),
-            None,
-        )
-        self.assertEqual(
-            _filter_out_none_values_recursively_internal({'k1': {}}, True),
-            None,
-        )
+def test__filter_out_none_values_recursively() -> None:
+    assert _filter_out_none_values_recursively({'k1': 'v1'}) == {'k1': 'v1'}
+    assert _filter_out_none_values_recursively({'k1': None}) == {}
+    assert _filter_out_none_values_recursively({'k1': 'v1', 'k2': None, 'k3': {'k4': 'v4', 'k5': None}, 'k6': {'k7': None}}) \
+        == {'k1': 'v1', 'k3': {'k4': 'v4'}}
 
-    def test__make_async_docs(self) -> None:
-        def source_func() -> None:
-            """source_func docs."""
-            pass
 
-        @_make_async_docs(src=source_func)
-        def target_func() -> None:
-            pass
+def test__filter_out_none_values_recursively_internal() -> None:
+    assert _filter_out_none_values_recursively_internal({}) == {}
+    assert _filter_out_none_values_recursively_internal({'k1': {}}) == {}
+    assert _filter_out_none_values_recursively_internal({}, False) == {}
+    assert _filter_out_none_values_recursively_internal({'k1': {}}, False) == {'k1': {}}
+    assert _filter_out_none_values_recursively_internal({}, True) is None
+    assert _filter_out_none_values_recursively_internal({'k1': {}}, True) is None
 
-        self.assertEqual(
-            target_func.__doc__,
-            'source_func docs.',
-        )
+
+def test__make_async_docs() -> None:
+    def source_func() -> None:
+        """source_func docs."""
+        pass
+
+    @_make_async_docs(src=source_func)
+    def target_func() -> None:
+        pass
+
+    assert target_func.__doc__ == 'source_func docs.'


### PR DESCRIPTION
This is to bring consistency with the Python SDK, which is also converting to `pytest`-style tests [here](https://github.com/apify/apify-sdk-python/pull/16).