### PR TITLE
fix: Calling user().get() will use '/me' endpoint correctly

### DIFF
--- a/src/apify_client/clients/resource_clients/user.py
+++ b/src/apify_client/clients/resource_clients/user.py
@@ -8,7 +8,9 @@ class UserClient(ResourceClient):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the UserClient."""
-        resource_id = kwargs.pop('resource_id', 'me')
+        resource_id = kwargs.pop('resource_id', None)
+        if resource_id is None:
+            resource_id = 'me'
         resource_path = kwargs.pop('resource_path', 'users')
         super().__init__(*args, resource_id=resource_id, resource_path=resource_path, **kwargs)
 
@@ -30,7 +32,9 @@ class UserClientAsync(ResourceClientAsync):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the UserClientAsync."""
-        resource_id = kwargs.pop('resource_id', 'me')
+        resource_id = kwargs.pop('resource_id', None)
+        if resource_id is None:
+            resource_id = 'me'
         resource_path = kwargs.pop('resource_path', 'users')
         super().__init__(*args, resource_id=resource_id, resource_path=resource_path, **kwargs)
 


### PR DESCRIPTION
The previous code didn't work since we always pass something into `resource_id` from the `.user()` call (the type is `str | None`). This way, we always popped something from `kwargs` and `'me'` could never make it to the URL. 

Now, it will just check whether the value is `None` or not and replace it with `'me'` if it's `None`