### PR TITLE
fix: allow newer versions of httpx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 
 requires-python = ">=3.8"
 dependencies = [
-    "httpx ~= 0.23.0"
+    "httpx >=0.23.0,<1.0.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
I've seen this clash with some libraries that want the newest version of httpx. The changelog is here https://github.com/encode/httpx/blob/master/CHANGELOG.md. Would it be possible to allow newer versions of httpx together with this awesome apify client? 🙏 