### PR TITLE
Fix encoding webhook lists in request parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+[1.2.2](../../releases/tag/v1.2.2) - 2023-05-31
+
+### Fixed
+
+- Fixed encoding webhook lists in request parameters
+
 [1.2.1](../../releases/tag/v1.2.1) - 2023-05-23
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apify_client"
-version = "1.2.1"
+version = "1.2.2"
 description = "Apify API client for Python"
 readme = "README.md"
 license = {text = "Apache Software License"}

--- a/src/apify_client/_utils.py
+++ b/src/apify_client/_utils.py
@@ -169,7 +169,7 @@ def _catch_not_found_or_throw(exc: 'ApifyApiError') -> None:
     return None
 
 
-def _encode_webhook_list_to_base64(webhooks: List[Dict]) -> bytes:
+def _encode_webhook_list_to_base64(webhooks: List[Dict]) -> str:
     """Encode a list of dictionaries representing webhooks to their base64-encoded representation for the API."""
     data = []
     for webhook in webhooks:
@@ -181,7 +181,7 @@ def _encode_webhook_list_to_base64(webhooks: List[Dict]) -> bytes:
             webhook_representation['payloadTemplate'] = webhook['payload_template']
         data.append(webhook_representation)
 
-    return base64.b64encode(json.dumps(data).encode('utf-8'))
+    return base64.b64encode(json.dumps(data).encode('utf-8')).decode('ascii')
 
 
 def _filter_out_none_values_recursively(dictionary: Dict) -> Dict:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -213,7 +213,7 @@ async def test__retry_with_exp_backoff_async() -> None:
 
 
 def test__encode_webhook_list_to_base64() -> None:
-    assert _encode_webhook_list_to_base64([]) == b'W10='
+    assert _encode_webhook_list_to_base64([]) == 'W10='
     assert _encode_webhook_list_to_base64([
         {
             'event_types': [WebhookEventType.ACTOR_RUN_CREATED],
@@ -224,7 +224,7 @@ def test__encode_webhook_list_to_base64() -> None:
             'request_url': 'https://example.com/run-succeeded',
             'payload_template': '{"hello": "world", "resource":{{resource}}}',
         },
-    ]) == b'W3siZXZlbnRUeXBlcyI6IFsiQUNUT1IuUlVOLkNSRUFURUQiXSwgInJlcXVlc3RVcmwiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9ydW4tY3JlYXRlZCJ9LCB7ImV2ZW50VHlwZXMiOiBbIkFDVE9SLlJVTi5TVUNDRUVERUQiXSwgInJlcXVlc3RVcmwiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9ydW4tc3VjY2VlZGVkIiwgInBheWxvYWRUZW1wbGF0ZSI6ICJ7XCJoZWxsb1wiOiBcIndvcmxkXCIsIFwicmVzb3VyY2VcIjp7e3Jlc291cmNlfX19In1d'  # noqa: E501
+    ]) == 'W3siZXZlbnRUeXBlcyI6IFsiQUNUT1IuUlVOLkNSRUFURUQiXSwgInJlcXVlc3RVcmwiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9ydW4tY3JlYXRlZCJ9LCB7ImV2ZW50VHlwZXMiOiBbIkFDVE9SLlJVTi5TVUNDRUVERUQiXSwgInJlcXVlc3RVcmwiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9ydW4tc3VjY2VlZGVkIiwgInBheWxvYWRUZW1wbGF0ZSI6ICJ7XCJoZWxsb1wiOiBcIndvcmxkXCIsIFwicmVzb3VyY2VcIjp7e3Jlc291cmNlfX19In1d'  # noqa: E501
 
 
 def test__maybe_extract_enum_member_value() -> None:


### PR DESCRIPTION
Webhooks could not be parsed on the API when sent base64-encoded as bytes, they need to be sent as string.