### PR TITLE
Write docs for async methods explicitly, get rid of `_make_async_docs` decorator

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -20,7 +20,6 @@ ignore =
     D409
     D413
     U101
-ignore-decorators = _make_async_docs
 per-file-ignores =
     docs/*: D
     scripts/*: D

--- a/.github/workflows/check_docs.yaml
+++ b/.github/workflows/check_docs.yaml
@@ -19,5 +19,8 @@ jobs:
     - name: Install dependencies
       run: make install-dev
 
+    - name: Check async docstrings
+      run: make check-async-docstrings
+
     - name: Check docs building
       run: make check-docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,12 @@ repos:
       language: system
       pass_filenames: false
 
+    - id: check-docs
+      name: "Check whether async docstrings are aligned with sync ones"
+      entry: "make check-async-docstrings"
+      language: system
+      pass_filenames: false
+
     - id: type-check
       name: "Type-check codebase"
       entry: "make type-check"

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test:
 type-check:
 	python3 -m mypy
 
-check-code: lint type-check test
+check-code: lint check-async-docstrings type-check test
 
 format:
 	python3 -m isort src tests
@@ -29,6 +29,12 @@ docs:
 
 check-docs:
 	./docs/res/check.sh
+
+check-async-docstrings:
+	python3 scripts/check_async_docstrings.py
+
+fix-async-docstrings:
+	python3 scripts/fix_async_docstrings.py
 
 check-changelog-entry:
 	python3 scripts/check_version_in_changelog.py

--- a/scripts/check_async_docstrings.py
+++ b/scripts/check_async_docstrings.py
@@ -1,0 +1,38 @@
+import re
+import sys
+from pathlib import Path
+
+from redbaron import RedBaron  # type: ignore
+from utils import sync_to_async_docstring
+
+found_issues = False
+
+clients_path = Path(__file__).parent.resolve() / '../src/apify_client'
+for client_source_path in clients_path.glob('**/*.py'):
+    with open(client_source_path, 'r') as source_file:
+        red = RedBaron(source_code=source_file.read())
+        async_class = red.find('ClassNode', name=re.compile('.*ClientAsync$'))
+        if not async_class:
+            continue
+        sync_class = red.find('ClassNode', name=async_class.name.replace('ClientAsync', 'Client'))
+        for async_method in async_class.find_all('DefNode'):
+            sync_method = sync_class.find('DefNode', name=async_method.name)
+            if isinstance(sync_method.value[0].value, str):
+                sync_docstring = sync_method.value[0].value
+                async_docstring = async_method.value[0].value
+                expected_docstring = sync_to_async_docstring(sync_docstring)
+
+                if not isinstance(async_docstring, str):
+                    print(f'Missing docstring for "{async_class.name}.{async_method.name}"!')
+                    found_issues = True
+                    continue
+                if expected_docstring != async_docstring:
+                    print(f'Docstring for "{async_class.name}.{async_method.name}" is out of sync with "{sync_class.name}.{sync_method.name}"!')
+                    found_issues = True
+
+if found_issues:
+    print()
+    print('Issues with async docstrings found. Please fix them manually or by running `make fix-async-docstrings`.')
+    sys.exit(1)
+else:
+    print('Success: async method docstrings are in sync with sync method docstrings.')

--- a/scripts/fix_async_docstrings.py
+++ b/scripts/fix_async_docstrings.py
@@ -1,0 +1,51 @@
+import re
+from pathlib import Path
+
+from redbaron import RedBaron  # type: ignore
+from utils import sync_to_async_docstring
+
+clients_path = Path(__file__).parent.resolve() / '../src/apify_client'
+for client_source_path in clients_path.glob('**/*.py'):
+    with open(client_source_path, 'r+') as source_file:
+        red = RedBaron(source_code=source_file.read())
+        async_class = red.find('ClassNode', name=re.compile('.*ClientAsync$'))
+        if not async_class:
+            continue
+        sync_class = red.find('ClassNode', name=async_class.name.replace('ClientAsync', 'Client'))
+        for async_method in async_class.find_all('DefNode'):
+            sync_method = sync_class.find('DefNode', name=async_method.name)
+            if isinstance(sync_method.value[0].value, str):
+                sync_docstring = sync_method.value[0].value
+                async_docstring = async_method.value[0].value
+                correct_async_docstring = sync_to_async_docstring(sync_docstring)
+                if async_docstring == correct_async_docstring:
+                    continue
+
+                # work around a bug in Red Baron, which indents docstrings too much when you insert them, so we have to un-indent it one level first
+                correct_async_docstring = re.sub('^    ', '', correct_async_docstring, flags=re.M)
+
+                if not isinstance(async_docstring, str):
+                    print(f'Fixing missing docstring for "{async_class.name}.{async_method.name}"...')
+                    async_method.value.insert(0, correct_async_docstring)
+                else:
+                    async_method.value[0] = correct_async_docstring
+
+        updated_source_code = red.dumps()
+
+        # work around a bug in Red Baron, which adds indents to docstrings when you insert them (including empty lines),
+        # so we have to remove the extra whitespace
+        updated_source_code = re.sub('^    $', '', updated_source_code, flags=re.M)
+
+        # work around a bug in Red Baron, which indents `except` and `finally` statements wrong
+        # so we have to add some extra whitespace
+        updated_source_code = re.sub('^except', '        except', updated_source_code, flags=re.M)
+        updated_source_code = re.sub('^    except', '        except', updated_source_code, flags=re.M)
+        updated_source_code = re.sub('^finally', '        finally', updated_source_code, flags=re.M)
+        updated_source_code = re.sub('^    finally', '        finally', updated_source_code, flags=re.M)
+
+        # work around a bug in Red Baron, which sometimes adds an extra new line to the end of a file
+        updated_source_code = updated_source_code.rstrip() + '\n'
+
+        source_file.seek(0)
+        source_file.write(updated_source_code)
+        source_file.truncate()

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,4 +1,5 @@
 import pathlib
+import re
 
 PACKAGE_NAME = 'apify_client'
 REPO_ROOT = pathlib.Path(__file__).parent.resolve() / '..'
@@ -36,3 +37,13 @@ def set_current_package_version(version: str) -> None:
         version_file.seek(0)
         version_file.write('\n'.join(updated_version_file_lines))
         version_file.truncate()
+
+
+# Generate convert a docstring from a sync resource client method
+# into a doctring for its async resource client analogue
+def sync_to_async_docstring(docstring: str) -> str:
+    substitutions = [(r'Client', r'ClientAsync')]
+    res = docstring
+    for (pattern, replacement) in substitutions:
+        res = re.sub(pattern, replacement, res, flags=re.M)
+    return res

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
             'pre-commit ~= 2.20.0',
             'pytest ~= 7.2.0',
             'pytest-asyncio ~= 0.20.3',
+            'redbaron ~= 0.9.2',
             'sphinx ~= 5.3.0',
             'sphinx-autodoc-typehints ~= 1.19.5',
             'sphinx-markdown-builder == 0.5.4',  # pinned to 0.5.4, because 0.5.5 has a formatting bug

--- a/src/apify_client/_utils.py
+++ b/src/apify_client/_utils.py
@@ -222,23 +222,6 @@ def _maybe_extract_enum_member_value(maybe_enum_member: Any) -> Any:
     return maybe_enum_member
 
 
-BoundFunc = TypeVar('BoundFunc', bound=Callable[..., Any])
-
-
-def _make_async_docs(*, src: Callable) -> Callable[[BoundFunc], BoundFunc]:
-    """Copy docstring from another method, adjusting it to work in an async scenario."""
-    substitutions = [(r'Client', r'ClientAsync')]
-
-    def decorator(dest: BoundFunc) -> BoundFunc:
-        if not dest.__doc__ and src.__doc__:
-            dest.__doc__ = src.__doc__
-            for (pattern, replacement) in substitutions:
-                dest.__doc__ = re.sub(pattern, replacement, dest.__doc__, flags=re.M)
-        return dest
-
-    return decorator
-
-
 class ListPage(Generic[T]):
     """A single page of items returned from a list() method."""
 

--- a/src/apify_client/client.py
+++ b/src/apify_client/client.py
@@ -1,7 +1,6 @@
 from typing import Dict, Optional, Union
 
 from ._http_client import _HTTPClient, _HTTPClientAsync
-from ._utils import _make_async_docs
 from .clients import (
     ActorClient,
     ActorClientAsync,
@@ -272,7 +271,6 @@ class ApifyClientAsync(_BaseApifyClient):
 
     http_client: _HTTPClientAsync
 
-    @_make_async_docs(src=ApifyClient.__init__)
     def __init__(
         self,
         token: Optional[str] = None,
@@ -282,6 +280,16 @@ class ApifyClientAsync(_BaseApifyClient):
         min_delay_between_retries_millis: Optional[int] = 500,
         timeout_secs: Optional[int] = 360,
     ):
+        """Initialize the ApifyClientAsync.
+
+        Args:
+            token (str, optional): The Apify API token
+            api_url (str, optional): The URL of the Apify API server to which to connect to. Defaults to https://api.apify.com
+            max_retries (int, optional): How many times to retry a failed request at most
+            min_delay_between_retries_millis (int, optional): How long will the client wait between retrying requests
+                (increases exponentially from this value)
+            timeout_secs (int, optional): The socket timeout of the HTTP requests sent to the Apify API
+        """
         super().__init__(
             token,
             api_url=api_url,
@@ -297,90 +305,139 @@ class ApifyClientAsync(_BaseApifyClient):
             timeout_secs=self.timeout_secs,
         )
 
-    @_make_async_docs(src=ApifyClient.actor)
     def actor(self, actor_id: str) -> ActorClientAsync:
+        """Retrieve the sub-client for manipulating a single actor.
+
+        Args:
+            actor_id (str): ID of the actor to be manipulated
+        """
         return ActorClientAsync(resource_id=actor_id, **self._options())
 
-    @_make_async_docs(src=ApifyClient.actors)
     def actors(self) -> ActorCollectionClientAsync:
+        """Retrieve the sub-client for manipulating actors."""
         return ActorCollectionClientAsync(**self._options())
 
-    @_make_async_docs(src=ApifyClient.build)
     def build(self, build_id: str) -> BuildClientAsync:
+        """Retrieve the sub-client for manipulating a single actor build.
+
+        Args:
+            build_id (str): ID of the actor build to be manipulated
+        """
         return BuildClientAsync(resource_id=build_id, **self._options())
 
-    @_make_async_docs(src=ApifyClient.builds)
     def builds(self) -> BuildCollectionClientAsync:
+        """Retrieve the sub-client for querying multiple builds of a user."""
         return BuildCollectionClientAsync(**self._options())
 
-    @_make_async_docs(src=ApifyClient.run)
     def run(self, run_id: str) -> RunClientAsync:
+        """Retrieve the sub-client for manipulating a single actor run.
+
+        Args:
+            run_id (str): ID of the actor run to be manipulated
+        """
         return RunClientAsync(resource_id=run_id, **self._options())
 
-    @_make_async_docs(src=ApifyClient.runs)
     def runs(self) -> RunCollectionClientAsync:
+        """Retrieve the sub-client for querying multiple actor runs of a user."""
         return RunCollectionClientAsync(**self._options())
 
-    @_make_async_docs(src=ApifyClient.dataset)
     def dataset(self, dataset_id: str) -> DatasetClientAsync:
+        """Retrieve the sub-client for manipulating a single dataset.
+
+        Args:
+            dataset_id (str): ID of the dataset to be manipulated
+        """
         return DatasetClientAsync(resource_id=dataset_id, **self._options())
 
-    @_make_async_docs(src=ApifyClient.datasets)
     def datasets(self) -> DatasetCollectionClientAsync:
+        """Retrieve the sub-client for manipulating datasets."""
         return DatasetCollectionClientAsync(**self._options())
 
-    @_make_async_docs(src=ApifyClient.key_value_store)
     def key_value_store(self, key_value_store_id: str) -> KeyValueStoreClientAsync:
+        """Retrieve the sub-client for manipulating a single key-value store.
+
+        Args:
+            key_value_store_id (str): ID of the key-value store to be manipulated
+        """
         return KeyValueStoreClientAsync(resource_id=key_value_store_id, **self._options())
 
-    @_make_async_docs(src=ApifyClient.key_value_stores)
     def key_value_stores(self) -> KeyValueStoreCollectionClientAsync:
+        """Retrieve the sub-client for manipulating key-value stores."""
         return KeyValueStoreCollectionClientAsync(**self._options())
 
-    @_make_async_docs(src=ApifyClient.request_queue)
     def request_queue(self, request_queue_id: str, *, client_key: Optional[str] = None) -> RequestQueueClientAsync:
+        """Retrieve the sub-client for manipulating a single request queue.
+
+        Args:
+            request_queue_id (str): ID of the request queue to be manipulated
+            client_key (str): A unique identifier of the client accessing the request queue
+        """
         return RequestQueueClientAsync(resource_id=request_queue_id, client_key=client_key, **self._options())
 
-    @_make_async_docs(src=ApifyClient.request_queues)
     def request_queues(self) -> RequestQueueCollectionClientAsync:
+        """Retrieve the sub-client for manipulating request queues."""
         return RequestQueueCollectionClientAsync(**self._options())
 
-    @_make_async_docs(src=ApifyClient.webhook)
     def webhook(self, webhook_id: str) -> WebhookClientAsync:
+        """Retrieve the sub-client for manipulating a single webhook.
+
+        Args:
+            webhook_id (str): ID of the webhook to be manipulated
+        """
         return WebhookClientAsync(resource_id=webhook_id, **self._options())
 
-    @_make_async_docs(src=ApifyClient.webhooks)
     def webhooks(self) -> WebhookCollectionClientAsync:
+        """Retrieve the sub-client for querying multiple webhooks of a user."""
         return WebhookCollectionClientAsync(**self._options())
 
-    @_make_async_docs(src=ApifyClient.webhook_dispatch)
     def webhook_dispatch(self, webhook_dispatch_id: str) -> WebhookDispatchClientAsync:
+        """Retrieve the sub-client for accessing a single webhook dispatch.
+
+        Args:
+            webhook_dispatch_id (str): ID of the webhook dispatch to access
+        """
         return WebhookDispatchClientAsync(resource_id=webhook_dispatch_id, **self._options())
 
-    @_make_async_docs(src=ApifyClient.webhook_dispatches)
     def webhook_dispatches(self) -> WebhookDispatchCollectionClientAsync:
+        """Retrieve the sub-client for querying multiple webhook dispatches of a user."""
         return WebhookDispatchCollectionClientAsync(**self._options())
 
-    @_make_async_docs(src=ApifyClient.schedule)
     def schedule(self, schedule_id: str) -> ScheduleClientAsync:
+        """Retrieve the sub-client for manipulating a single schedule.
+
+        Args:
+            schedule_id (str): ID of the schedule to be manipulated
+        """
         return ScheduleClientAsync(resource_id=schedule_id, **self._options())
 
-    @_make_async_docs(src=ApifyClient.schedules)
     def schedules(self) -> ScheduleCollectionClientAsync:
+        """Retrieve the sub-client for manipulating schedules."""
         return ScheduleCollectionClientAsync(**self._options())
 
-    @_make_async_docs(src=ApifyClient.log)
     def log(self, build_or_run_id: str) -> LogClientAsync:
+        """Retrieve the sub-client for retrieving logs.
+
+        Args:
+            build_or_run_id (str): ID of the actor build or run for which to access the log
+        """
         return LogClientAsync(resource_id=build_or_run_id, **self._options())
 
-    @_make_async_docs(src=ApifyClient.task)
     def task(self, task_id: str) -> TaskClientAsync:
+        """Retrieve the sub-client for manipulating a single task.
+
+        Args:
+            task_id (str): ID of the task to be manipulated
+        """
         return TaskClientAsync(resource_id=task_id, **self._options())
 
-    @_make_async_docs(src=ApifyClient.tasks)
     def tasks(self) -> TaskCollectionClientAsync:
+        """Retrieve the sub-client for manipulating tasks."""
         return TaskCollectionClientAsync(**self._options())
 
-    @_make_async_docs(src=ApifyClient.user)
     def user(self, user_id: Optional[str] = None) -> UserClientAsync:
+        """Retrieve the sub-client for querying users.
+
+        Args:
+            user_id (str, optional): ID of user to be queried. If None, queries the user belonging to the token supplied to the client
+        """
         return UserClientAsync(resource_id=user_id, **self._options())

--- a/src/apify_client/clients/base/base_client.py
+++ b/src/apify_client/clients/base/base_client.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from ..._http_client import _HTTPClient, _HTTPClientAsync
 from ..._logging import _WithLogDetailsClient
-from ..._utils import _make_async_docs, _to_safe_id
+from ..._utils import _to_safe_id
 
 # Conditional import only executed when type checking, otherwise we'd get circular dependency issues
 if TYPE_CHECKING:
@@ -90,7 +90,6 @@ class BaseClientAsync(_BaseBaseClient):
     http_client: _HTTPClientAsync
     root_client: ApifyClientAsync
 
-    @_make_async_docs(src=BaseClient.__init__)
     def __init__(
         self,
         *,
@@ -101,6 +100,16 @@ class BaseClientAsync(_BaseBaseClient):
         resource_path: str,
         params: Optional[Dict] = None,
     ) -> None:
+        """Initialize the sub-client.
+
+        Args:
+            base_url (str): Base URL of the API server
+            root_client (ApifyClientAsync): The ApifyClientAsync instance under which this resource client exists
+            http_client (_HTTPClientAsync): The _HTTPClientAsync instance to be used in this client
+            resource_id (str): ID of the manipulated resource, in case of a single-resource client
+            resource_path (str): Path to the resource's endpoint on the API server
+            params (dict): Parameters to include in all requests from this client
+        """
         if resource_path.endswith('/'):
             raise ValueError('resource_path must not end with "/"')
 

--- a/src/apify_client/clients/resource_clients/actor.py
+++ b/src/apify_client/clients/resource_clients/actor.py
@@ -4,7 +4,6 @@ from ..._utils import (
     _encode_key_value_store_record_value,
     _encode_webhook_list_to_base64,
     _filter_out_none_values_recursively,
-    _make_async_docs,
     _maybe_extract_enum_member_value,
     _parse_date_fields,
     _pluck_data,
@@ -357,11 +356,16 @@ class ActorClientAsync(ResourceClientAsync):
         resource_path = kwargs.pop('resource_path', 'acts')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=ActorClient.get)
     async def get(self) -> Optional[Dict]:
+        """Retrieve the actor.
+
+        https://docs.apify.com/api/v2#/reference/actors/actor-object/get-actor
+
+        Returns:
+            dict, optional: The retrieved actor
+        """
         return await self._get()
 
-    @_make_async_docs(src=ActorClient.update)
     async def update(
         self,
         *,
@@ -382,6 +386,31 @@ class ActorClientAsync(ResourceClientAsync):
         example_run_input_body: Optional[Any] = None,
         example_run_input_content_type: Optional[str] = None,
     ) -> Dict:
+        """Update the actor with the specified fields.
+
+        https://docs.apify.com/api/v2#/reference/actors/actor-object/update-actor
+
+        Args:
+            name (str, optional): The name of the actor
+            title (str, optional): The title of the actor (human-readable)
+            description (str, optional): The description for the actor
+            seo_title (str, optional): The title of the actor optimized for search engines
+            seo_description (str, optional): The description of the actor optimized for search engines
+            versions (list of dict, optional): The list of actor versions
+            restart_on_error (bool, optional): If true, the main actor run process will be restarted whenever it exits with a non-zero status code.
+            is_public (bool, optional): Whether the actor is public.
+            is_deprecated (bool, optional): Whether the actor is deprecated.
+            is_anonymously_runnable (bool, optional): Whether the actor is anonymously runnable.
+            categories (list of str, optional): The categories to which the actor belongs to.
+            default_run_build (str, optional): Tag or number of the build that you want to run by default.
+            default_run_memory_mbytes (int, optional): Default amount of memory allocated for the runs of this actor, in megabytes.
+            default_run_timeout_secs (int, optional): Default timeout for the runs of this actor in seconds.
+            example_run_input_body (Any, optional): Input to be prefilled as default input to new users of this actor.
+            example_run_input_content_type (str, optional): The content type of the example run input.
+
+        Returns:
+            dict: The updated actor
+        """
         actor_representation = _get_actor_representation(
             name=name,
             title=title,
@@ -403,11 +432,13 @@ class ActorClientAsync(ResourceClientAsync):
 
         return await self._update(_filter_out_none_values_recursively(actor_representation))
 
-    @_make_async_docs(src=ActorClient.delete)
     async def delete(self) -> None:
+        """Delete the actor.
+
+        https://docs.apify.com/api/v2#/reference/actors/actor-object/delete-actor
+        """
         return await self._delete()
 
-    @_make_async_docs(src=ActorClient.start)
     async def start(
         self,
         *,
@@ -419,6 +450,33 @@ class ActorClientAsync(ResourceClientAsync):
         wait_for_finish: Optional[int] = None,
         webhooks: Optional[List[Dict]] = None,
     ) -> Dict:
+        """Start the actor and immediately return the Run object.
+
+        https://docs.apify.com/api/v2#/reference/actors/run-collection/run-actor
+
+        Args:
+            run_input (Any, optional): The input to pass to the actor run.
+            content_type (str, optional): The content type of the input.
+            build (str, optional): Specifies the actor build to run. It can be either a build tag or build number.
+                                   By default, the run uses the build specified in the default run configuration for the actor (typically latest).
+            memory_mbytes (int, optional): Memory limit for the run, in megabytes.
+                                           By default, the run uses a memory limit specified in the default run configuration for the actor.
+            timeout_secs (int, optional): Optional timeout for the run, in seconds.
+                                          By default, the run uses timeout specified in the default run configuration for the actor.
+            wait_for_finish (int, optional): The maximum number of seconds the server waits for the run to finish.
+                                               By default, it is 0, the maximum value is 300.
+            webhooks (list of dict, optional): Optional ad-hoc webhooks (https://docs.apify.com/webhooks/ad-hoc-webhooks)
+                                               associated with the actor run which can be used to receive a notification,
+                                               e.g. when the actor finished or failed.
+                                               If you already have a webhook set up for the actor or task, you do not have to add it again here.
+                                               Each webhook is represented by a dictionary containing these items:
+                                               * ``event_types``: list of ``WebhookEventType`` values which trigger the webhook
+                                               * ``request_url``: URL to which to send the webhook HTTP request
+                                               * ``payload_template`` (optional): Optional template for the request payload
+
+        Returns:
+            dict: The run object
+        """
         run_input, content_type = _encode_key_value_store_record_value(run_input, content_type)
 
         request_params = self._params(
@@ -439,7 +497,6 @@ class ActorClientAsync(ResourceClientAsync):
 
         return _parse_date_fields(_pluck_data(response.json()))
 
-    @_make_async_docs(src=ActorClient.call)
     async def call(
         self,
         *,
@@ -451,6 +508,29 @@ class ActorClientAsync(ResourceClientAsync):
         webhooks: Optional[List[Dict]] = None,
         wait_secs: Optional[int] = None,
     ) -> Optional[Dict]:
+        """Start the actor and wait for it to finish before returning the Run object.
+
+        It waits indefinitely, unless the wait_secs argument is provided.
+
+        https://docs.apify.com/api/v2#/reference/actors/run-collection/run-actor
+
+        Args:
+            run_input (Any, optional): The input to pass to the actor run.
+            content_type (str, optional): The content type of the input.
+            build (str, optional): Specifies the actor build to run. It can be either a build tag or build number.
+                                   By default, the run uses the build specified in the default run configuration for the actor (typically latest).
+            memory_mbytes (int, optional): Memory limit for the run, in megabytes.
+                                           By default, the run uses a memory limit specified in the default run configuration for the actor.
+            timeout_secs (int, optional): Optional timeout for the run, in seconds.
+                                          By default, the run uses timeout specified in the default run configuration for the actor.
+            webhooks (list, optional): Optional webhooks (https://docs.apify.com/webhooks) associated with the actor run,
+                                       which can be used to receive a notification, e.g. when the actor finished or failed.
+                                       If you already have a webhook set up for the actor, you do not have to add it again here.
+            wait_secs (int, optional): The maximum number of seconds the server waits for the run to finish. If not provided, waits indefinitely.
+
+        Returns:
+            dict: The run object
+        """
         started_run = await self.start(
             run_input=run_input,
             content_type=content_type,
@@ -462,7 +542,6 @@ class ActorClientAsync(ResourceClientAsync):
 
         return await self.root_client.run(started_run['id']).wait_for_finish(wait_secs=wait_secs)
 
-    @_make_async_docs(src=ActorClient.build)
     async def build(
         self,
         *,
@@ -472,6 +551,25 @@ class ActorClientAsync(ResourceClientAsync):
         use_cache: Optional[bool] = None,
         wait_for_finish: Optional[int] = None,
     ) -> Dict:
+        """Build the actor.
+
+        https://docs.apify.com/api/v2#/reference/actors/build-collection/build-actor
+
+        Args:
+            version_number (str): Actor version number to be built.
+            beta_packages (bool, optional): If True, then the actor is built with beta versions of Apify NPM packages.
+                                            By default, the build uses latest stable packages.
+            tag (str, optional): Tag to be applied to the build on success. By default, the tag is taken from the actor version's buildTag property.
+            use_cache (bool, optional): If true, the actor's Docker container will be rebuilt using layer cache
+                                        (https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#leverage-build-cache).
+                                        This is to enable quick rebuild during development.
+                                        By default, the cache is not used.
+            wait_for_finish (int, optional): The maximum number of seconds the server waits for the build to finish before returning.
+                                             By default it is 0, the maximum value is 300.
+
+        Returns:
+            dict: The build object
+        """
         request_params = self._params(
             version=version_number,
             betaPackages=beta_packages,
@@ -488,16 +586,26 @@ class ActorClientAsync(ResourceClientAsync):
 
         return _parse_date_fields(_pluck_data(response.json()))
 
-    @_make_async_docs(src=ActorClient.builds)
     def builds(self) -> BuildCollectionClientAsync:
+        """Retrieve a client for the builds of this actor."""
         return BuildCollectionClientAsync(**self._sub_resource_init_options(resource_path='builds'))
 
-    @_make_async_docs(src=ActorClient.runs)
     def runs(self) -> RunCollectionClientAsync:
+        """Retrieve a client for the runs of this actor."""
         return RunCollectionClientAsync(**self._sub_resource_init_options(resource_path='runs'))
 
-    @_make_async_docs(src=ActorClient.last_run)
     def last_run(self, *, status: Optional[ActorJobStatus] = None, origin: Optional[MetaOrigin] = None) -> RunClientAsync:
+        """Retrieve the client for the last run of this actor.
+
+        Last run is retrieved based on the start time of the runs.
+
+        Args:
+            status (ActorJobStatus, optional): Consider only runs with this status.
+            origin (MetaOrigin, optional): Consider only runs started with this origin.
+
+        Returns:
+            RunClientAsync: The resource client for the last run of this actor.
+        """
         return RunClientAsync(**self._sub_resource_init_options(
             resource_id='last',
             resource_path='runs',
@@ -507,14 +615,21 @@ class ActorClientAsync(ResourceClientAsync):
             ),
         ))
 
-    @_make_async_docs(src=ActorClient.versions)
     def versions(self) -> ActorVersionCollectionClientAsync:
+        """Retrieve a client for the versions of this actor."""
         return ActorVersionCollectionClientAsync(**self._sub_resource_init_options())
 
-    @_make_async_docs(src=ActorClient.version)
     def version(self, version_number: str) -> ActorVersionClientAsync:
+        """Retrieve the client for the specified version of this actor.
+
+        Args:
+            version_number (str): The version number for which to retrieve the resource client.
+
+        Returns:
+            ActorVersionClientAsync: The resource client for the specified actor version.
+        """
         return ActorVersionClientAsync(**self._sub_resource_init_options(resource_id=version_number))
 
-    @_make_async_docs(src=ActorClient.webhooks)
     def webhooks(self) -> WebhookCollectionClientAsync:
+        """Retrieve a client for webhooks associated with this actor."""
         return WebhookCollectionClientAsync(**self._sub_resource_init_options())

--- a/src/apify_client/clients/resource_clients/actor_collection.py
+++ b/src/apify_client/clients/resource_clients/actor_collection.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from ..._utils import ListPage, _filter_out_none_values_recursively, _make_async_docs
+from ..._utils import ListPage, _filter_out_none_values_recursively
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 from .actor import _get_actor_representation
 
@@ -111,7 +111,6 @@ class ActorCollectionClientAsync(ResourceCollectionClientAsync):
         resource_path = kwargs.pop('resource_path', 'acts')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=ActorCollectionClient.list)
     async def list(
         self,
         *,
@@ -120,9 +119,21 @@ class ActorCollectionClientAsync(ResourceCollectionClientAsync):
         offset: Optional[int] = None,
         desc: Optional[bool] = None,
     ) -> ListPage[Dict]:
+        """List the actors the user has created or used.
+
+        https://docs.apify.com/api/v2#/reference/actors/actor-collection/get-list-of-actors
+
+        Args:
+            my (bool, optional): If True, will return only actors which the user has created themselves.
+            limit (int, optional): How many actors to list
+            offset (int, optional): What actor to include as first when retrieving the list
+            desc (bool, optional): Whether to sort the actors in descending order based on their creation date
+
+        Returns:
+            ListPage: The list of available actors matching the specified filters.
+        """
         return await self._list(my=my, limit=limit, offset=offset, desc=desc)
 
-    @_make_async_docs(src=ActorCollectionClient.create)
     async def create(
         self,
         *,
@@ -143,6 +154,31 @@ class ActorCollectionClientAsync(ResourceCollectionClientAsync):
         example_run_input_body: Optional[Any] = None,
         example_run_input_content_type: Optional[str] = None,
     ) -> Dict:
+        """Create a new actor.
+
+        https://docs.apify.com/api/v2#/reference/actors/actor-collection/create-actor
+
+        Args:
+            name (str): The name of the actor
+            title (str, optional): The title of the actor (human-readable)
+            description (str, optional): The description for the actor
+            seo_title (str, optional): The title of the actor optimized for search engines
+            seo_description (str, optional): The description of the actor optimized for search engines
+            versions (list of dict, optional): The list of actor versions
+            restart_on_error (bool, optional): If true, the main actor run process will be restarted whenever it exits with a non-zero status code.
+            is_public (bool, optional): Whether the actor is public.
+            is_deprecated (bool, optional): Whether the actor is deprecated.
+            is_anonymously_runnable (bool, optional): Whether the actor is anonymously runnable.
+            categories (list of str, optional): The categories to which the actor belongs to.
+            default_run_build (str, optional): Tag or number of the build that you want to run by default.
+            default_run_memory_mbytes (int, optional): Default amount of memory allocated for the runs of this actor, in megabytes.
+            default_run_timeout_secs (int, optional): Default timeout for the runs of this actor in seconds.
+            example_run_input_body (Any, optional): Input to be prefilled as default input to new users of this actor.
+            example_run_input_content_type (str, optional): The content type of the example run input.
+
+        Returns:
+            dict: The created actor.
+        """
         actor_representation = _get_actor_representation(
             name=name,
             title=title,

--- a/src/apify_client/clients/resource_clients/actor_env_var.py
+++ b/src/apify_client/clients/resource_clients/actor_env_var.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import _filter_out_none_values_recursively, _make_async_docs
+from ..._utils import _filter_out_none_values_recursively
 from ..base import ResourceClient, ResourceClientAsync
 
 
@@ -78,11 +78,16 @@ class ActorEnvVarClientAsync(ResourceClientAsync):
         resource_path = kwargs.pop('resource_path', 'env-vars')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=ActorEnvVarClient.get)
     async def get(self) -> Optional[Dict]:
+        """Return information about the actor environment variable.
+
+        https://docs.apify.com/api/v2#/reference/actors/environment-variable-object/get-environment-variable
+
+        Returns:
+            dict, optional: The retrieved actor environment variable data
+        """
         return await self._get()
 
-    @_make_async_docs(src=ActorEnvVarClient.update)
     async def update(
         self,
         *,
@@ -90,6 +95,18 @@ class ActorEnvVarClientAsync(ResourceClientAsync):
         name: str,
         value: str,
     ) -> Dict:
+        """Update the actor environment variable with specified fields.
+
+        https://docs.apify.com/api/v2#/reference/actors/environment-variable-object/update-environment-variable
+
+        Args:
+            is_secret (bool, optional): Whether the environment variable is secret or not
+            name (str): The name of the environment variable
+            value (str): The value of the environment variable
+
+        Returns:
+            dict: The updated actor environment variable
+        """
         actor_env_var_representation = _get_actor_env_var_representation(
             is_secret=is_secret,
             name=name,
@@ -98,6 +115,9 @@ class ActorEnvVarClientAsync(ResourceClientAsync):
 
         return await self._update(_filter_out_none_values_recursively(actor_env_var_representation))
 
-    @_make_async_docs(src=ActorEnvVarClient.delete)
     async def delete(self) -> None:
+        """Delete the actor environment variable.
+
+        https://docs.apify.com/api/v2#/reference/actors/environment-variable-object/delete-environment-variable
+        """
         return await self._delete()

--- a/src/apify_client/clients/resource_clients/actor_env_var_collection.py
+++ b/src/apify_client/clients/resource_clients/actor_env_var_collection.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import ListPage, _filter_out_none_values_recursively, _make_async_docs
+from ..._utils import ListPage, _filter_out_none_values_recursively
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 from .actor_env_var import _get_actor_env_var_representation
 
@@ -59,11 +59,16 @@ class ActorEnvVarCollectionClientAsync(ResourceCollectionClientAsync):
         resource_path = kwargs.pop('resource_path', 'env-vars')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=ActorEnvVarCollectionClient.list)
     async def list(self) -> ListPage[Dict]:
+        """List the available actor environment variables.
+
+        https://docs.apify.com/api/v2#/reference/actors/environment-variable-collection/get-list-of-environment-variables
+
+        Returns:
+            ListPage: The list of available actor environment variables.
+        """
         return await self._list()
 
-    @_make_async_docs(src=ActorEnvVarCollectionClient.create)
     async def create(
         self,
         *,
@@ -71,6 +76,18 @@ class ActorEnvVarCollectionClientAsync(ResourceCollectionClientAsync):
         name: str,
         value: str,
     ) -> Dict:
+        """Create a new actor environment variable.
+
+        https://docs.apify.com/api/v2#/reference/actors/environment-variable-collection/create-environment-variable
+
+        Args:
+            is_secret (bool, optional): Whether the environment variable is secret or not
+            name (str): The name of the environment variable
+            value (str): The value of the environment variable
+
+        Returns:
+            dict: The created actor environment variable
+        """
         actor_env_var_representation = _get_actor_env_var_representation(
             is_secret=is_secret,
             name=name,

--- a/src/apify_client/clients/resource_clients/actor_version.py
+++ b/src/apify_client/clients/resource_clients/actor_version.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from ..._utils import _filter_out_none_values_recursively, _make_async_docs, _maybe_extract_enum_member_value
+from ..._utils import _filter_out_none_values_recursively, _maybe_extract_enum_member_value
 from ...consts import ActorSourceType
 from ..base import ResourceClient, ResourceClientAsync
 from .actor_env_var import ActorEnvVarClient, ActorEnvVarClientAsync
@@ -129,11 +129,16 @@ class ActorVersionClientAsync(ResourceClientAsync):
         resource_path = kwargs.pop('resource_path', 'versions')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=ActorVersionClient.get)
     async def get(self) -> Optional[Dict]:
+        """Return information about the actor version.
+
+        https://docs.apify.com/api/v2#/reference/actors/version-object/get-version
+
+        Returns:
+            dict, optional: The retrieved actor version data
+        """
         return await self._get()
 
-    @_make_async_docs(src=ActorVersionClient.update)
     async def update(
         self,
         *,
@@ -146,6 +151,29 @@ class ActorVersionClientAsync(ResourceClientAsync):
         tarball_url: Optional[str] = None,
         github_gist_url: Optional[str] = None,
     ) -> Dict:
+        """Update the actor version with specified fields.
+
+        https://docs.apify.com/api/v2#/reference/actors/version-object/update-version
+
+        Args:
+            build_tag (str, optional): Tag that is automatically set to the latest successful build of the current version.
+            env_vars (list of dict, optional): Environment variables that will be available to the actor run process,
+                and optionally also to the build process. See the API docs for their exact structure.
+            apply_env_vars_to_build (bool, optional): Whether the environment variables specified for the actor run
+                will also be set to the actor build process.
+            source_type (ActorSourceType, optional): What source type is the actor version using.
+            source_files (list of dict, optional): Source code comprised of multiple files, each an item of the array.
+                Required when ``source_type`` is ``ActorSourceType.SOURCE_FILES``. See the API docs for the exact structure.
+            git_repo_url (str, optional): The URL of a Git repository from which the source code will be cloned.
+                Required when ``source_type`` is ``ActorSourceType.GIT_REPO``.
+            tarball_url (str, optional): The URL of a tarball or a zip archive from which the source code will be downloaded.
+                Required when ``source_type`` is ``ActorSourceType.TARBALL``.
+            github_gist_url (str, optional): The URL of a GitHub Gist from which the source will be downloaded.
+                Required when ``source_type`` is ``ActorSourceType.GITHUB_GIST``.
+
+        Returns:
+            dict: The updated actor version
+        """
         actor_version_representation = _get_actor_version_representation(
             build_tag=build_tag,
             env_vars=env_vars,
@@ -159,14 +187,24 @@ class ActorVersionClientAsync(ResourceClientAsync):
 
         return await self._update(_filter_out_none_values_recursively(actor_version_representation))
 
-    @_make_async_docs(src=ActorVersionClient.delete)
     async def delete(self) -> None:
+        """Delete the actor version.
+
+        https://docs.apify.com/api/v2#/reference/actors/version-object/delete-version
+        """
         return await self._delete()
 
-    @_make_async_docs(src=ActorVersionClient.env_vars)
     def env_vars(self) -> ActorEnvVarCollectionClientAsync:
+        """Retrieve a client for the environment variables of this actor version."""
         return ActorEnvVarCollectionClientAsync(**self._sub_resource_init_options())
 
-    @_make_async_docs(src=ActorVersionClient.env_var)
     def env_var(self, env_var_name: str) -> ActorEnvVarClientAsync:
+        """Retrieve the client for the specified environment variable of this actor version.
+
+        Args:
+            env_var_name (str): The name of the environment variable for which to retrieve the resource client.
+
+        Returns:
+            ActorEnvVarClientAsync: The resource client for the specified actor environment variable.
+        """
         return ActorEnvVarClientAsync(**self._sub_resource_init_options(resource_id=env_var_name))

--- a/src/apify_client/clients/resource_clients/actor_version_collection.py
+++ b/src/apify_client/clients/resource_clients/actor_version_collection.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from ..._utils import ListPage, _filter_out_none_values_recursively, _make_async_docs
+from ..._utils import ListPage, _filter_out_none_values_recursively
 from ...consts import ActorSourceType
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 from .actor_version import _get_actor_version_representation
@@ -84,11 +84,16 @@ class ActorVersionCollectionClientAsync(ResourceCollectionClientAsync):
         resource_path = kwargs.pop('resource_path', 'versions')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=ActorVersionCollectionClient.list)
     async def list(self) -> ListPage[Dict]:
+        """List the available actor versions.
+
+        https://docs.apify.com/api/v2#/reference/actors/version-collection/get-list-of-versions
+
+        Returns:
+            ListPage: The list of available actor versions.
+        """
         return await self._list()
 
-    @_make_async_docs(src=ActorVersionCollectionClient.create)
     async def create(
         self,
         *,
@@ -102,6 +107,30 @@ class ActorVersionCollectionClientAsync(ResourceCollectionClientAsync):
         tarball_url: Optional[str] = None,
         github_gist_url: Optional[str] = None,
     ) -> Dict:
+        """Create a new actor version.
+
+        https://docs.apify.com/api/v2#/reference/actors/version-collection/create-version
+
+        Args:
+            version_number (str): Major and minor version of the actor (e.g. ``1.0``)
+            build_tag (str, optional): Tag that is automatically set to the latest successful build of the current version.
+            env_vars (list of dict, optional): Environment variables that will be available to the actor run process,
+                and optionally also to the build process. See the API docs for their exact structure.
+            apply_env_vars_to_build (bool, optional): Whether the environment variables specified for the actor run
+                will also be set to the actor build process.
+            source_type (ActorSourceType): What source type is the actor version using.
+            source_files (list of dict, optional): Source code comprised of multiple files, each an item of the array.
+                Required when ``source_type`` is ``ActorSourceType.SOURCE_FILES``. See the API docs for the exact structure.
+            git_repo_url (str, optional): The URL of a Git repository from which the source code will be cloned.
+                Required when ``source_type`` is ``ActorSourceType.GIT_REPO``.
+            tarball_url (str, optional): The URL of a tarball or a zip archive from which the source code will be downloaded.
+                Required when ``source_type`` is ``ActorSourceType.TARBALL``.
+            github_gist_url (str, optional): The URL of a GitHub Gist from which the source will be downloaded.
+                Required when ``source_type`` is ``ActorSourceType.GITHUB_GIST``.
+
+        Returns:
+            dict: The created actor version
+        """
         actor_version_representation = _get_actor_version_representation(
             version_number=version_number,
             build_tag=build_tag,

--- a/src/apify_client/clients/resource_clients/build.py
+++ b/src/apify_client/clients/resource_clients/build.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import _make_async_docs
 from ..base import ActorJobBaseClient, ActorJobBaseClientAsync
 
 
@@ -53,14 +52,34 @@ class BuildClientAsync(ActorJobBaseClientAsync):
         resource_path = kwargs.pop('resource_path', 'actor-builds')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=BuildClient.get)
     async def get(self) -> Optional[Dict]:
+        """Return information about the actor build.
+
+        https://docs.apify.com/api/v2#/reference/actor-builds/build-object/get-build
+
+        Returns:
+            dict, optional: The retrieved actor build data
+        """
         return await self._get()
 
-    @_make_async_docs(src=BuildClient.abort)
     async def abort(self) -> Dict:
+        """Abort the actor build which is starting or currently running and return its details.
+
+        https://docs.apify.com/api/v2#/reference/actor-builds/abort-build/abort-build
+
+        Returns:
+            dict: The data of the aborted actor build
+        """
         return await self._abort()
 
-    @_make_async_docs(src=BuildClient.wait_for_finish)
     async def wait_for_finish(self, *, wait_secs: Optional[int] = None) -> Optional[Dict]:
+        """Wait synchronously until the build finishes or the server times out.
+
+        Args:
+            wait_secs (int, optional): how long does the client wait for build to finish. None for indefinite.
+
+        Returns:
+            dict, optional: The actor build data. If the status on the object is not one of the terminal statuses
+                (SUCEEDED, FAILED, TIMED_OUT, ABORTED), then the build has not yet finished.
+        """
         return await self._wait_for_finish(wait_secs=wait_secs)

--- a/src/apify_client/clients/resource_clients/build_collection.py
+++ b/src/apify_client/clients/resource_clients/build_collection.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import ListPage, _make_async_docs
+from ..._utils import ListPage
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 
 
@@ -43,7 +43,6 @@ class BuildCollectionClientAsync(ResourceCollectionClientAsync):
         resource_path = kwargs.pop('resource_path', 'actor-builds')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=BuildCollectionClient.list)
     async def list(
         self,
         *,
@@ -51,4 +50,17 @@ class BuildCollectionClientAsync(ResourceCollectionClientAsync):
         offset: Optional[int] = None,
         desc: Optional[bool] = None,
     ) -> ListPage[Dict]:
+        """List all actor builds (either of a single actor, or all user's actors, depending on where this client was initialized from).
+
+        https://docs.apify.com/api/v2#/reference/actors/build-collection/get-list-of-builds
+        https://docs.apify.com/api/v2#/reference/actor-builds/build-collection/get-user-builds-list
+
+        Args:
+            limit (int, optional): How many builds to retrieve
+            offset (int, optional): What build to include as first when retrieving the list
+            desc (bool, optional): Whether to sort the builds in descending order based on their start date
+
+        Returns:
+            ListPage: The retrieved actor builds
+        """
         return await self._list(limit=limit, offset=offset, desc=desc)

--- a/src/apify_client/clients/resource_clients/dataset.py
+++ b/src/apify_client/clients/resource_clients/dataset.py
@@ -5,7 +5,7 @@ from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
 import httpx
 
 from ..._types import JSONSerializable
-from ..._utils import ListPage, _filter_out_none_values_recursively, _make_async_docs
+from ..._utils import ListPage, _filter_out_none_values_recursively
 from ..base import ResourceClient, ResourceClientAsync
 
 
@@ -508,23 +508,40 @@ class DatasetClientAsync(ResourceClientAsync):
         resource_path = kwargs.pop('resource_path', 'datasets')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=DatasetClient.get)
     async def get(self) -> Optional[Dict]:
+        """Retrieve the dataset.
+
+        https://docs.apify.com/api/v2#/reference/datasets/dataset/get-dataset
+
+        Returns:
+            dict, optional: The retrieved dataset, or None, if it does not exist
+        """
         return await self._get()
 
-    @_make_async_docs(src=DatasetClient.update)
     async def update(self, *, name: Optional[str] = None) -> Dict:
+        """Update the dataset with specified fields.
+
+        https://docs.apify.com/api/v2#/reference/datasets/dataset/update-dataset
+
+        Args:
+            name (str, optional): The new name for the dataset
+
+        Returns:
+            dict: The updated dataset
+        """
         updated_fields = {
             'name': name,
         }
 
         return await self._update(_filter_out_none_values_recursively(updated_fields))
 
-    @_make_async_docs(src=DatasetClient.delete)
     async def delete(self) -> None:
+        """Delete the dataset.
+
+        https://docs.apify.com/api/v2#/reference/datasets/dataset/delete-dataset
+        """
         return await self._delete()
 
-    @_make_async_docs(src=DatasetClient.list_items)
     async def list_items(
         self,
         *,
@@ -540,6 +557,37 @@ class DatasetClientAsync(ResourceClientAsync):
         flatten: Optional[List[str]] = None,
         view: Optional[str] = None,
     ) -> ListPage:
+        """List the items of the dataset.
+
+        https://docs.apify.com/api/v2#/reference/datasets/item-collection/get-items
+
+        Args:
+            offset (int, optional): Number of items that should be skipped at the start. The default value is 0
+            limit (int, optional): Maximum number of items to return. By default there is no limit.
+            desc (bool, optional): By default, results are returned in the same order as they were stored.
+                To reverse the order, set this parameter to True.
+            clean (bool, optional): If True, returns only non-empty items and skips hidden fields (i.e. fields starting with the # character).
+                The clean parameter is just a shortcut for skip_hidden=True and skip_empty=True parameters.
+                Note that since some objects might be skipped from the output, that the result might contain less items than the limit value.
+            fields (list of str, optional): A list of fields which should be picked from the items,
+                only these fields will remain in the resulting record objects.
+                Note that the fields in the outputted items are sorted the same way as they are specified in the fields parameter.
+                You can use this feature to effectively fix the output format.
+            omit (list of str, optional): A list of fields which should be omitted from the items.
+            unwind (str, optional): Name of a field which should be unwound.
+                If the field is an array then every element of the array will become a separate record and merged with parent object.
+                If the unwound field is an object then it is merged with the parent object.
+                If the unwound field is missing or its value is neither an array nor an object and therefore cannot be merged with a parent object,
+                then the item gets preserved as it is. Note that the unwound items ignore the desc parameter.
+            skip_empty (bool, optional): If True, then empty items are skipped from the output.
+                Note that if used, the results might contain less items than the limit value.
+            skip_hidden (bool, optional): If True, then hidden fields are skipped from the output, i.e. fields starting with the # character.
+            flatten (list of str, optional): A list of fields that should be flattened
+            view (str, optional): Name of the dataset view to be used
+
+        Returns:
+            ListPage: A page of the list of dataset items according to the specified filters.
+        """
         request_params = self._params(
             offset=offset,
             limit=limit,
@@ -571,7 +619,6 @@ class DatasetClientAsync(ResourceClientAsync):
             'desc': bool(response.headers['x-apify-pagination-desc']),
         })
 
-    @_make_async_docs(src=DatasetClient.iterate_items)
     async def iterate_items(
         self,
         *,
@@ -585,6 +632,35 @@ class DatasetClientAsync(ResourceClientAsync):
         skip_empty: Optional[bool] = None,
         skip_hidden: Optional[bool] = None,
     ) -> AsyncIterator[Dict]:
+        """Iterate over the items in the dataset.
+
+        https://docs.apify.com/api/v2#/reference/datasets/item-collection/get-items
+
+        Args:
+            offset (int, optional): Number of items that should be skipped at the start. The default value is 0
+            limit (int, optional): Maximum number of items to return. By default there is no limit.
+            desc (bool, optional): By default, results are returned in the same order as they were stored.
+                To reverse the order, set this parameter to True.
+            clean (bool, optional): If True, returns only non-empty items and skips hidden fields (i.e. fields starting with the # character).
+                The clean parameter is just a shortcut for skip_hidden=True and skip_empty=True parameters.
+                Note that since some objects might be skipped from the output, that the result might contain less items than the limit value.
+            fields (list of str, optional): A list of fields which should be picked from the items,
+                only these fields will remain in the resulting record objects.
+                Note that the fields in the outputted items are sorted the same way as they are specified in the fields parameter.
+                You can use this feature to effectively fix the output format.
+            omit (list of str, optional): A list of fields which should be omitted from the items.
+            unwind (str, optional): Name of a field which should be unwound.
+                If the field is an array then every element of the array will become a separate record and merged with parent object.
+                If the unwound field is an object then it is merged with the parent object.
+                If the unwound field is missing or its value is neither an array nor an object and therefore cannot be merged with a parent object,
+                then the item gets preserved as it is. Note that the unwound items ignore the desc parameter.
+            skip_empty (bool, optional): If True, then empty items are skipped from the output.
+                Note that if used, the results might contain less items than the limit value.
+            skip_hidden (bool, optional): If True, then hidden fields are skipped from the output, i.e. fields starting with the # character.
+
+        Yields:
+            dict: An item from the dataset
+        """
         cache_size = 1000
         first_item = offset
 
@@ -620,7 +696,6 @@ class DatasetClientAsync(ResourceClientAsync):
             for item in current_items_page.items:
                 yield item
 
-    @_make_async_docs(src=DatasetClient.get_items_as_bytes)
     async def get_items_as_bytes(
         self,
         *,
@@ -641,6 +716,46 @@ class DatasetClientAsync(ResourceClientAsync):
         xml_row: Optional[str] = None,
         flatten: Optional[List[str]] = None,
     ) -> bytes:
+        """Get the items in the dataset as raw bytes.
+
+        https://docs.apify.com/api/v2#/reference/datasets/item-collection/get-items
+
+        Args:
+            item_format (str): Format of the results, possible values are: json, jsonl, csv, html, xlsx, xml and rss. The default value is json.
+            offset (int, optional): Number of items that should be skipped at the start. The default value is 0
+            limit (int, optional): Maximum number of items to return. By default there is no limit.
+            desc (bool, optional): By default, results are returned in the same order as they were stored.
+                To reverse the order, set this parameter to True.
+            clean (bool, optional): If True, returns only non-empty items and skips hidden fields (i.e. fields starting with the # character).
+                The clean parameter is just a shortcut for skip_hidden=True and skip_empty=True parameters.
+                Note that since some objects might be skipped from the output, that the result might contain less items than the limit value.
+            bom (bool, optional): All text responses are encoded in UTF-8 encoding.
+                By default, csv files are prefixed with the UTF-8 Byte Order Mark (BOM),
+                while json, jsonl, xml, html and rss files are not. If you want to override this default behavior,
+                specify bom=True query parameter to include the BOM or bom=False to skip it.
+            delimiter (str, optional): A delimiter character for CSV files. The default delimiter is a simple comma (,).
+            fields (list of str, optional): A list of fields which should be picked from the items,
+                only these fields will remain in the resulting record objects.
+                Note that the fields in the outputted items are sorted the same way as they are specified in the fields parameter.
+                You can use this feature to effectively fix the output format.
+            omit (list of str, optional): A list of fields which should be omitted from the items.
+            unwind (str, optional): Name of a field which should be unwound.
+                If the field is an array then every element of the array will become a separate record and merged with parent object.
+                If the unwound field is an object then it is merged with the parent object.
+                If the unwound field is missing or its value is neither an array nor an object and therefore cannot be merged with a parent object,
+                then the item gets preserved as it is. Note that the unwound items ignore the desc parameter.
+            skip_empty (bool, optional): If True, then empty items are skipped from the output.
+                Note that if used, the results might contain less items than the limit value.
+            skip_header_row (bool, optional): If True, then header row in the csv format is skipped.
+            skip_hidden (bool, optional): If True, then hidden fields are skipped from the output, i.e. fields starting with the # character.
+            xml_root (str, optional): Overrides default root element name of xml output. By default the root element is items.
+            xml_row (str, optional): Overrides default element name that wraps each page or page function result object in xml output.
+                By default the element name is item.
+            flatten (list of str, optional): A list of fields that should be flattened
+
+        Returns:
+            bytes: The dataset items as raw bytes
+        """
         request_params = self._params(
             format=item_format,
             offset=offset,
@@ -670,7 +785,6 @@ class DatasetClientAsync(ResourceClientAsync):
         return response.content
 
     @asynccontextmanager
-    @_make_async_docs(src=DatasetClient.stream_items)
     async def stream_items(
         self,
         *,
@@ -690,6 +804,45 @@ class DatasetClientAsync(ResourceClientAsync):
         xml_root: Optional[str] = None,
         xml_row: Optional[str] = None,
     ) -> AsyncIterator[httpx.Response]:
+        """Retrieve the items in the dataset as a stream.
+
+        https://docs.apify.com/api/v2#/reference/datasets/item-collection/get-items
+
+        Args:
+            item_format (str): Format of the results, possible values are: json, jsonl, csv, html, xlsx, xml and rss. The default value is json.
+            offset (int, optional): Number of items that should be skipped at the start. The default value is 0
+            limit (int, optional): Maximum number of items to return. By default there is no limit.
+            desc (bool, optional): By default, results are returned in the same order as they were stored.
+                To reverse the order, set this parameter to True.
+            clean (bool, optional): If True, returns only non-empty items and skips hidden fields (i.e. fields starting with the # character).
+                The clean parameter is just a shortcut for skip_hidden=True and skip_empty=True parameters.
+                Note that since some objects might be skipped from the output, that the result might contain less items than the limit value.
+            bom (bool, optional): All text responses are encoded in UTF-8 encoding.
+                By default, csv files are prefixed with the UTF-8 Byte Order Mark (BOM),
+                while json, jsonl, xml, html and rss files are not. If you want to override this default behavior,
+                specify bom=True query parameter to include the BOM or bom=False to skip it.
+            delimiter (str, optional): A delimiter character for CSV files. The default delimiter is a simple comma (,).
+            fields (list of str, optional): A list of fields which should be picked from the items,
+                only these fields will remain in the resulting record objects.
+                Note that the fields in the outputted items are sorted the same way as they are specified in the fields parameter.
+                You can use this feature to effectively fix the output format.
+            omit (list of str, optional): A list of fields which should be omitted from the items.
+            unwind (str, optional): Name of a field which should be unwound.
+                If the field is an array then every element of the array will become a separate record and merged with parent object.
+                If the unwound field is an object then it is merged with the parent object.
+                If the unwound field is missing or its value is neither an array nor an object and therefore cannot be merged with a parent object,
+                then the item gets preserved as it is. Note that the unwound items ignore the desc parameter.
+            skip_empty (bool, optional): If True, then empty items are skipped from the output.
+                Note that if used, the results might contain less items than the limit value.
+            skip_header_row (bool, optional): If True, then header row in the csv format is skipped.
+            skip_hidden (bool, optional): If True, then hidden fields are skipped from the output, i.e. fields starting with the # character.
+            xml_root (str, optional): Overrides default root element name of xml output. By default the root element is items.
+            xml_row (str, optional): Overrides default element name that wraps each page or page function result object in xml output.
+                By default the element name is item.
+
+        Returns:
+            httpx.Response: The dataset items as a context-managed streaming Response
+        """
         response = None
         try:
             request_params = self._params(
@@ -722,8 +875,14 @@ class DatasetClientAsync(ResourceClientAsync):
             if response:
                 await response.aclose()
 
-    @_make_async_docs(src=DatasetClient.push_items)
     async def push_items(self, items: JSONSerializable) -> None:
+        """Push items to the dataset.
+
+        https://docs.apify.com/api/v2#/reference/datasets/item-collection/put-items
+
+        Args:
+            items: The items which to push in the dataset. Either a stringified JSON, a dictionary, or a list of strings or dictionaries.
+        """
         data = None
         json = None
 

--- a/src/apify_client/clients/resource_clients/dataset_collection.py
+++ b/src/apify_client/clients/resource_clients/dataset_collection.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import ListPage, _filter_out_none_values_recursively, _make_async_docs
+from ..._utils import ListPage, _filter_out_none_values_recursively
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 
 
@@ -58,7 +58,6 @@ class DatasetCollectionClientAsync(ResourceCollectionClientAsync):
         resource_path = kwargs.pop('resource_path', 'datasets')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=DatasetCollectionClient.list)
     async def list(
         self,
         *,
@@ -67,8 +66,31 @@ class DatasetCollectionClientAsync(ResourceCollectionClientAsync):
         offset: Optional[int] = None,
         desc: Optional[bool] = None,
     ) -> ListPage[Dict]:
+        """List the available datasets.
+
+        https://docs.apify.com/api/v2#/reference/datasets/dataset-collection/get-list-of-datasets
+
+        Args:
+            unnamed (bool, optional): Whether to include unnamed datasets in the list
+            limit (int, optional): How many datasets to retrieve
+            offset (int, optional): What dataset to include as first when retrieving the list
+            desc (bool, optional): Whether to sort the datasets in descending order based on their modification date
+
+        Returns:
+            ListPage: The list of available datasets matching the specified filters.
+        """
         return await self._list(unnamed=unnamed, limit=limit, offset=offset, desc=desc)
 
-    @_make_async_docs(src=DatasetCollectionClient.get_or_create)
     async def get_or_create(self, *, name: Optional[str] = None, schema: Optional[Dict] = None) -> Dict:
+        """Retrieve a named dataset, or create a new one when it doesn't exist.
+
+        https://docs.apify.com/api/v2#/reference/datasets/dataset-collection/create-dataset
+
+        Args:
+            name (str, optional): The name of the dataset to retrieve or create.
+            schema (Dict, optional): The schema of the dataset
+
+        Returns:
+            dict: The retrieved or newly-created dataset.
+        """
         return await self._get_or_create(name=name, resource=_filter_out_none_values_recursively({'schema': schema}))

--- a/src/apify_client/clients/resource_clients/key_value_store.py
+++ b/src/apify_client/clients/resource_clients/key_value_store.py
@@ -7,7 +7,6 @@ from ..._utils import (
     _catch_not_found_or_throw,
     _encode_key_value_store_record_value,
     _filter_out_none_values_recursively,
-    _make_async_docs,
     _parse_date_fields,
     _pluck_data,
 )
@@ -250,24 +249,52 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
         resource_path = kwargs.pop('resource_path', 'key-value-stores')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=KeyValueStoreClient.get)
     async def get(self) -> Optional[Dict]:
+        """Retrieve the key-value store.
+
+        https://docs.apify.com/api/v2#/reference/key-value-stores/store-object/get-store
+
+        Returns:
+            dict, optional: The retrieved key-value store, or None if it does not exist
+        """
         return await self._get()
 
-    @_make_async_docs(src=KeyValueStoreClient.update)
     async def update(self, *, name: Optional[str] = None) -> Dict:
+        """Update the key-value store with specified fields.
+
+        https://docs.apify.com/api/v2#/reference/key-value-stores/store-object/update-store
+
+        Args:
+            name (str, optional): The new name for key-value store
+
+        Returns:
+            dict: The updated key-value store
+        """
         updated_fields = {
             'name': name,
         }
 
         return await self._update(_filter_out_none_values_recursively(updated_fields))
 
-    @_make_async_docs(src=KeyValueStoreClient.delete)
     async def delete(self) -> None:
+        """Delete the key-value store.
+
+        https://docs.apify.com/api/v2#/reference/key-value-stores/store-object/delete-store
+        """
         return await self._delete()
 
-    @_make_async_docs(src=KeyValueStoreClient.list_keys)
     async def list_keys(self, *, limit: Optional[int] = None, exclusive_start_key: Optional[str] = None) -> Dict:
+        """List the keys in the key-value store.
+
+        https://docs.apify.com/api/v2#/reference/key-value-stores/key-collection/get-list-of-keys
+
+        Args:
+            limit (int, optional): Number of keys to be returned. Maximum value is 1000
+            exclusive_start_key (str, optional): All keys up to this one (including) are skipped from the result
+
+        Returns:
+            dict: The list of keys in the key-value store matching the given arguments
+        """
         request_params = self._params(
             limit=limit,
             exclusiveStartKey=exclusive_start_key,
@@ -281,8 +308,19 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
 
         return _parse_date_fields(_pluck_data(response.json()))
 
-    @_make_async_docs(src=KeyValueStoreClient.get_record)
     async def get_record(self, key: str) -> Optional[Dict]:
+        """Retrieve the given record from the key-value store.
+
+        https://docs.apify.com/api/v2#/reference/key-value-stores/record/get-record
+
+        Args:
+            key (str): Key of the record to retrieve
+            as_bytes (bool, optional): Deprecated, use `get_record_as_bytes()` instead. Whether to retrieve the record as raw bytes, default False
+            as_file (bool, optional): Deprecated, use `stream_record()` instead. Whether to retrieve the record as a file-like object, default False
+
+        Returns:
+            dict, optional: The requested record, or None, if the record does not exist
+        """
         try:
             response = await self.http_client.call(
                 url=self._url(f'records/{key}'),
@@ -301,8 +339,17 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
 
         return None
 
-    @_make_async_docs(src=KeyValueStoreClient.get_record_as_bytes)
     async def get_record_as_bytes(self, key: str) -> Optional[Dict]:
+        """Retrieve the given record from the key-value store, without parsing it.
+
+        https://docs.apify.com/api/v2#/reference/key-value-stores/record/get-record
+
+        Args:
+            key (str): Key of the record to retrieve
+
+        Returns:
+            dict, optional: The requested record, or None, if the record does not exist
+        """
         try:
             response = await self.http_client.call(
                 url=self._url(f'records/{key}'),
@@ -323,8 +370,17 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
         return None
 
     @asynccontextmanager
-    @_make_async_docs(src=KeyValueStoreClient.stream_record)
     async def stream_record(self, key: str) -> AsyncIterator[Optional[Dict]]:
+        """Retrieve the given record from the key-value store, as a stream.
+
+        https://docs.apify.com/api/v2#/reference/key-value-stores/record/get-record
+
+        Args:
+            key (str): Key of the record to retrieve
+
+        Returns:
+            dict, optional: The requested record as a context-managed streaming Response, or None, if the record does not exist
+        """
         response = None
         try:
             response = await self.http_client.call(
@@ -348,8 +404,16 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
             if response:
                 await response.aclose()
 
-    @_make_async_docs(src=KeyValueStoreClient.set_record)
     async def set_record(self, key: str, value: Any, content_type: Optional[str] = None) -> None:
+        """Set a value to the given record in the key-value store.
+
+        https://docs.apify.com/api/v2#/reference/key-value-stores/record/put-record
+
+        Args:
+            key (str): The key of the record to save the value to
+            value (Any): The value to save into the record
+            content_type (str, optional): The content type of the saved value
+        """
         value, content_type = _encode_key_value_store_record_value(value, content_type)
 
         headers = {'content-type': content_type}
@@ -362,8 +426,14 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
             headers=headers,
         )
 
-    @_make_async_docs(src=KeyValueStoreClient.delete_record)
     async def delete_record(self, key: str) -> None:
+        """Delete the specified record from the key-value store.
+
+        https://docs.apify.com/api/v2#/reference/key-value-stores/record/delete-record
+
+        Args:
+            key (str): The key of the record which to delete
+        """
         await self.http_client.call(
             url=self._url(f'records/{key}'),
             method='DELETE',

--- a/src/apify_client/clients/resource_clients/key_value_store_collection.py
+++ b/src/apify_client/clients/resource_clients/key_value_store_collection.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import ListPage, _filter_out_none_values_recursively, _make_async_docs
+from ..._utils import ListPage, _filter_out_none_values_recursively
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 
 
@@ -58,7 +58,6 @@ class KeyValueStoreCollectionClientAsync(ResourceCollectionClientAsync):
         resource_path = kwargs.pop('resource_path', 'key-value-stores')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=KeyValueStoreCollectionClient.list)
     async def list(
         self,
         *,
@@ -67,8 +66,31 @@ class KeyValueStoreCollectionClientAsync(ResourceCollectionClientAsync):
         offset: Optional[int] = None,
         desc: Optional[bool] = None,
     ) -> ListPage[Dict]:
+        """List the available key-value stores.
+
+        https://docs.apify.com/api/v2#/reference/key-value-stores/store-collection/get-list-of-key-value-stores
+
+        Args:
+            unnamed (bool, optional): Whether to include unnamed key-value stores in the list
+            limit (int, optional): How many key-value stores to retrieve
+            offset (int, optional): What key-value store to include as first when retrieving the list
+            desc (bool, optional): Whether to sort the key-value stores in descending order based on their modification date
+
+        Returns:
+            ListPage: The list of available key-value stores matching the specified filters.
+        """
         return await self._list(unnamed=unnamed, limit=limit, offset=offset, desc=desc)
 
-    @_make_async_docs(src=KeyValueStoreCollectionClient.get_or_create)
     async def get_or_create(self, *, name: Optional[str] = None, schema: Optional[Dict] = None) -> Dict:
+        """Retrieve a named key-value store, or create a new one when it doesn't exist.
+
+        https://docs.apify.com/api/v2#/reference/key-value-stores/store-collection/create-key-value-store
+
+        Args:
+            name (str, optional): The name of the key-value store to retrieve or create.
+            schema (Dict, optional): The schema of the key-value store
+
+        Returns:
+            dict: The retrieved or newly-created key-value store.
+        """
         return await self._get_or_create(name=name, resource=_filter_out_none_values_recursively({'schema': schema}))

--- a/src/apify_client/clients/resource_clients/log.py
+++ b/src/apify_client/clients/resource_clients/log.py
@@ -4,7 +4,7 @@ from typing import Any, AsyncIterator, Iterator, Optional
 import httpx
 
 from ..._errors import ApifyApiError
-from ..._utils import _catch_not_found_or_throw, _make_async_docs
+from ..._utils import _catch_not_found_or_throw
 from ..base import ResourceClient, ResourceClientAsync
 
 
@@ -97,8 +97,14 @@ class LogClientAsync(ResourceClientAsync):
         resource_path = kwargs.pop('resource_path', 'logs')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=LogClient.get)
     async def get(self) -> Optional[str]:
+        """Retrieve the log as text.
+
+        https://docs.apify.com/api/v2#/reference/logs/log/get-log
+
+        Returns:
+            str, optional: The retrieved log, or None, if it does not exist.
+        """
         try:
             response = await self.http_client.call(
                 url=self.url,
@@ -113,8 +119,14 @@ class LogClientAsync(ResourceClientAsync):
 
         return None
 
-    @_make_async_docs(src=LogClient.get_as_bytes)
     async def get_as_bytes(self) -> Optional[bytes]:
+        """Retrieve the log as raw bytes.
+
+        https://docs.apify.com/api/v2#/reference/logs/log/get-log
+
+        Returns:
+            bytes, optional: The retrieved log as raw bytes, or None, if it does not exist.
+        """
         try:
             response = await self.http_client.call(
                 url=self.url,
@@ -131,8 +143,14 @@ class LogClientAsync(ResourceClientAsync):
         return None
 
     @asynccontextmanager
-    @_make_async_docs(src=LogClient.stream)
     async def stream(self) -> AsyncIterator[Optional[httpx.Response]]:
+        """Retrieve the log as a stream.
+
+        https://docs.apify.com/api/v2#/reference/logs/log/get-log
+
+        Returns:
+            httpx.Response, optional: The retrieved log as a context-managed streaming Response, or None, if it does not exist.
+        """
         response = None
         try:
             response = await self.http_client.call(

--- a/src/apify_client/clients/resource_clients/request_queue.py
+++ b/src/apify_client/clients/resource_clients/request_queue.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Optional
 
 from ..._errors import ApifyApiError
-from ..._utils import _catch_not_found_or_throw, _filter_out_none_values_recursively, _make_async_docs, _parse_date_fields, _pluck_data
+from ..._utils import _catch_not_found_or_throw, _filter_out_none_values_recursively, _parse_date_fields, _pluck_data
 from ..base import ResourceClient, ResourceClientAsync
 
 
@@ -183,24 +183,51 @@ class RequestQueueClientAsync(ResourceClientAsync):
         super().__init__(*args, resource_path=resource_path, **kwargs)
         self.client_key = client_key
 
-    @_make_async_docs(src=RequestQueueClient.get)
     async def get(self) -> Optional[Dict]:
+        """Retrieve the request queue.
+
+        https://docs.apify.com/api/v2#/reference/request-queues/queue/get-request-queue
+
+        Returns:
+            dict, optional: The retrieved request queue, or None, if it does not exist
+        """
         return await self._get()
 
-    @_make_async_docs(src=RequestQueueClient.update)
     async def update(self, *, name: Optional[str] = None) -> Dict:
+        """Update the request queue with specified fields.
+
+        https://docs.apify.com/api/v2#/reference/request-queues/queue/update-request-queue
+
+        Args:
+            name (str, optional): The new name for the request queue
+
+        Returns:
+            dict: The updated request queue
+        """
         updated_fields = {
             'name': name,
         }
 
         return await self._update(_filter_out_none_values_recursively(updated_fields))
 
-    @_make_async_docs(src=RequestQueueClient.delete)
     async def delete(self) -> None:
+        """Delete the request queue.
+
+        https://docs.apify.com/api/v2#/reference/request-queues/queue/delete-request-queue
+        """
         return await self._delete()
 
-    @_make_async_docs(src=RequestQueueClient.list_head)
     async def list_head(self, *, limit: Optional[int] = None) -> Dict:
+        """Retrieve a given number of requests from the beginning of the queue.
+
+        https://docs.apify.com/api/v2#/reference/request-queues/queue-head/get-head
+
+        Args:
+            limit (int, optional): How many requests to retrieve
+
+        Returns:
+            dict: The desired number of requests from the beginning of the queue.
+        """
         request_params = self._params(limit=limit, clientKey=self.client_key)
 
         response = await self.http_client.call(
@@ -211,8 +238,18 @@ class RequestQueueClientAsync(ResourceClientAsync):
 
         return _parse_date_fields(_pluck_data(response.json()))
 
-    @_make_async_docs(src=RequestQueueClient.add_request)
     async def add_request(self, request: Dict, *, forefront: Optional[bool] = None) -> Dict:
+        """Add a request to the queue.
+
+        https://docs.apify.com/api/v2#/reference/request-queues/request-collection/add-request
+
+        Args:
+            request (dict): The request to add to the queue
+            forefront (bool, optional): Whether to add the request to the head or the end of the queue
+
+        Returns:
+            dict: The added request.
+        """
         request_params = self._params(
             forefront=forefront,
             clientKey=self.client_key,
@@ -227,8 +264,17 @@ class RequestQueueClientAsync(ResourceClientAsync):
 
         return _parse_date_fields(_pluck_data(response.json()))
 
-    @_make_async_docs(src=RequestQueueClient.get_request)
     async def get_request(self, request_id: str) -> Optional[Dict]:
+        """Retrieve a request from the queue.
+
+        https://docs.apify.com/api/v2#/reference/request-queues/request/get-request
+
+        Args:
+            request_id (str): ID of the request to retrieve
+
+        Returns:
+            dict, optional: The retrieved request, or None, if it did not exist.
+        """
         try:
             response = await self.http_client.call(
                 url=self._url(f'requests/{request_id}'),
@@ -242,8 +288,18 @@ class RequestQueueClientAsync(ResourceClientAsync):
 
         return None
 
-    @_make_async_docs(src=RequestQueueClient.update_request)
     async def update_request(self, request: Dict, *, forefront: Optional[bool] = None) -> Dict:
+        """Update a request in the queue.
+
+        https://docs.apify.com/api/v2#/reference/request-queues/request/update-request
+
+        Args:
+            request (dict): The updated request
+            forefront (bool, optional): Whether to put the updated request in the beginning or the end of the queue
+
+        Returns:
+            dict: The updated request
+        """
         request_id = request['id']
 
         request_params = self._params(
@@ -260,8 +316,14 @@ class RequestQueueClientAsync(ResourceClientAsync):
 
         return _parse_date_fields(_pluck_data(response.json()))
 
-    @_make_async_docs(src=RequestQueueClient.delete_request)
     async def delete_request(self, request_id: str) -> None:
+        """Delete a request from the queue.
+
+        https://docs.apify.com/api/v2#/reference/request-queues/request/delete-request
+
+        Args:
+            request_id (str): ID of the request to delete.
+        """
         request_params = self._params(
             clientKey=self.client_key,
         )

--- a/src/apify_client/clients/resource_clients/request_queue_collection.py
+++ b/src/apify_client/clients/resource_clients/request_queue_collection.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import ListPage, _make_async_docs
+from ..._utils import ListPage
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 
 
@@ -57,7 +57,6 @@ class RequestQueueCollectionClientAsync(ResourceCollectionClientAsync):
         resource_path = kwargs.pop('resource_path', 'request-queues')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=RequestQueueCollectionClient.list)
     async def list(
         self,
         *,
@@ -66,8 +65,30 @@ class RequestQueueCollectionClientAsync(ResourceCollectionClientAsync):
         offset: Optional[int] = None,
         desc: Optional[bool] = None,
     ) -> ListPage[Dict]:
+        """List the available request queues.
+
+        https://docs.apify.com/api/v2#/reference/request-queues/queue-collection/get-list-of-request-queues
+
+        Args:
+            unnamed (bool, optional): Whether to include unnamed request queues in the list
+            limit (int, optional): How many request queues to retrieve
+            offset (int, optional): What request queue to include as first when retrieving the list
+            desc (bool, optional): Whether to sort therequest queues in descending order based on their modification date
+
+        Returns:
+            ListPage: The list of available request queues matching the specified filters.
+        """
         return await self._list(unnamed=unnamed, limit=limit, offset=offset, desc=desc)
 
-    @_make_async_docs(src=RequestQueueCollectionClient.get_or_create)
     async def get_or_create(self, *, name: Optional[str] = None) -> Dict:
+        """Retrieve a named request queue, or create a new one when it doesn't exist.
+
+        https://docs.apify.com/api/v2#/reference/request-queues/queue-collection/create-request-queue
+
+        Args:
+            name (str, optional): The name of the request queue to retrieve or create.
+
+        Returns:
+            dict: The retrieved or newly-created request queue.
+        """
         return await self._get_or_create(name=name)

--- a/src/apify_client/clients/resource_clients/run.py
+++ b/src/apify_client/clients/resource_clients/run.py
@@ -1,13 +1,6 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import (
-    _encode_key_value_store_record_value,
-    _filter_out_none_values_recursively,
-    _make_async_docs,
-    _parse_date_fields,
-    _pluck_data,
-    _to_safe_id,
-)
+from ..._utils import _encode_key_value_store_record_value, _filter_out_none_values_recursively, _parse_date_fields, _pluck_data, _to_safe_id
 from ..base import ActorJobBaseClient, ActorJobBaseClientAsync
 from .dataset import DatasetClient, DatasetClientAsync
 from .key_value_store import KeyValueStoreClient, KeyValueStoreClientAsync
@@ -194,27 +187,60 @@ class RunClientAsync(ActorJobBaseClientAsync):
         resource_path = kwargs.pop('resource_path', 'actor-runs')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=RunClient.get)
     async def get(self) -> Optional[Dict]:
+        """Return information about the actor run.
+
+        https://docs.apify.com/api/v2#/reference/actor-runs/run-object/get-run
+
+        Returns:
+            dict: The retrieved actor run data
+        """
         return await self._get()
 
-    @_make_async_docs(src=RunClient.update)
     async def update(self, *, status_message: Optional[str] = None) -> Dict:
+        """Update the run with the specified fields.
+
+        https://docs.apify.com/api/v2#/reference/actor-runs/run-object/update-run
+
+        Args:
+            status_message (str, optional): The new status message for the run
+
+        Returns:
+            dict: The updated run
+        """
         updated_fields = {
             'statusMessage': status_message,
         }
 
         return await self._update(_filter_out_none_values_recursively(updated_fields))
 
-    @_make_async_docs(src=RunClient.abort)
     async def abort(self, *, gracefully: Optional[bool] = None) -> Dict:
+        """Abort the actor run which is starting or currently running and return its details.
+
+        https://docs.apify.com/api/v2#/reference/actor-runs/abort-run/abort-run
+
+        Args:
+            gracefully (bool, optional): If True, the actor run will abort gracefully.
+                It will send ``aborting`` and ``persistStates`` events into the run and force-stop the run after 30 seconds.
+                It is helpful in cases where you plan to resurrect the run later.
+
+        Returns:
+            dict: The data of the aborted actor run
+        """
         return await self._abort(gracefully=gracefully)
 
-    @_make_async_docs(src=RunClient.wait_for_finish)
     async def wait_for_finish(self, *, wait_secs: Optional[int] = None) -> Optional[Dict]:
+        """Wait synchronously until the run finishes or the server times out.
+
+        Args:
+            wait_secs (int, optional): how long does the client wait for run to finish. None for indefinite.
+
+        Returns:
+            dict, optional: The actor run data. If the status on the object is not one of the terminal statuses
+                (SUCEEDED, FAILED, TIMED_OUT, ABORTED), then the run has not yet finished.
+        """
         return await self._wait_for_finish(wait_secs=wait_secs)
 
-    @_make_async_docs(src=RunClient.metamorph)
     async def metamorph(
         self,
         *,
@@ -223,6 +249,20 @@ class RunClientAsync(ActorJobBaseClientAsync):
         run_input: Optional[Any] = None,
         content_type: Optional[str] = None,
     ) -> Dict:
+        """Transform an actor run into a run of another actor with a new input.
+
+        https://docs.apify.com/api/v2#/reference/actor-runs/metamorph-run/metamorph-run
+
+        Args:
+            target_actor_id (str): ID of the target actor that the run should be transformed into
+            target_actor_build (str, optional): The build of the target actor. It can be either a build tag or build number.
+                By default, the run uses the build specified in the default run configuration for the target actor (typically the latest build).
+            run_input (Any, optional): The input to pass to the new run.
+            content_type (str, optional): The content type of the input.
+
+        Returns:
+            dict: The actor run data.
+        """
         run_input, content_type = _encode_key_value_store_record_value(run_input, content_type)
 
         safe_target_actor_id = _to_safe_id(target_actor_id)
@@ -242,8 +282,17 @@ class RunClientAsync(ActorJobBaseClientAsync):
 
         return _parse_date_fields(_pluck_data(response.json()))
 
-    @_make_async_docs(src=RunClient.resurrect)
     async def resurrect(self) -> Dict:
+        """Resurrect a finished actor run.
+
+        Only finished runs, i.e. runs with status FINISHED, FAILED, ABORTED and TIMED-OUT can be resurrected.
+        Run status will be updated to RUNNING and its container will be restarted with the same default storages.
+
+        https://docs.apify.com/api/v2#/reference/actor-runs/resurrect-run/resurrect-run
+
+        Returns:
+            dict: The actor run data.
+        """
         response = await self.http_client.call(
             url=self._url('resurrect'),
             method='POST',
@@ -252,26 +301,50 @@ class RunClientAsync(ActorJobBaseClientAsync):
 
         return _parse_date_fields(_pluck_data(response.json()))
 
-    @_make_async_docs(src=RunClient.dataset)
     def dataset(self) -> DatasetClientAsync:
+        """Get the client for the default dataset of the actor run.
+
+        https://docs.apify.com/api/v2#/reference/actors/last-run-object-and-its-storages
+
+        Returns:
+            DatasetClientAsync: A client allowing access to the default dataset of this actor run.
+        """
         return DatasetClientAsync(
             **self._sub_resource_init_options(resource_path='dataset'),
         )
 
-    @_make_async_docs(src=RunClient.key_value_store)
     def key_value_store(self) -> KeyValueStoreClientAsync:
+        """Get the client for the default key-value store of the actor run.
+
+        https://docs.apify.com/api/v2#/reference/actors/last-run-object-and-its-storages
+
+        Returns:
+            KeyValueStoreClientAsync: A client allowing access to the default key-value store of this actor run.
+        """
         return KeyValueStoreClientAsync(
             **self._sub_resource_init_options(resource_path='key-value-store'),
         )
 
-    @_make_async_docs(src=RunClient.request_queue)
     def request_queue(self) -> RequestQueueClientAsync:
+        """Get the client for the default request queue of the actor run.
+
+        https://docs.apify.com/api/v2#/reference/actors/last-run-object-and-its-storages
+
+        Returns:
+            RequestQueueClientAsync: A client allowing access to the default request_queue of this actor run.
+        """
         return RequestQueueClientAsync(
             **self._sub_resource_init_options(resource_path='request-queue'),
         )
 
-    @_make_async_docs(src=RunClient.log)
     def log(self) -> LogClientAsync:
+        """Get the client for the log of the actor run.
+
+        https://docs.apify.com/api/v2#/reference/actors/last-run-object-and-its-storages
+
+        Returns:
+            LogClientAsync: A client allowing access to the log of this actor run.
+        """
         return LogClientAsync(
             **self._sub_resource_init_options(resource_path='log'),
         )

--- a/src/apify_client/clients/resource_clients/run_collection.py
+++ b/src/apify_client/clients/resource_clients/run_collection.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import ListPage, _make_async_docs, _maybe_extract_enum_member_value
+from ..._utils import ListPage, _maybe_extract_enum_member_value
 from ...consts import ActorJobStatus
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 
@@ -51,7 +51,6 @@ class RunCollectionClientAsync(ResourceCollectionClientAsync):
         resource_path = kwargs.pop('resource_path', 'actor-runs')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=RunCollectionClient.list)
     async def list(
         self,
         *,
@@ -60,6 +59,20 @@ class RunCollectionClientAsync(ResourceCollectionClientAsync):
         desc: Optional[bool] = None,
         status: Optional[ActorJobStatus] = None,
     ) -> ListPage[Dict]:
+        """List all actor runs (either of a single actor, or all user's actors, depending on where this client was initialized from).
+
+        https://docs.apify.com/api/v2#/reference/actors/run-collection/get-list-of-runs
+        https://docs.apify.com/api/v2#/reference/actor-runs/run-collection/get-user-runs-list
+
+        Args:
+            limit (int, optional): How many runs to retrieve
+            offset (int, optional): What run to include as first when retrieving the list
+            desc (bool, optional): Whether to sort the runs in descending order based on their start date
+            status (ActorJobStatus, optional): Retrieve only runs with the provided status
+
+        Returns:
+            ListPage: The retrieved actor runs
+        """
         return await self._list(
             limit=limit,
             offset=offset,

--- a/src/apify_client/clients/resource_clients/schedule.py
+++ b/src/apify_client/clients/resource_clients/schedule.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional
 
 from ..._errors import ApifyApiError
-from ..._utils import _catch_not_found_or_throw, _filter_out_none_values_recursively, _make_async_docs, _pluck_data_as_list
+from ..._utils import _catch_not_found_or_throw, _filter_out_none_values_recursively, _pluck_data_as_list
 from ..base import ResourceClient, ResourceClientAsync
 
 
@@ -124,11 +124,16 @@ class ScheduleClientAsync(ResourceClientAsync):
         resource_path = kwargs.pop('resource_path', 'schedules')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=ScheduleClient.get)
     async def get(self) -> Optional[Dict]:
+        """Return information about the schedule.
+
+        https://docs.apify.com/api/v2#/reference/schedules/schedule-object/get-schedule
+
+        Returns:
+            dict, optional: The retrieved schedule
+        """
         return await self._get()
 
-    @_make_async_docs(src=ScheduleClient.update)
     async def update(
         self,
         *,
@@ -141,6 +146,24 @@ class ScheduleClientAsync(ResourceClientAsync):
         timezone: Optional[str] = None,
         title: Optional[str] = None,
     ) -> Dict:
+        """Update the schedule with specified fields.
+
+        https://docs.apify.com/api/v2#/reference/schedules/schedule-object/update-schedule
+
+        Args:
+            cron_expression (str, optional): The cron expression used by this schedule
+            is_enabled (bool, optional): True if the schedule should be enabled
+            is_exclusive (bool, optional): When set to true, don't start actor or actor task if it's still running from the previous schedule.
+            name (str, optional): The name of the schedule to create.
+            actions (list of dict, optional): Actors or tasks that should be run on this schedule. See the API documentation for exact structure.
+            description (str, optional): Description of this schedule
+            timezone (str, optional): Timezone in which your cron expression runs
+                                      (TZ database name from https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+            title (str, optional): A human-friendly equivalent of the name
+
+        Returns:
+            dict: The updated schedule
+        """
         schedule_representation = _get_schedule_representation(
             cron_expression=cron_expression,
             is_enabled=is_enabled,
@@ -154,12 +177,21 @@ class ScheduleClientAsync(ResourceClientAsync):
 
         return await self._update(_filter_out_none_values_recursively(schedule_representation))
 
-    @_make_async_docs(src=ScheduleClient.delete)
     async def delete(self) -> None:
+        """Delete the schedule.
+
+        https://docs.apify.com/api/v2#/reference/schedules/schedule-object/delete-schedule
+        """
         await self._delete()
 
-    @_make_async_docs(src=ScheduleClient.get_log)
     async def get_log(self) -> Optional[List]:
+        """Return log for the given schedule.
+
+        https://docs.apify.com/api/v2#/reference/schedules/schedule-log/get-schedule-log
+
+        Returns:
+            list, optional: Retrieved log of the given schedule
+        """
         try:
             response = await self.http_client.call(
                 url=self._url('log'),

--- a/src/apify_client/clients/resource_clients/schedule_collection.py
+++ b/src/apify_client/clients/resource_clients/schedule_collection.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from ..._utils import ListPage, _filter_out_none_values_recursively, _make_async_docs
+from ..._utils import ListPage, _filter_out_none_values_recursively
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 from .schedule import _get_schedule_representation
 
@@ -88,7 +88,6 @@ class ScheduleCollectionClientAsync(ResourceCollectionClientAsync):
         resource_path = kwargs.pop('resource_path', 'schedules')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=ScheduleCollectionClient.list)
     async def list(
         self,
         *,
@@ -96,9 +95,20 @@ class ScheduleCollectionClientAsync(ResourceCollectionClientAsync):
         offset: Optional[int] = None,
         desc: Optional[bool] = None,
     ) -> ListPage[Dict]:
+        """List the available schedules.
+
+        https://docs.apify.com/api/v2#/reference/schedules/schedules-collection/get-list-of-schedules
+
+        Args:
+            limit (int, optional): How many schedules to retrieve
+            offset (int, optional): What schedules to include as first when retrieving the list
+            desc (bool, optional): Whether to sort the schedules in descending order based on their modification date
+
+        Returns:
+            ListPage: The list of available schedules matching the specified filters.
+        """
         return await self._list(limit=limit, offset=offset, desc=desc)
 
-    @_make_async_docs(src=ScheduleCollectionClient.create)
     async def create(
         self,
         *,
@@ -111,6 +121,23 @@ class ScheduleCollectionClientAsync(ResourceCollectionClientAsync):
         timezone: Optional[str] = None,
         title: Optional[str] = None,
     ) -> Dict:
+        """Create a new schedule.
+
+        https://docs.apify.com/api/v2#/reference/schedules/schedules-collection/create-schedule
+
+        Args:
+            cron_expression (str): The cron expression used by this schedule
+            is_enabled (bool): True if the schedule should be enabled
+            is_exclusive (bool): When set to true, don't start actor or actor task if it's still running from the previous schedule.
+            name (str, optional): The name of the schedule to create.
+            actions (list of dict, optional): Actors or tasks that should be run on this schedule. See the API documentation for exact structure.
+            description (str, optional): Description of this schedule
+            timezone (str, optional): Timezone in which your cron expression runs
+                (TZ database name from https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+
+        Returns:
+            dict: The created schedule.
+        """
         if not actions:
             actions = []
 

--- a/src/apify_client/clients/resource_clients/task.py
+++ b/src/apify_client/clients/resource_clients/task.py
@@ -5,7 +5,6 @@ from ..._utils import (
     _catch_not_found_or_throw,
     _encode_webhook_list_to_base64,
     _filter_out_none_values_recursively,
-    _make_async_docs,
     _maybe_extract_enum_member_value,
     _parse_date_fields,
     _pluck_data,
@@ -269,11 +268,16 @@ class TaskClientAsync(ResourceClientAsync):
         resource_path = kwargs.pop('resource_path', 'actor-tasks')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=TaskClient.get)
     async def get(self) -> Optional[Dict]:
+        """Retrieve the task.
+
+        https://docs.apify.com/api/v2#/reference/actor-tasks/task-object/get-task
+
+        Returns:
+            dict, optional: The retrieved task
+        """
         return await self._get()
 
-    @_make_async_docs(src=TaskClient.update)
     async def update(
         self,
         *,
@@ -284,6 +288,23 @@ class TaskClientAsync(ResourceClientAsync):
         timeout_secs: Optional[int] = None,
         title: Optional[str] = None,
     ) -> Dict:
+        """Update the task with specified fields.
+
+        https://docs.apify.com/api/v2#/reference/actor-tasks/task-object/update-task
+
+        Args:
+            name (str, optional): Name of the task
+            build (str, optional): Actor build to run. It can be either a build tag or build number.
+                                   By default, the run uses the build specified in the task settings (typically latest).
+            memory_mbytes (int, optional): Memory limit for the run, in megabytes.
+                                           By default, the run uses a memory limit specified in the task settings.
+            timeout_secs (int, optional): Optional timeout for the run, in seconds. By default, the run uses timeout specified in the task settings.
+            task_input (dict, optional): Task input dictionary
+            title (str, optional): A human-friendly equivalent of the name
+
+        Returns:
+            dict: The updated task
+        """
         task_representation = _get_task_representation(
             name=name,
             task_input=task_input,
@@ -295,11 +316,13 @@ class TaskClientAsync(ResourceClientAsync):
 
         return await self._update(_filter_out_none_values_recursively(task_representation))
 
-    @_make_async_docs(src=TaskClient.delete)
     async def delete(self) -> None:
+        """Delete the task.
+
+        https://docs.apify.com/api/v2#/reference/actor-tasks/task-object/delete-task
+        """
         return await self._delete()
 
-    @_make_async_docs(src=TaskClient.start)
     async def start(
         self,
         *,
@@ -310,6 +333,31 @@ class TaskClientAsync(ResourceClientAsync):
         wait_for_finish: Optional[int] = None,
         webhooks: Optional[List[Dict]] = None,
     ) -> Dict:
+        """Start the task and immediately return the Run object.
+
+        https://docs.apify.com/api/v2#/reference/actor-tasks/run-collection/run-task
+
+        Args:
+            task_input (dict, optional): Task input dictionary
+            build (str, optional): Specifies the actor build to run. It can be either a build tag or build number.
+                                   By default, the run uses the build specified in the task settings (typically latest).
+            memory_mbytes (int, optional): Memory limit for the run, in megabytes.
+                                           By default, the run uses a memory limit specified in the task settings.
+            timeout_secs (int, optional): Optional timeout for the run, in seconds. By default, the run uses timeout specified in the task settings.
+            wait_for_finish (int, optional): The maximum number of seconds the server waits for the run to finish.
+                                               By default, it is 0, the maximum value is 300.
+            webhooks (list of dict, optional): Optional ad-hoc webhooks (https://docs.apify.com/webhooks/ad-hoc-webhooks)
+                                               associated with the actor run which can be used to receive a notification,
+                                               e.g. when the actor finished or failed.
+                                               If you already have a webhook set up for the actor or task, you do not have to add it again here.
+                                               Each webhook is represented by a dictionary containing these items:
+                                               * ``event_types``: list of ``WebhookEventType`` values which trigger the webhook
+                                               * ``request_url``: URL to which to send the webhook HTTP request
+                                               * ``payload_template`` (optional): Optional template for the request payload
+
+        Returns:
+            dict: The run object
+        """
         request_params = self._params(
             build=build,
             memory=memory_mbytes,
@@ -328,7 +376,6 @@ class TaskClientAsync(ResourceClientAsync):
 
         return _parse_date_fields(_pluck_data(response.json()))
 
-    @_make_async_docs(src=TaskClient.call)
     async def call(
         self,
         *,
@@ -339,6 +386,27 @@ class TaskClientAsync(ResourceClientAsync):
         webhooks: Optional[List[Dict]] = None,
         wait_secs: Optional[int] = None,
     ) -> Optional[Dict]:
+        """Start a task and wait for it to finish before returning the Run object.
+
+        It waits indefinitely, unless the wait_secs argument is provided.
+
+        https://docs.apify.com/api/v2#/reference/actor-tasks/run-collection/run-task
+
+        Args:
+            task_input (dict, optional): Task input dictionary
+            build (str, optional): Specifies the actor build to run. It can be either a build tag or build number.
+                                   By default, the run uses the build specified in the task settings (typically latest).
+            memory_mbytes (int, optional): Memory limit for the run, in megabytes.
+                                           By default, the run uses a memory limit specified in the task settings.
+            timeout_secs (int, optional): Optional timeout for the run, in seconds. By default, the run uses timeout specified in the task settings.
+            webhooks (list, optional): Specifies optional webhooks associated with the actor run, which can be used to receive a notification
+                                       e.g. when the actor finished or failed. Note: if you already have a webhook set up for the actor or task,
+                                       you do not have to add it again here.
+            wait_secs (int, optional): The maximum number of seconds the server waits for the task run to finish. If not provided, waits indefinitely.
+
+        Returns:
+            dict: The run object
+        """
         started_run = await self.start(
             task_input=task_input,
             build=build,
@@ -349,8 +417,14 @@ class TaskClientAsync(ResourceClientAsync):
 
         return await self.root_client.run(started_run['id']).wait_for_finish(wait_secs=wait_secs)
 
-    @_make_async_docs(src=TaskClient.get_input)
     async def get_input(self) -> Optional[Dict]:
+        """Retrieve the default input for this task.
+
+        https://docs.apify.com/api/v2#/reference/actor-tasks/task-input-object/get-task-input
+
+        Returns:
+            dict, optional: Retrieved task input
+        """
         try:
             response = await self.http_client.call(
                 url=self._url('input'),
@@ -362,8 +436,14 @@ class TaskClientAsync(ResourceClientAsync):
             _catch_not_found_or_throw(exc)
         return None
 
-    @_make_async_docs(src=TaskClient.update_input)
     async def update_input(self, *, task_input: Dict) -> Dict:
+        """Update the default input for this task.
+
+        https://docs.apify.com/api/v2#/reference/actor-tasks/task-input-object/update-task-input
+
+        Returns:
+            dict, Retrieved task input
+        """
         response = await self.http_client.call(
             url=self._url('input'),
             method='PUT',
@@ -372,12 +452,22 @@ class TaskClientAsync(ResourceClientAsync):
         )
         return cast(Dict, response.json())
 
-    @_make_async_docs(src=TaskClient.runs)
     def runs(self) -> RunCollectionClientAsync:
+        """Retrieve a client for the runs of this task."""
         return RunCollectionClientAsync(**self._sub_resource_init_options(resource_path='runs'))
 
-    @_make_async_docs(src=TaskClient.last_run)
     def last_run(self, *, status: Optional[ActorJobStatus] = None, origin: Optional[MetaOrigin] = None) -> RunClientAsync:
+        """Retrieve the client for the last run of this task.
+
+        Last run is retrieved based on the start time of the runs.
+
+        Args:
+            status (ActorJobStatus, optional): Consider only runs with this status.
+            origin (MetaOrigin, optional): Consider only runs started with this origin.
+
+        Returns:
+            RunClientAsync: The resource client for the last run of this task.
+        """
         return RunClientAsync(**self._sub_resource_init_options(
             resource_id='last',
             resource_path='runs',
@@ -387,6 +477,6 @@ class TaskClientAsync(ResourceClientAsync):
             ),
         ))
 
-    @_make_async_docs(src=TaskClient.webhooks)
     def webhooks(self) -> WebhookCollectionClientAsync:
+        """Retrieve a client for webhooks associated with this task."""
         return WebhookCollectionClientAsync(**self._sub_resource_init_options())

--- a/src/apify_client/clients/resource_clients/task_collection.py
+++ b/src/apify_client/clients/resource_clients/task_collection.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import ListPage, _filter_out_none_values_recursively, _make_async_docs
+from ..._utils import ListPage, _filter_out_none_values_recursively
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 from .task import _get_task_representation
 
@@ -84,7 +84,6 @@ class TaskCollectionClientAsync(ResourceCollectionClientAsync):
         resource_path = kwargs.pop('resource_path', 'actor-tasks')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=TaskCollectionClient.list)
     async def list(
         self,
         *,
@@ -92,9 +91,20 @@ class TaskCollectionClientAsync(ResourceCollectionClientAsync):
         offset: Optional[int] = None,
         desc: Optional[bool] = None,
     ) -> ListPage[Dict]:
+        """List the available tasks.
+
+        https://docs.apify.com/api/v2#/reference/actor-tasks/task-collection/get-list-of-tasks
+
+        Args:
+            limit (int, optional): How many tasks to list
+            offset (int, optional): What task to include as first when retrieving the list
+            desc (bool, optional): Whether to sort the tasks in descending order based on their creation date
+
+        Returns:
+            ListPage: The list of available tasks matching the specified filters.
+        """
         return await self._list(limit=limit, offset=offset, desc=desc)
 
-    @_make_async_docs(src=TaskCollectionClient.create)
     async def create(
         self,
         *,
@@ -106,6 +116,24 @@ class TaskCollectionClientAsync(ResourceCollectionClientAsync):
         task_input: Optional[Dict] = None,
         title: Optional[str] = None,
     ) -> Dict:
+        """Create a new task.
+
+        https://docs.apify.com/api/v2#/reference/actor-tasks/task-collection/create-task
+
+        Args:
+            actor_id (str): Id of the actor that should be run
+            name (str): Name of the task
+            build (str, optional): Actor build to run. It can be either a build tag or build number.
+                                   By default, the run uses the build specified in the task settings (typically latest).
+            memory_mbytes (int, optional): Memory limit for the run, in megabytes.
+                                           By default, the run uses a memory limit specified in the task settings.
+            timeout_secs (int, optional): Optional timeout for the run, in seconds. By default, the run uses timeout specified in the task settings.
+            task_input (dict, optional): Task input object.
+            title (str, optional): A human-friendly equivalent of the name
+
+        Returns:
+            dict: The created task.
+        """
         task_representation = _get_task_representation(
             actor_id=actor_id,
             name=name,

--- a/src/apify_client/clients/resource_clients/user.py
+++ b/src/apify_client/clients/resource_clients/user.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import _make_async_docs
 from ..base import ResourceClient, ResourceClientAsync
 
 
@@ -35,6 +34,14 @@ class UserClientAsync(ResourceClientAsync):
         resource_path = kwargs.pop('resource_path', 'users')
         super().__init__(*args, resource_id=resource_id, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=UserClient.get)
     async def get(self) -> Optional[Dict]:
+        """Return information about user account.
+
+        You receive all or only public info based on your token permissions.
+
+        https://docs.apify.com/api/v2#/reference/users
+
+        Returns:
+            dict, optional: The retrieved user data, or None if the user does not exist.
+        """
         return await self._get()

--- a/src/apify_client/clients/resource_clients/webhook.py
+++ b/src/apify_client/clients/resource_clients/webhook.py
@@ -4,7 +4,6 @@ from ..._errors import ApifyApiError
 from ..._utils import (
     _catch_not_found_or_throw,
     _filter_out_none_values_recursively,
-    _make_async_docs,
     _maybe_extract_enum_member_value,
     _parse_date_fields,
     _pluck_data,
@@ -168,11 +167,16 @@ class WebhookClientAsync(ResourceClientAsync):
         resource_path = kwargs.pop('resource_path', 'webhooks')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=WebhookClient.get)
     async def get(self) -> Optional[Dict]:
+        """Retrieve the webhook.
+
+        https://docs.apify.com/api/v2#/reference/webhooks/webhook-object/get-webhook
+
+        Returns:
+            dict, optional: The retrieved webhook, or None if it does not exist
+        """
         return await self._get()
 
-    @_make_async_docs(src=WebhookClient.update)
     async def update(
         self,
         *,
@@ -186,6 +190,26 @@ class WebhookClientAsync(ResourceClientAsync):
         do_not_retry: Optional[bool] = None,
         is_ad_hoc: Optional[bool] = None,
     ) -> Dict:
+        """Update the webhook.
+
+        https://docs.apify.com/api/v2#/reference/webhooks/webhook-object/update-webhook
+
+        Args:
+            event_types (list of WebhookEventType, optional): List of event types that should trigger the webhook. At least one is required.
+            request_url (str, optional): URL that will be invoked once the webhook is triggered.
+            payload_template (str, optional): Specification of the payload that will be sent to request_url
+            actor_id (str, optional): Id of the actor whose runs should trigger the webhook.
+            actor_task_id (str, optional): Id of the actor task whose runs should trigger the webhook.
+            actor_run_id (str, optional): Id of the actor run which should trigger the webhook.
+            ignore_ssl_errors (bool, optional): Whether the webhook should ignore SSL errors returned by request_url
+            do_not_retry (bool, optional): Whether the webhook should retry sending the payload to request_url upon
+                                           failure.
+            is_ad_hoc (bool, optional): Set to True if you want the webhook to be triggered only the first time the
+                                        condition is fulfilled. Only applicable when actor_run_id is filled.
+
+        Returns:
+            dict: The updated webhook
+        """
         webhook_representation = _get_webhook_representation(
             event_types=event_types,
             request_url=request_url,
@@ -200,12 +224,23 @@ class WebhookClientAsync(ResourceClientAsync):
 
         return await self._update(_filter_out_none_values_recursively(webhook_representation))
 
-    @_make_async_docs(src=WebhookClient.delete)
     async def delete(self) -> None:
+        """Delete the webhook.
+
+        https://docs.apify.com/api/v2#/reference/webhooks/webhook-object/delete-webhook
+        """
         return await self._delete()
 
-    @_make_async_docs(src=WebhookClient.test)
     async def test(self) -> Optional[Dict]:
+        """Test a webhook.
+
+        Creates a webhook dispatch with a dummy payload.
+
+        https://docs.apify.com/api/v2#/reference/webhooks/webhook-test/test-webhook
+
+        Returns:
+            dict, optional: The webhook dispatch created by the test
+        """
         try:
             response = await self.http_client.call(
                 url=self._url('test'),
@@ -220,8 +255,14 @@ class WebhookClientAsync(ResourceClientAsync):
 
         return None
 
-    @_make_async_docs(src=WebhookClient.dispatches)
     def dispatches(self) -> WebhookDispatchCollectionClientAsync:
+        """Get dispatches of the webhook.
+
+        https://docs.apify.com/api/v2#/reference/webhooks/dispatches-collection/get-collection
+
+        Returns:
+            WebhookDispatchCollectionClientAsync: A client allowing access to dispatches of this webhook using its list method
+        """
         return WebhookDispatchCollectionClientAsync(
             **self._sub_resource_init_options(resource_path='dispatches'),
         )

--- a/src/apify_client/clients/resource_clients/webhook_collection.py
+++ b/src/apify_client/clients/resource_clients/webhook_collection.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional
 
 from apify_client.consts import WebhookEventType
 
-from ..._utils import ListPage, _filter_out_none_values_recursively, _make_async_docs
+from ..._utils import ListPage, _filter_out_none_values_recursively
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 from .webhook import _get_webhook_representation
 
@@ -98,7 +98,6 @@ class WebhookCollectionClientAsync(ResourceCollectionClientAsync):
         resource_path = kwargs.pop('resource_path', 'webhooks')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=WebhookCollectionClient.list)
     async def list(
         self,
         *,
@@ -106,9 +105,20 @@ class WebhookCollectionClientAsync(ResourceCollectionClientAsync):
         offset: Optional[int] = None,
         desc: Optional[bool] = None,
     ) -> ListPage[Dict]:
+        """List the available webhooks.
+
+        https://docs.apify.com/api/v2#/reference/webhooks/webhook-collection/get-list-of-webhooks
+
+        Args:
+            limit (int, optional): How many webhooks to retrieve
+            offset (int, optional): What webhook to include as first when retrieving the list
+            desc (bool, optional): Whether to sort the webhooks in descending order based on their date of creation
+
+        Returns:
+            ListPage: The list of available webhooks matching the specified filters.
+        """
         return await self._list(limit=limit, offset=offset, desc=desc)
 
-    @_make_async_docs(src=WebhookCollectionClient.create)
     async def create(
         self,
         *,
@@ -123,6 +133,30 @@ class WebhookCollectionClientAsync(ResourceCollectionClientAsync):
         idempotency_key: Optional[str] = None,
         is_ad_hoc: Optional[bool] = None,
     ) -> Dict:
+        """Create a new webhook.
+
+        You have to specify exactly one out of actor_id, actor_task_id or actor_run_id.
+
+        https://docs.apify.com/api/v2#/reference/webhooks/webhook-collection/create-webhook
+
+        Args:
+            event_types (list of WebhookEventType): List of event types that should trigger the webhook. At least one is required.
+            request_url (str): URL that will be invoked once the webhook is triggered.
+            payload_template (str, optional): Specification of the payload that will be sent to request_url
+            actor_id (str, optional): Id of the actor whose runs should trigger the webhook.
+            actor_task_id (str, optional): Id of the actor task whose runs should trigger the webhook.
+            actor_run_id (str, optional): Id of the actor run which should trigger the webhook.
+            ignore_ssl_errors (bool, optional): Whether the webhook should ignore SSL errors returned by request_url
+            do_not_retry (bool, optional): Whether the webhook should retry sending the payload to request_url upon
+                                           failure.
+            idempotency_key (str, optional): A unique identifier of a webhook. You can use it to ensure that you won't
+                                             create the same webhook multiple times.
+            is_ad_hoc (bool, optional): Set to True if you want the webhook to be triggered only the first time the
+                                        condition is fulfilled. Only applicable when actor_run_id is filled.
+
+        Returns:
+            dict: The created webhook
+        """
         webhook_representation = _get_webhook_representation(
             event_types=event_types,
             request_url=request_url,

--- a/src/apify_client/clients/resource_clients/webhook_dispatch.py
+++ b/src/apify_client/clients/resource_clients/webhook_dispatch.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import _make_async_docs
 from ..base import ResourceClient, ResourceClientAsync
 
 
@@ -31,6 +30,12 @@ class WebhookDispatchClientAsync(ResourceClientAsync):
         resource_path = kwargs.pop('resource_path', 'webhook-dispatches')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=WebhookDispatchClient.get)
     async def get(self) -> Optional[Dict]:
+        """Retrieve the webhook dispatch.
+
+        https://docs.apify.com/api/v2#/reference/webhook-dispatches/webhook-dispatch-object/get-webhook-dispatch
+
+        Returns:
+            dict, optional: The retrieved webhook dispatch, or None if it does not exist
+        """
         return await self._get()

--- a/src/apify_client/clients/resource_clients/webhook_dispatch_collection.py
+++ b/src/apify_client/clients/resource_clients/webhook_dispatch_collection.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import ListPage, _make_async_docs
+from ..._utils import ListPage
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 
 
@@ -42,7 +42,6 @@ class WebhookDispatchCollectionClientAsync(ResourceCollectionClientAsync):
         resource_path = kwargs.pop('resource_path', 'webhook-dispatches')
         super().__init__(*args, resource_path=resource_path, **kwargs)
 
-    @_make_async_docs(src=WebhookDispatchCollectionClient.list)
     async def list(
         self,
         *,
@@ -50,4 +49,16 @@ class WebhookDispatchCollectionClientAsync(ResourceCollectionClientAsync):
         offset: Optional[int] = None,
         desc: Optional[bool] = None,
     ) -> ListPage[Dict]:
+        """List all webhook dispatches of a user.
+
+        https://docs.apify.com/api/v2#/reference/webhook-dispatches/webhook-dispatches-collection/get-list-of-webhook-dispatches
+
+        Args:
+            limit (int, optional): How many webhook dispatches to retrieve
+            offset (int, optional): What webhook dispatch to include as first when retrieving the list
+            desc (bool, optional): Whether to sort the webhook dispatches in descending order based on the date of their creation
+
+        Returns:
+            ListPage: The retrieved webhook dispatches of a user
+        """
         return await self._list(limit=limit, offset=offset, desc=desc)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -14,7 +14,6 @@ from apify_client._utils import (
     _is_content_type_text,
     _is_content_type_xml,
     _is_file_or_bytes,
-    _make_async_docs,
     _maybe_extract_enum_member_value,
     _parse_date_fields,
     _pluck_data,
@@ -254,15 +253,3 @@ def test__filter_out_none_values_recursively_internal() -> None:
     assert _filter_out_none_values_recursively_internal({'k1': {}}, False) == {'k1': {}}
     assert _filter_out_none_values_recursively_internal({}, True) is None
     assert _filter_out_none_values_recursively_internal({'k1': {}}, True) is None
-
-
-def test__make_async_docs() -> None:
-    def source_func() -> None:
-        """source_func docs."""
-        pass
-
-    @_make_async_docs(src=source_func)
-    def target_func() -> None:
-        pass
-
-    assert target_func.__doc__ == 'source_func docs.'


### PR DESCRIPTION
Since the docs for async methods which were generated with the `_make_async_docs` decorator were not showing in the hints in VSCode, and were not processed in `pydoc-markdown`, it's better that we write the docstrings for async methods explicitly.

So that we don't have to copy-paste all the docstrings manually, I wrote a script, which uses the [Red Baron](https://github.com/PyCQA/redbaron) package, which synchronizes the docstrings from the sync methods to their analogous async methods, making some adjustments to make the docstrings work for the async methods.

I also wrote another script, which runs in CI, and just checks that the docstrings are synchronized, failing the check if they're not.

This was way easier than I was worried about, we should have done this right from the start.

CC @barjin I hope you haven't spent too much time on replicating the `_make_async_docs` decorator while rendering the docs, this should make your job a fair bit easier.