### PR TITLE
Add `ignore_docs` decorator

### DIFF
--- a/src/apify_client/_errors.py
+++ b/src/apify_client/_errors.py
@@ -2,6 +2,8 @@ from typing import Optional
 
 import httpx
 
+from ._utils import ignore_docs
+
 
 class ApifyClientError(Exception):
     """Base class for errors specific to the Apify API Client."""
@@ -18,6 +20,7 @@ class ApifyApiError(ApifyClientError):
     errors, which are thrown immediately, because a correction by the user is needed.
     """
 
+    @ignore_docs
     def __init__(self, response: httpx.Response, attempt: int) -> None:
         """Create the ApifyApiError instance.
 
@@ -58,6 +61,7 @@ class InvalidResponseBodyError(ApifyClientError):
     request. We do that by identifying this error in the _HTTPClient.
     """
 
+    @ignore_docs
     def __init__(self, response: httpx.Response) -> None:
         """Create the InvalidResponseBodyError instance.
 

--- a/src/apify_client/_http_client.py
+++ b/src/apify_client/_http_client.py
@@ -11,7 +11,14 @@ import httpx
 from ._errors import ApifyApiError, InvalidResponseBodyError, _is_retryable_error
 from ._logging import logger_name
 from ._types import JSONSerializable
-from ._utils import _is_content_type_json, _is_content_type_text, _is_content_type_xml, _retry_with_exp_backoff, _retry_with_exp_backoff_async
+from ._utils import (
+    _is_content_type_json,
+    _is_content_type_text,
+    _is_content_type_xml,
+    _retry_with_exp_backoff,
+    _retry_with_exp_backoff_async,
+    ignore_docs,
+)
 from ._version import __version__
 
 DEFAULT_BACKOFF_EXPONENTIAL_FACTOR = 2
@@ -21,6 +28,7 @@ logger = logging.getLogger(logger_name)
 
 
 class _BaseHTTPClient:
+    @ignore_docs
     def __init__(
         self,
         *,

--- a/src/apify_client/_utils.py
+++ b/src/apify_client/_utils.py
@@ -8,9 +8,10 @@ import time
 from datetime import datetime, timezone
 from enum import Enum
 from http import HTTPStatus
-from typing import Any, Awaitable, Callable, Dict, Generic, List, Optional, Tuple, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, Generic, List, Optional, Tuple, TypeVar, cast
 
-from ._errors import ApifyApiError
+if TYPE_CHECKING:
+    from ._errors import ApifyApiError
 
 PARSE_DATE_FIELDS_MAX_DEPTH = 3
 PARSE_DATE_FIELDS_KEY_SUFFIX = 'At'
@@ -159,7 +160,7 @@ async def _retry_with_exp_backoff_async(
     return await async_func(stop_retrying, max_retries + 1)
 
 
-def _catch_not_found_or_throw(exc: ApifyApiError) -> None:
+def _catch_not_found_or_throw(exc: 'ApifyApiError') -> None:
     is_not_found_status = (exc.status_code == HTTPStatus.NOT_FOUND)
     is_not_found_type = (exc.type in RECORD_NOT_FOUND_EXCEPTION_TYPES)
     if not (is_not_found_status and is_not_found_type):
@@ -222,6 +223,11 @@ def _maybe_extract_enum_member_value(maybe_enum_member: Any) -> Any:
     return maybe_enum_member
 
 
+def ignore_docs(method: T) -> T:
+    """Mark that a method's documentation should not be rendered. Functionally, this decorator is a noop."""
+    return method
+
+
 class ListPage(Generic[T]):
     """A single page of items returned from a list() method."""
 
@@ -238,6 +244,7 @@ class ListPage(Generic[T]):
     #: bool: Whether the listing is descending or not
     desc: bool
 
+    @ignore_docs
     def __init__(self, data: Dict) -> None:
         """Initialize a ListPage instance from the API response data."""
         self.items = data['items'] if 'items' in data else []

--- a/src/apify_client/client.py
+++ b/src/apify_client/client.py
@@ -1,6 +1,7 @@
 from typing import Dict, Optional, Union
 
 from ._http_client import _HTTPClient, _HTTPClientAsync
+from ._utils import ignore_docs
 from .clients import (
     ActorClient,
     ActorClientAsync,
@@ -55,6 +56,7 @@ API_VERSION = 'v2'
 class _BaseApifyClient:
     http_client: Union[_HTTPClient, _HTTPClientAsync]
 
+    @ignore_docs
     def __init__(
         self,
         token: Optional[str] = None,

--- a/src/apify_client/clients/base/base_client.py
+++ b/src/apify_client/clients/base/base_client.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from ..._http_client import _HTTPClient, _HTTPClientAsync
 from ..._logging import _WithLogDetailsClient
-from ..._utils import _to_safe_id
+from ..._utils import _to_safe_id, ignore_docs
 
 # Conditional import only executed when type checking, otherwise we'd get circular dependency issues
 if TYPE_CHECKING:
@@ -49,6 +49,7 @@ class BaseClient(_BaseBaseClient):
     http_client: _HTTPClient
     root_client: ApifyClient
 
+    @ignore_docs
     def __init__(
         self,
         *,
@@ -90,6 +91,7 @@ class BaseClientAsync(_BaseBaseClient):
     http_client: _HTTPClientAsync
     root_client: ApifyClientAsync
 
+    @ignore_docs
     def __init__(
         self,
         *,

--- a/src/apify_client/clients/resource_clients/actor.py
+++ b/src/apify_client/clients/resource_clients/actor.py
@@ -7,6 +7,7 @@ from ..._utils import (
     _maybe_extract_enum_member_value,
     _parse_date_fields,
     _pluck_data,
+    ignore_docs,
 )
 from ...consts import ActorJobStatus, MetaOrigin
 from ..base import ResourceClient, ResourceClientAsync
@@ -64,6 +65,7 @@ def _get_actor_representation(
 class ActorClient(ResourceClient):
     """Sub-client for manipulating a single actor."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the ActorClient."""
         resource_path = kwargs.pop('resource_path', 'acts')
@@ -351,6 +353,7 @@ class ActorClient(ResourceClient):
 class ActorClientAsync(ResourceClientAsync):
     """Async sub-client for manipulating a single actor."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the ActorClientAsync."""
         resource_path = kwargs.pop('resource_path', 'acts')

--- a/src/apify_client/clients/resource_clients/actor_collection.py
+++ b/src/apify_client/clients/resource_clients/actor_collection.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from ..._utils import ListPage, _filter_out_none_values_recursively
+from ..._utils import ListPage, _filter_out_none_values_recursively, ignore_docs
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 from .actor import _get_actor_representation
 
@@ -8,6 +8,7 @@ from .actor import _get_actor_representation
 class ActorCollectionClient(ResourceCollectionClient):
     """Sub-client for manipulating actors."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the ActorCollectionClient."""
         resource_path = kwargs.pop('resource_path', 'acts')
@@ -106,6 +107,7 @@ class ActorCollectionClient(ResourceCollectionClient):
 class ActorCollectionClientAsync(ResourceCollectionClientAsync):
     """Async sub-client for manipulating actors."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the ActorCollectionClientAsync."""
         resource_path = kwargs.pop('resource_path', 'acts')

--- a/src/apify_client/clients/resource_clients/actor_env_var.py
+++ b/src/apify_client/clients/resource_clients/actor_env_var.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import _filter_out_none_values_recursively
+from ..._utils import _filter_out_none_values_recursively, ignore_docs
 from ..base import ResourceClient, ResourceClientAsync
 
 
@@ -20,6 +20,7 @@ def _get_actor_env_var_representation(
 class ActorEnvVarClient(ResourceClient):
     """Sub-client for manipulating a single actor environment variable."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the ActorEnvVarClient."""
         resource_path = kwargs.pop('resource_path', 'env-vars')
@@ -73,6 +74,7 @@ class ActorEnvVarClient(ResourceClient):
 class ActorEnvVarClientAsync(ResourceClientAsync):
     """Async sub-client for manipulating a single actor environment variable."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the ActorEnvVarClientAsync."""
         resource_path = kwargs.pop('resource_path', 'env-vars')

--- a/src/apify_client/clients/resource_clients/actor_env_var_collection.py
+++ b/src/apify_client/clients/resource_clients/actor_env_var_collection.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import ListPage, _filter_out_none_values_recursively
+from ..._utils import ListPage, _filter_out_none_values_recursively, ignore_docs
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 from .actor_env_var import _get_actor_env_var_representation
 
@@ -8,6 +8,7 @@ from .actor_env_var import _get_actor_env_var_representation
 class ActorEnvVarCollectionClient(ResourceCollectionClient):
     """Sub-client for manipulating actor env vars."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the ActorEnvVarCollectionClient with the passed arguments."""
         resource_path = kwargs.pop('resource_path', 'env-vars')
@@ -54,6 +55,7 @@ class ActorEnvVarCollectionClient(ResourceCollectionClient):
 class ActorEnvVarCollectionClientAsync(ResourceCollectionClientAsync):
     """Async sub-client for manipulating actor env vars."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the ActorEnvVarCollectionClientAsync with the passed arguments."""
         resource_path = kwargs.pop('resource_path', 'env-vars')

--- a/src/apify_client/clients/resource_clients/actor_version.py
+++ b/src/apify_client/clients/resource_clients/actor_version.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from ..._utils import _filter_out_none_values_recursively, _maybe_extract_enum_member_value
+from ..._utils import _filter_out_none_values_recursively, _maybe_extract_enum_member_value, ignore_docs
 from ...consts import ActorSourceType
 from ..base import ResourceClient, ResourceClientAsync
 from .actor_env_var import ActorEnvVarClient, ActorEnvVarClientAsync
@@ -35,6 +35,7 @@ def _get_actor_version_representation(
 class ActorVersionClient(ResourceClient):
     """Sub-client for manipulating a single actor version."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the ActorVersionClient."""
         resource_path = kwargs.pop('resource_path', 'versions')
@@ -124,6 +125,7 @@ class ActorVersionClient(ResourceClient):
 class ActorVersionClientAsync(ResourceClientAsync):
     """Async sub-client for manipulating a single actor version."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the ActorVersionClientAsync."""
         resource_path = kwargs.pop('resource_path', 'versions')

--- a/src/apify_client/clients/resource_clients/actor_version_collection.py
+++ b/src/apify_client/clients/resource_clients/actor_version_collection.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from ..._utils import ListPage, _filter_out_none_values_recursively
+from ..._utils import ListPage, _filter_out_none_values_recursively, ignore_docs
 from ...consts import ActorSourceType
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 from .actor_version import _get_actor_version_representation
@@ -9,6 +9,7 @@ from .actor_version import _get_actor_version_representation
 class ActorVersionCollectionClient(ResourceCollectionClient):
     """Sub-client for manipulating actor versions."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the ActorVersionCollectionClient with the passed arguments."""
         resource_path = kwargs.pop('resource_path', 'versions')
@@ -79,6 +80,7 @@ class ActorVersionCollectionClient(ResourceCollectionClient):
 class ActorVersionCollectionClientAsync(ResourceCollectionClientAsync):
     """Async sub-client for manipulating actor versions."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the ActorVersionCollectionClientAsync with the passed arguments."""
         resource_path = kwargs.pop('resource_path', 'versions')

--- a/src/apify_client/clients/resource_clients/build.py
+++ b/src/apify_client/clients/resource_clients/build.py
@@ -1,11 +1,13 @@
 from typing import Any, Dict, Optional
 
+from ..._utils import ignore_docs
 from ..base import ActorJobBaseClient, ActorJobBaseClientAsync
 
 
 class BuildClient(ActorJobBaseClient):
     """Sub-client for manipulating a single actor build."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the BuildClient."""
         resource_path = kwargs.pop('resource_path', 'actor-builds')
@@ -47,6 +49,7 @@ class BuildClient(ActorJobBaseClient):
 class BuildClientAsync(ActorJobBaseClientAsync):
     """Async sub-client for manipulating a single actor build."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the BuildClientAsync."""
         resource_path = kwargs.pop('resource_path', 'actor-builds')

--- a/src/apify_client/clients/resource_clients/build_collection.py
+++ b/src/apify_client/clients/resource_clients/build_collection.py
@@ -1,12 +1,13 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import ListPage
+from ..._utils import ListPage, ignore_docs
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 
 
 class BuildCollectionClient(ResourceCollectionClient):
     """Sub-client for listing actor builds."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the BuildCollectionClient."""
         resource_path = kwargs.pop('resource_path', 'actor-builds')
@@ -38,6 +39,7 @@ class BuildCollectionClient(ResourceCollectionClient):
 class BuildCollectionClientAsync(ResourceCollectionClientAsync):
     """Async sub-client for listing actor builds."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the BuildCollectionClientAsync."""
         resource_path = kwargs.pop('resource_path', 'actor-builds')

--- a/src/apify_client/clients/resource_clients/dataset.py
+++ b/src/apify_client/clients/resource_clients/dataset.py
@@ -5,13 +5,14 @@ from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
 import httpx
 
 from ..._types import JSONSerializable
-from ..._utils import ListPage, _filter_out_none_values_recursively
+from ..._utils import ListPage, _filter_out_none_values_recursively, ignore_docs
 from ..base import ResourceClient, ResourceClientAsync
 
 
 class DatasetClient(ResourceClient):
     """Sub-client for manipulating a single dataset."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the DatasetClient."""
         resource_path = kwargs.pop('resource_path', 'datasets')
@@ -503,6 +504,7 @@ class DatasetClient(ResourceClient):
 class DatasetClientAsync(ResourceClientAsync):
     """Async sub-client for manipulating a single dataset."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the DatasetClientAsync."""
         resource_path = kwargs.pop('resource_path', 'datasets')

--- a/src/apify_client/clients/resource_clients/dataset_collection.py
+++ b/src/apify_client/clients/resource_clients/dataset_collection.py
@@ -1,12 +1,13 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import ListPage, _filter_out_none_values_recursively
+from ..._utils import ListPage, _filter_out_none_values_recursively, ignore_docs
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 
 
 class DatasetCollectionClient(ResourceCollectionClient):
     """Sub-client for manipulating datasets."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the DatasetCollectionClient with the passed arguments."""
         resource_path = kwargs.pop('resource_path', 'datasets')
@@ -53,6 +54,7 @@ class DatasetCollectionClient(ResourceCollectionClient):
 class DatasetCollectionClientAsync(ResourceCollectionClientAsync):
     """Async sub-client for manipulating datasets."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the DatasetCollectionClientAsync with the passed arguments."""
         resource_path = kwargs.pop('resource_path', 'datasets')

--- a/src/apify_client/clients/resource_clients/key_value_store.py
+++ b/src/apify_client/clients/resource_clients/key_value_store.py
@@ -9,6 +9,7 @@ from ..._utils import (
     _filter_out_none_values_recursively,
     _parse_date_fields,
     _pluck_data,
+    ignore_docs,
 )
 from ..base import ResourceClient, ResourceClientAsync
 
@@ -16,6 +17,7 @@ from ..base import ResourceClient, ResourceClientAsync
 class KeyValueStoreClient(ResourceClient):
     """Sub-client for manipulating a single key-value store."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the KeyValueStoreClient."""
         resource_path = kwargs.pop('resource_path', 'key-value-stores')
@@ -244,6 +246,7 @@ class KeyValueStoreClient(ResourceClient):
 class KeyValueStoreClientAsync(ResourceClientAsync):
     """Async sub-client for manipulating a single key-value store."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the KeyValueStoreClientAsync."""
         resource_path = kwargs.pop('resource_path', 'key-value-stores')

--- a/src/apify_client/clients/resource_clients/key_value_store_collection.py
+++ b/src/apify_client/clients/resource_clients/key_value_store_collection.py
@@ -1,12 +1,13 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import ListPage, _filter_out_none_values_recursively
+from ..._utils import ListPage, _filter_out_none_values_recursively, ignore_docs
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 
 
 class KeyValueStoreCollectionClient(ResourceCollectionClient):
     """Sub-client for manipulating key-value stores."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the KeyValueStoreCollectionClient with the passed arguments."""
         resource_path = kwargs.pop('resource_path', 'key-value-stores')
@@ -53,6 +54,7 @@ class KeyValueStoreCollectionClient(ResourceCollectionClient):
 class KeyValueStoreCollectionClientAsync(ResourceCollectionClientAsync):
     """Async sub-client for manipulating key-value stores."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the KeyValueStoreCollectionClientAsync with the passed arguments."""
         resource_path = kwargs.pop('resource_path', 'key-value-stores')

--- a/src/apify_client/clients/resource_clients/log.py
+++ b/src/apify_client/clients/resource_clients/log.py
@@ -4,13 +4,14 @@ from typing import Any, AsyncIterator, Iterator, Optional
 import httpx
 
 from ..._errors import ApifyApiError
-from ..._utils import _catch_not_found_or_throw
+from ..._utils import _catch_not_found_or_throw, ignore_docs
 from ..base import ResourceClient, ResourceClientAsync
 
 
 class LogClient(ResourceClient):
     """Sub-client for manipulating logs."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the LogClient."""
         resource_path = kwargs.pop('resource_path', 'logs')
@@ -92,6 +93,7 @@ class LogClient(ResourceClient):
 class LogClientAsync(ResourceClientAsync):
     """Async sub-client for manipulating logs."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the LogClientAsync."""
         resource_path = kwargs.pop('resource_path', 'logs')

--- a/src/apify_client/clients/resource_clients/request_queue.py
+++ b/src/apify_client/clients/resource_clients/request_queue.py
@@ -1,13 +1,14 @@
 from typing import Any, Dict, Optional
 
 from ..._errors import ApifyApiError
-from ..._utils import _catch_not_found_or_throw, _filter_out_none_values_recursively, _parse_date_fields, _pluck_data
+from ..._utils import _catch_not_found_or_throw, _filter_out_none_values_recursively, _parse_date_fields, _pluck_data, ignore_docs
 from ..base import ResourceClient, ResourceClientAsync
 
 
 class RequestQueueClient(ResourceClient):
     """Sub-client for manipulating a single request queue."""
 
+    @ignore_docs
     def __init__(self, *args: Any, client_key: Optional[str] = None, **kwargs: Any) -> None:
         """Initialize the RequestQueueClient.
 
@@ -173,6 +174,7 @@ class RequestQueueClient(ResourceClient):
 class RequestQueueClientAsync(ResourceClientAsync):
     """Async sub-client for manipulating a single request queue."""
 
+    @ignore_docs
     def __init__(self, *args: Any, client_key: Optional[str] = None, **kwargs: Any) -> None:
         """Initialize the RequestQueueClientAsync.
 

--- a/src/apify_client/clients/resource_clients/request_queue_collection.py
+++ b/src/apify_client/clients/resource_clients/request_queue_collection.py
@@ -1,12 +1,13 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import ListPage
+from ..._utils import ListPage, ignore_docs
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 
 
 class RequestQueueCollectionClient(ResourceCollectionClient):
     """Sub-client for manipulating request queues."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the RequestQueueCollectionClient with the passed arguments."""
         resource_path = kwargs.pop('resource_path', 'request-queues')
@@ -52,6 +53,7 @@ class RequestQueueCollectionClient(ResourceCollectionClient):
 class RequestQueueCollectionClientAsync(ResourceCollectionClientAsync):
     """Async sub-client for manipulating request queues."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the RequestQueueCollectionClientAsync with the passed arguments."""
         resource_path = kwargs.pop('resource_path', 'request-queues')

--- a/src/apify_client/clients/resource_clients/run.py
+++ b/src/apify_client/clients/resource_clients/run.py
@@ -1,6 +1,13 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import _encode_key_value_store_record_value, _filter_out_none_values_recursively, _parse_date_fields, _pluck_data, _to_safe_id
+from ..._utils import (
+    _encode_key_value_store_record_value,
+    _filter_out_none_values_recursively,
+    _parse_date_fields,
+    _pluck_data,
+    _to_safe_id,
+    ignore_docs,
+)
 from ..base import ActorJobBaseClient, ActorJobBaseClientAsync
 from .dataset import DatasetClient, DatasetClientAsync
 from .key_value_store import KeyValueStoreClient, KeyValueStoreClientAsync
@@ -11,6 +18,7 @@ from .request_queue import RequestQueueClient, RequestQueueClientAsync
 class RunClient(ActorJobBaseClient):
     """Sub-client for manipulating a single actor run."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the RunClient."""
         resource_path = kwargs.pop('resource_path', 'actor-runs')
@@ -182,6 +190,7 @@ class RunClient(ActorJobBaseClient):
 class RunClientAsync(ActorJobBaseClientAsync):
     """Async sub-client for manipulating a single actor run."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the RunClientAsync."""
         resource_path = kwargs.pop('resource_path', 'actor-runs')

--- a/src/apify_client/clients/resource_clients/run_collection.py
+++ b/src/apify_client/clients/resource_clients/run_collection.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import ListPage, _maybe_extract_enum_member_value
+from ..._utils import ListPage, _maybe_extract_enum_member_value, ignore_docs
 from ...consts import ActorJobStatus
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 
@@ -8,6 +8,7 @@ from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 class RunCollectionClient(ResourceCollectionClient):
     """Sub-client for listing actor runs."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the RunCollectionClient."""
         resource_path = kwargs.pop('resource_path', 'actor-runs')
@@ -47,6 +48,7 @@ class RunCollectionClient(ResourceCollectionClient):
 class RunCollectionClientAsync(ResourceCollectionClientAsync):
     """Async sub-client for listing actor runs."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the RunCollectionClientAsync."""
         resource_path = kwargs.pop('resource_path', 'actor-runs')

--- a/src/apify_client/clients/resource_clients/schedule.py
+++ b/src/apify_client/clients/resource_clients/schedule.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional
 
 from ..._errors import ApifyApiError
-from ..._utils import _catch_not_found_or_throw, _filter_out_none_values_recursively, _pluck_data_as_list
+from ..._utils import _catch_not_found_or_throw, _filter_out_none_values_recursively, _pluck_data_as_list, ignore_docs
 from ..base import ResourceClient, ResourceClientAsync
 
 
@@ -30,6 +30,7 @@ def _get_schedule_representation(
 class ScheduleClient(ResourceClient):
     """Sub-client for manipulating a single schedule."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the ScheduleClient."""
         resource_path = kwargs.pop('resource_path', 'schedules')
@@ -119,6 +120,7 @@ class ScheduleClient(ResourceClient):
 class ScheduleClientAsync(ResourceClientAsync):
     """Async sub-client for manipulating a single schedule."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the ScheduleClientAsync."""
         resource_path = kwargs.pop('resource_path', 'schedules')

--- a/src/apify_client/clients/resource_clients/schedule_collection.py
+++ b/src/apify_client/clients/resource_clients/schedule_collection.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from ..._utils import ListPage, _filter_out_none_values_recursively
+from ..._utils import ListPage, _filter_out_none_values_recursively, ignore_docs
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 from .schedule import _get_schedule_representation
 
@@ -8,6 +8,7 @@ from .schedule import _get_schedule_representation
 class ScheduleCollectionClient(ResourceCollectionClient):
     """Sub-client for manipulating schedules."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the ScheduleCollectionClient with the passed arguments."""
         resource_path = kwargs.pop('resource_path', 'schedules')
@@ -83,6 +84,7 @@ class ScheduleCollectionClient(ResourceCollectionClient):
 class ScheduleCollectionClientAsync(ResourceCollectionClientAsync):
     """Async sub-client for manipulating schedules."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the ScheduleCollectionClientAsync with the passed arguments."""
         resource_path = kwargs.pop('resource_path', 'schedules')

--- a/src/apify_client/clients/resource_clients/task.py
+++ b/src/apify_client/clients/resource_clients/task.py
@@ -8,6 +8,7 @@ from ..._utils import (
     _maybe_extract_enum_member_value,
     _parse_date_fields,
     _pluck_data,
+    ignore_docs,
 )
 from ...consts import ActorJobStatus, MetaOrigin
 from ..base import ResourceClient, ResourceClientAsync
@@ -41,6 +42,7 @@ def _get_task_representation(
 class TaskClient(ResourceClient):
     """Sub-client for manipulating a single task."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the TaskClient."""
         resource_path = kwargs.pop('resource_path', 'actor-tasks')
@@ -263,6 +265,7 @@ class TaskClient(ResourceClient):
 class TaskClientAsync(ResourceClientAsync):
     """Async sub-client for manipulating a single task."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the TaskClientAsync."""
         resource_path = kwargs.pop('resource_path', 'actor-tasks')

--- a/src/apify_client/clients/resource_clients/task_collection.py
+++ b/src/apify_client/clients/resource_clients/task_collection.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import ListPage, _filter_out_none_values_recursively
+from ..._utils import ListPage, _filter_out_none_values_recursively, ignore_docs
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 from .task import _get_task_representation
 
@@ -8,6 +8,7 @@ from .task import _get_task_representation
 class TaskCollectionClient(ResourceCollectionClient):
     """Sub-client for manipulating tasks."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the TaskCollectionClient."""
         resource_path = kwargs.pop('resource_path', 'actor-tasks')
@@ -79,6 +80,7 @@ class TaskCollectionClient(ResourceCollectionClient):
 class TaskCollectionClientAsync(ResourceCollectionClientAsync):
     """Async sub-client for manipulating tasks."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the TaskCollectionClientAsync."""
         resource_path = kwargs.pop('resource_path', 'actor-tasks')

--- a/src/apify_client/clients/resource_clients/user.py
+++ b/src/apify_client/clients/resource_clients/user.py
@@ -1,11 +1,13 @@
 from typing import Any, Dict, Optional
 
+from ..._utils import ignore_docs
 from ..base import ResourceClient, ResourceClientAsync
 
 
 class UserClient(ResourceClient):
     """Sub-client for querying user data."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the UserClient."""
         resource_id = kwargs.pop('resource_id', None)
@@ -30,6 +32,7 @@ class UserClient(ResourceClient):
 class UserClientAsync(ResourceClientAsync):
     """Async sub-client for querying user data."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the UserClientAsync."""
         resource_id = kwargs.pop('resource_id', None)

--- a/src/apify_client/clients/resource_clients/webhook.py
+++ b/src/apify_client/clients/resource_clients/webhook.py
@@ -7,6 +7,7 @@ from ..._utils import (
     _maybe_extract_enum_member_value,
     _parse_date_fields,
     _pluck_data,
+    ignore_docs,
 )
 from ...consts import WebhookEventType
 from ..base import ResourceClient, ResourceClientAsync
@@ -53,6 +54,7 @@ def _get_webhook_representation(
 class WebhookClient(ResourceClient):
     """Sub-client for manipulating a single webhook."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the WebhookClient."""
         resource_path = kwargs.pop('resource_path', 'webhooks')
@@ -162,6 +164,7 @@ class WebhookClient(ResourceClient):
 class WebhookClientAsync(ResourceClientAsync):
     """Async sub-client for manipulating a single webhook."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the WebhookClientAsync."""
         resource_path = kwargs.pop('resource_path', 'webhooks')

--- a/src/apify_client/clients/resource_clients/webhook_collection.py
+++ b/src/apify_client/clients/resource_clients/webhook_collection.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional
 
 from apify_client.consts import WebhookEventType
 
-from ..._utils import ListPage, _filter_out_none_values_recursively
+from ..._utils import ListPage, _filter_out_none_values_recursively, ignore_docs
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 from .webhook import _get_webhook_representation
 
@@ -10,6 +10,7 @@ from .webhook import _get_webhook_representation
 class WebhookCollectionClient(ResourceCollectionClient):
     """Sub-client for manipulating webhooks."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the WebhookCollectionClient."""
         resource_path = kwargs.pop('resource_path', 'webhooks')
@@ -93,6 +94,7 @@ class WebhookCollectionClient(ResourceCollectionClient):
 class WebhookCollectionClientAsync(ResourceCollectionClientAsync):
     """Async sub-client for manipulating webhooks."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the WebhookCollectionClientAsync."""
         resource_path = kwargs.pop('resource_path', 'webhooks')

--- a/src/apify_client/clients/resource_clients/webhook_dispatch.py
+++ b/src/apify_client/clients/resource_clients/webhook_dispatch.py
@@ -1,11 +1,13 @@
 from typing import Any, Dict, Optional
 
+from ..._utils import ignore_docs
 from ..base import ResourceClient, ResourceClientAsync
 
 
 class WebhookDispatchClient(ResourceClient):
     """Sub-client for querying information about a webhook dispatch."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the WebhookDispatchClient."""
         resource_path = kwargs.pop('resource_path', 'webhook-dispatches')
@@ -25,6 +27,7 @@ class WebhookDispatchClient(ResourceClient):
 class WebhookDispatchClientAsync(ResourceClientAsync):
     """Async sub-client for querying information about a webhook dispatch."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the WebhookDispatchClientAsync."""
         resource_path = kwargs.pop('resource_path', 'webhook-dispatches')

--- a/src/apify_client/clients/resource_clients/webhook_dispatch_collection.py
+++ b/src/apify_client/clients/resource_clients/webhook_dispatch_collection.py
@@ -1,12 +1,13 @@
 from typing import Any, Dict, Optional
 
-from ..._utils import ListPage
+from ..._utils import ListPage, ignore_docs
 from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
 
 
 class WebhookDispatchCollectionClient(ResourceCollectionClient):
     """Sub-client for listing webhook dispatches."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the WebhookDispatchCollectionClient."""
         resource_path = kwargs.pop('resource_path', 'webhook-dispatches')
@@ -37,6 +38,7 @@ class WebhookDispatchCollectionClient(ResourceCollectionClient):
 class WebhookDispatchCollectionClientAsync(ResourceCollectionClientAsync):
     """Async sub-client for listing webhook dispatches."""
 
+    @ignore_docs
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the WebhookDispatchCollectionClientAsync."""
         resource_path = kwargs.pop('resource_path', 'webhook-dispatches')

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -20,6 +20,7 @@ from apify_client._utils import (
     _retry_with_exp_backoff,
     _retry_with_exp_backoff_async,
     _to_safe_id,
+    ignore_docs,
 )
 from apify_client.consts import WebhookEventType
 
@@ -253,3 +254,11 @@ def test__filter_out_none_values_recursively_internal() -> None:
     assert _filter_out_none_values_recursively_internal({'k1': {}}, False) == {'k1': {}}
     assert _filter_out_none_values_recursively_internal({}, True) is None
     assert _filter_out_none_values_recursively_internal({'k1': {}}, True) is None
+
+
+def test_ignore_docs() -> None:
+    def testing_function(_a: str, _b: str) -> str:
+        """Dummy docstring"""
+        return 'dummy'
+
+    assert testing_function is ignore_docs(testing_function)


### PR DESCRIPTION
This adds an `ignore_docs` decorator, which does not do anything on its own, it just serves as a mark that we will use in the new documentation rendering to mark methods that we want to ignore there.

I've added it to all the `__init__` methods of all the classes except for `ApifyClient` and `ApifyClientAsync`, because those are the only two classes that we want users to actually create. All the other classes should not be constructed externally.