### PR TITLE
Add option to change run options when resurrecting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+[1.2.0](../../releases/tag/v1.2.0) - Unreleased
+
+### Added
+
+- added option to change the build, memory limit and timeout when resurrecting a run
+
 [1.1.1](../../releases/tag/v1.1.1) - 2023-05-05
 
 ### Internal changes

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -2078,7 +2078,7 @@ Transform an actor run into a run of another actor with a new input.
 
 ***
 
-#### [](#runclient-resurrect) `RunClient.resurrect()`
+#### [](#runclient-resurrect) `RunClient.resurrect(*, build=None, memory_mbytes=None, timeout_secs=None)`
 
 Resurrect a finished actor run.
 
@@ -2086,6 +2086,17 @@ Only finished runs, i.e. runs with status FINISHED, FAILED, ABORTED and TIMED-OU
 Run status will be updated to RUNNING and its container will be restarted with the same default storages.
 
 [https://docs.apify.com/api/v2#/reference/actor-runs/resurrect-run/resurrect-run](https://docs.apify.com/api/v2#/reference/actor-runs/resurrect-run/resurrect-run)
+
+* **Parameters**
+
+  * **build** (`str`, *optional*) – Which actor build the resurrected run should use. It can be either a build tag or build number.
+  By default, the resurrected run uses the same build as before.
+
+  * **memory_mbytes** (`int`, *optional*) – New memory limit for the resurrected run, in megabytes.
+  By default, the resurrected run uses the same memory limit as before.
+
+  * **timeout_secs** (`int`, *optional*) – New timeout for the resurrected run, in seconds.
+  By default, the resurrected run uses the same timeout as before.
 
 * **Returns**
 
@@ -4283,7 +4294,7 @@ Transform an actor run into a run of another actor with a new input.
 
 ***
 
-#### [](#runclientasync-resurrect) `async RunClientAsync.resurrect()`
+#### [](#runclientasync-resurrect) `async RunClientAsync.resurrect(*, build=None, memory_mbytes=None, timeout_secs=None)`
 
 Resurrect a finished actor run.
 
@@ -4291,6 +4302,17 @@ Only finished runs, i.e. runs with status FINISHED, FAILED, ABORTED and TIMED-OU
 Run status will be updated to RUNNING and its container will be restarted with the same default storages.
 
 [https://docs.apify.com/api/v2#/reference/actor-runs/resurrect-run/resurrect-run](https://docs.apify.com/api/v2#/reference/actor-runs/resurrect-run/resurrect-run)
+
+* **Parameters**
+
+  * **build** (`str`, *optional*) – Which actor build the resurrected run should use. It can be either a build tag or build number.
+  By default, the resurrected run uses the same build as before.
+
+  * **memory_mbytes** (`int`, *optional*) – New memory limit for the resurrected run, in megabytes.
+  By default, the resurrected run uses the same memory limit as before.
+
+  * **timeout_secs** (`int`, *optional*) – New timeout for the resurrected run, in seconds.
+  By default, the resurrected run uses the same timeout as before.
 
 * **Returns**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apify_client"
-version = "1.1.1"
+version = "1.2.0"
 description = "Apify API client for Python"
 readme = "README.md"
 license = {text = "Apache Software License"}

--- a/src/apify_client/clients/resource_clients/run.py
+++ b/src/apify_client/clients/resource_clients/run.py
@@ -121,7 +121,13 @@ class RunClient(ActorJobBaseClient):
 
         return _parse_date_fields(_pluck_data(response.json()))
 
-    def resurrect(self) -> Dict:
+    def resurrect(
+        self,
+        *,
+        build: Optional[str] = None,
+        memory_mbytes: Optional[int] = None,
+        timeout_secs: Optional[int] = None,
+    ) -> Dict:
         """Resurrect a finished actor run.
 
         Only finished runs, i.e. runs with status FINISHED, FAILED, ABORTED and TIMED-OUT can be resurrected.
@@ -129,13 +135,27 @@ class RunClient(ActorJobBaseClient):
 
         https://docs.apify.com/api/v2#/reference/actor-runs/resurrect-run/resurrect-run
 
+        Args:
+            build (str, optional): Which actor build the resurrected run should use. It can be either a build tag or build number.
+                                   By default, the resurrected run uses the same build as before.
+            memory_mbytes (int, optional): New memory limit for the resurrected run, in megabytes.
+                                           By default, the resurrected run uses the same memory limit as before.
+            timeout_secs (int, optional): New timeout for the resurrected run, in seconds.
+                                           By default, the resurrected run uses the same timeout as before.
+
         Returns:
             dict: The actor run data.
         """
+        request_params = self._params(
+            build=build,
+            memory=memory_mbytes,
+            timeout=timeout_secs,
+        )
+
         response = self.http_client.call(
             url=self._url('resurrect'),
             method='POST',
-            params=self._params(),
+            params=request_params,
         )
 
         return _parse_date_fields(_pluck_data(response.json()))
@@ -295,7 +315,13 @@ class RunClientAsync(ActorJobBaseClientAsync):
 
         return _parse_date_fields(_pluck_data(response.json()))
 
-    async def resurrect(self) -> Dict:
+    async def resurrect(
+        self,
+        *,
+        build: Optional[str] = None,
+        memory_mbytes: Optional[int] = None,
+        timeout_secs: Optional[int] = None,
+    ) -> Dict:
         """Resurrect a finished actor run.
 
         Only finished runs, i.e. runs with status FINISHED, FAILED, ABORTED and TIMED-OUT can be resurrected.
@@ -303,13 +329,27 @@ class RunClientAsync(ActorJobBaseClientAsync):
 
         https://docs.apify.com/api/v2#/reference/actor-runs/resurrect-run/resurrect-run
 
+        Args:
+            build (str, optional): Which actor build the resurrected run should use. It can be either a build tag or build number.
+                                   By default, the resurrected run uses the same build as before.
+            memory_mbytes (int, optional): New memory limit for the resurrected run, in megabytes.
+                                           By default, the resurrected run uses the same memory limit as before.
+            timeout_secs (int, optional): New timeout for the resurrected run, in seconds.
+                                           By default, the resurrected run uses the same timeout as before.
+
         Returns:
             dict: The actor run data.
         """
+        request_params = self._params(
+            build=build,
+            memory=memory_mbytes,
+            timeout=timeout_secs,
+        )
+
         response = await self.http_client.call(
             url=self._url('resurrect'),
             method='POST',
-            params=self._params(),
+            params=request_params,
         )
 
         return _parse_date_fields(_pluck_data(response.json()))


### PR DESCRIPTION
On the API, we support changing the run options (build, memory, timeout) when resurrecting it, but we didn't support it in the client. This adds it.