### PR TITLE
Add actor reboot method to the RunClient

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -2117,11 +2117,11 @@ Reboot an Actor run. Only runs that are running, i.e. runs with status RUNNING c
 
 * **Returns**
 
-  Details about the rebooted run.
+  The Actor run data.
 
 * **Return type**
 
-  `dics`
+  `dict`
 
 ***
 
@@ -4586,11 +4586,11 @@ Reboot an Actor run. Only runs that are running, i.e. runs with status RUNNING c
 
 * **Returns**
 
-  Details about the rebooted run.
+  The Actor run data.
 
 * **Return type**
 
-  `dics`
+  `dict`
 
 ***
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1964,6 +1964,7 @@ Sub-client for manipulating a single actor run.
 * [wait\_for\_finish()](#runclient-wait\_for\_finish)
 * [metamorph()](#runclient-metamorph)
 * [resurrect()](#runclient-resurrect)
+* [reboot()](#runclient-reboot)
 * [dataset()](#runclient-dataset)
 * [key\_value\_store()](#runclient-key\_value\_store)
 * [request\_queue()](#runclient-request\_queue)
@@ -2105,6 +2106,22 @@ Run status will be updated to RUNNING and its container will be restarted with t
 * **Return type**
 
   `dict`
+
+***
+
+#### [](#runclient-reboot) `RunClient.reboot()`
+
+Reboot an Actor run. Only runs that are running, i.e. runs with status RUNNING can be rebooted.
+
+[https://docs.apify.com/api/v2#/reference/actor-runs/reboot-run/reboot-run](https://docs.apify.com/api/v2#/reference/actor-runs/reboot-run/reboot-run)
+
+* **Returns**
+
+  Details about the rebooted run.
+
+* **Return type**
+
+  `dics`
 
 ***
 
@@ -4416,6 +4433,7 @@ Async sub-client for manipulating a single actor run.
 * [async wait\_for\_finish()](#runclientasync-wait\_for\_finish)
 * [async metamorph()](#runclientasync-metamorph)
 * [async resurrect()](#runclientasync-resurrect)
+* [async reboot()](#runclientasync-reboot)
 * [dataset()](#runclientasync-dataset)
 * [key\_value\_store()](#runclientasync-key\_value\_store)
 * [request\_queue()](#runclientasync-request\_queue)
@@ -4557,6 +4575,22 @@ Run status will be updated to RUNNING and its container will be restarted with t
 * **Return type**
 
   `dict`
+
+***
+
+#### [](#runclientasync-reboot) `async RunClientAsync.reboot()`
+
+Reboot an Actor run. Only runs that are running, i.e. runs with status RUNNING can be rebooted.
+
+[https://docs.apify.com/api/v2#/reference/actor-runs/reboot-run/reboot-run](https://docs.apify.com/api/v2#/reference/actor-runs/reboot-run/reboot-run)
+
+* **Returns**
+
+  Details about the rebooted run.
+
+* **Return type**
+
+  `dics`
 
 ***
 

--- a/src/apify_client/clients/base/actor_job_base_client.py
+++ b/src/apify_client/clients/base/actor_job_base_client.py
@@ -73,13 +73,6 @@ class ActorJobBaseClient(ResourceClient):
         )
         return parse_date_fields(_pluck_data(response.json()))
 
-    def _reboot(self) -> Dict:
-        response = self.http_client.call(
-            url=self._url('reboot'),
-            method='POST',
-        )
-        return parse_date_fields(_pluck_data(response.json()))
-
 
 @ignore_docs
 class ActorJobBaseClientAsync(ResourceClientAsync):
@@ -134,12 +127,5 @@ class ActorJobBaseClientAsync(ResourceClientAsync):
             params=self._params(
                 gracefully=gracefully,
             ),
-        )
-        return parse_date_fields(_pluck_data(response.json()))
-
-    async def _reboot(self) -> Dict:
-        response = await self.http_client.call(
-            url=self._url('reboot'),
-            method='POST',
         )
         return parse_date_fields(_pluck_data(response.json()))

--- a/src/apify_client/clients/base/actor_job_base_client.py
+++ b/src/apify_client/clients/base/actor_job_base_client.py
@@ -73,6 +73,13 @@ class ActorJobBaseClient(ResourceClient):
         )
         return parse_date_fields(_pluck_data(response.json()))
 
+    def _reboot(self) -> Dict:
+        response = self.http_client.call(
+            url=self._url('reboot'),
+            method='POST',
+        )
+        return parse_date_fields(_pluck_data(response.json()))
+
 
 @ignore_docs
 class ActorJobBaseClientAsync(ResourceClientAsync):
@@ -127,5 +134,12 @@ class ActorJobBaseClientAsync(ResourceClientAsync):
             params=self._params(
                 gracefully=gracefully,
             ),
+        )
+        return parse_date_fields(_pluck_data(response.json()))
+
+    async def _reboot(self) -> Dict:
+        response = await self.http_client.call(
+            url=self._url('reboot'),
+            method='POST',
         )
         return parse_date_fields(_pluck_data(response.json()))

--- a/src/apify_client/clients/resource_clients/run.py
+++ b/src/apify_client/clients/resource_clients/run.py
@@ -163,7 +163,11 @@ class RunClient(ActorJobBaseClient):
         Returns:
             dict: The Actor run data.
         """
-        return self._reboot()
+        response = self.http_client.call(
+            url=self._url('reboot'),
+            method='POST',
+        )
+        return parse_date_fields(_pluck_data(response.json()))
 
     def dataset(self) -> DatasetClient:
         """Get the client for the default dataset of the actor run.
@@ -365,9 +369,13 @@ class RunClientAsync(ActorJobBaseClientAsync):
         https://docs.apify.com/api/v2#/reference/actor-runs/reboot-run/reboot-run
 
         Returns:
-            dics: Details about the rebooted run.
+            dict: The Actor run data.
         """
-        return await self._reboot()
+        response = await self.http_client.call(
+            url=self._url('reboot'),
+            method='POST',
+        )
+        return parse_date_fields(_pluck_data(response.json()))
 
     def dataset(self) -> DatasetClientAsync:
         """Get the client for the default dataset of the actor run.

--- a/src/apify_client/clients/resource_clients/run.py
+++ b/src/apify_client/clients/resource_clients/run.py
@@ -161,7 +161,7 @@ class RunClient(ActorJobBaseClient):
         https://docs.apify.com/api/v2#/reference/actor-runs/reboot-run/reboot-run
 
         Returns:
-            dics: Details about the rebooted run.
+            dict: The Actor run data.
         """
         return self._reboot()
 

--- a/src/apify_client/clients/resource_clients/run.py
+++ b/src/apify_client/clients/resource_clients/run.py
@@ -155,6 +155,16 @@ class RunClient(ActorJobBaseClient):
 
         return parse_date_fields(_pluck_data(response.json()))
 
+    def reboot(self) -> Dict:
+        """Reboot an Actor run. Only runs that are running, i.e. runs with status RUNNING can be rebooted.
+
+        https://docs.apify.com/api/v2#/reference/actor-runs/reboot-run/reboot-run
+
+        Returns:
+            dics: Details about the rebooted run.
+        """
+        return self._reboot()
+
     def dataset(self) -> DatasetClient:
         """Get the client for the default dataset of the actor run.
 
@@ -348,6 +358,16 @@ class RunClientAsync(ActorJobBaseClientAsync):
         )
 
         return parse_date_fields(_pluck_data(response.json()))
+
+    async def reboot(self) -> Dict:
+        """Reboot an Actor run. Only runs that are running, i.e. runs with status RUNNING can be rebooted.
+
+        https://docs.apify.com/api/v2#/reference/actor-runs/reboot-run/reboot-run
+
+        Returns:
+            dics: Details about the rebooted run.
+        """
+        return await self._reboot()
 
     def dataset(self) -> DatasetClientAsync:
         """Get the client for the default dataset of the actor run.


### PR DESCRIPTION
### Ticket

- Closes #137

### Description

- I implement the reboot method in the same way as other methods calling endpoints (e.g. abort).

### Test plan

- @fnesveda, @jirimoravcik: guys could you please give me some advice on how could I test it?

I tried the following: Get the object of type `RunClient` using the `last_run()` method called on the specific Actor. And then call on it the `reboot()` method...

```python
from src.apify_client import ApifyClient

# https://console.apify.com/account/integrations
API_TOKEN = 'todo'

# https://apify.com/vdusek/beautifulsoup-scraper
ACTOR_ID = 'apify/beautifulsoup-scraper'

apify_client = ApifyClient(API_TOKEN)
print(apify_client)

actor_client = apify_client.actor(ACTOR_ID)
print(actor_client)

last_run = actor_client.last_run()
print(last_run)

result = last_run.reboot()
print(result)
```

However, it does not work, and I got the unknown URL exception (full traceback below). The example of created URL: `https://api.apify.com/v2/acts/apify~beautifulsoup-scraper/runs/last`. 

Could please guide me on how could I get the instance of `RunClient` from which I'll be able to call the reboot method? For example, I know I can access the `runId` like this `last_run.get()['id']` but I have no idea how or where should I provide it. Thanks.

Full traceback:

```
Traceback (most recent call last):
  File "/home/vdusek/Apify/apify-client-python/run.py", line 19, in <module>
    result = last_run.reboot()
             ^^^^^^^^^^^^^^^^^
  File "/home/vdusek/Apify/apify-client-python/src/apify_client/_logging.py", line 68, in wrapper
    return fun(resource_client, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vdusek/Apify/apify-client-python/src/apify_client/clients/resource_clients/run.py", line 166, in reboot
    return self._reboot()
           ^^^^^^^^^^^^^^
  File "/home/vdusek/Apify/apify-client-python/src/apify_client/clients/base/actor_job_base_client.py", line 78, in _reboot
    response = self.http_client.call(
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vdusek/Apify/apify-client-python/src/apify_client/_http_client.py", line 185, in call
    return _retry_with_exp_backoff(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vdusek/Apify/apify-client-python/src/apify_client/_utils.py", line 66, in _retry_with_exp_backoff
    raise e
  File "/home/vdusek/Apify/apify-client-python/src/apify_client/_utils.py", line 63, in _retry_with_exp_backoff
    return func(stop_retrying, attempt)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vdusek/Apify/apify-client-python/src/apify_client/_http_client.py", line 183, in _make_request
    raise ApifyApiError(response, attempt)
src.apify_client._errors.ApifyApiError: We have bad news: there is no API endpoint at this URL. Did you specify it correctly?
```

Edit: updated test script

```python
from src.apify_client import ApifyClient

API_TOKEN = 'todo'
ACTOR_ID = 'apify/beautifulsoup-scraper'
apify_client = ApifyClient(API_TOKEN)
actor_client = apify_client.actor(ACTOR_ID)
last_run = actor_client.last_run()
run_id = last_run.get()['id']
result = apify_client.run(run_id).reboot()
print(result)
```