### PR TITLE
Add support for specifying the `max_items` parameter for pay-per result Actors and their runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Changelog
 [1.4.1](../../releases/tag/v1.4.1) - Unreleased
 -----------------------------------------------
 
+### Added
+
+- support for specifying the `max_items` parameter for pay-per result Actors and their runs
+
 ### Internal changes
 
 - Improved logging of HTTP requests

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -885,7 +885,7 @@ Retrieve the actor.
 
 ***
 
-#### [](#actorclient-update) `ActorClient.update(*, name=None, title=None, description=None, seo_title=None, seo_description=None, versions=None, restart_on_error=None, is_public=None, is_deprecated=None, is_anonymously_runnable=None, categories=None, default_run_build=None, default_run_memory_mbytes=None, default_run_timeout_secs=None, example_run_input_body=None, example_run_input_content_type=None)`
+#### [](#actorclient-update) `ActorClient.update(*, name=None, title=None, description=None, seo_title=None, seo_description=None, versions=None, restart_on_error=None, is_public=None, is_deprecated=None, is_anonymously_runnable=None, categories=None, default_run_build=None, default_run_max_items=None, default_run_memory_mbytes=None, default_run_timeout_secs=None, example_run_input_body=None, example_run_input_content_type=None)`
 
 Update the actor with the specified fields.
 
@@ -917,6 +917,9 @@ Update the actor with the specified fields.
 
   * **default_run_build** (`str`, *optional*) – Tag or number of the build that you want to run by default.
 
+  * **default_run_max_items** (`int`, *optional*) – Default limit of the number of results that will be returned by runs of this Actor,
+  if the Actor is charged per result.
+
   * **default_run_memory_mbytes** (`int`, *optional*) – Default amount of memory allocated for the runs of this actor, in megabytes.
 
   * **default_run_timeout_secs** (`int`, *optional*) – Default timeout for the runs of this actor in seconds.
@@ -947,7 +950,7 @@ Delete the actor.
 
 ***
 
-#### [](#actorclient-start) `ActorClient.start(*, run_input=None, content_type=None, build=None, memory_mbytes=None, timeout_secs=None, wait_for_finish=None, webhooks=None)`
+#### [](#actorclient-start) `ActorClient.start(*, run_input=None, content_type=None, build=None, max_items=None, memory_mbytes=None, timeout_secs=None, wait_for_finish=None, webhooks=None)`
 
 Start the actor and immediately return the Run object.
 
@@ -961,6 +964,9 @@ Start the actor and immediately return the Run object.
 
   * **build** (`str`, *optional*) – Specifies the actor build to run. It can be either a build tag or build number.
   By default, the run uses the build specified in the default run configuration for the actor (typically latest).
+
+  * **max_items** (`int`, *optional*) – Maximum number of results that will be returned by this run.
+  If the Actor is charged per result, you will not be charged for more results than the given limit.
 
   * **memory_mbytes** (`int`, *optional*) – Memory limit for the run, in megabytes.
   By default, the run uses a memory limit specified in the default run configuration for the actor.
@@ -990,7 +996,7 @@ Start the actor and immediately return the Run object.
 
 ***
 
-#### [](#actorclient-call) `ActorClient.call(*, run_input=None, content_type=None, build=None, memory_mbytes=None, timeout_secs=None, webhooks=None, wait_secs=None)`
+#### [](#actorclient-call) `ActorClient.call(*, run_input=None, content_type=None, build=None, max_items=None, memory_mbytes=None, timeout_secs=None, webhooks=None, wait_secs=None)`
 
 Start the actor and wait for it to finish before returning the Run object.
 
@@ -1006,6 +1012,9 @@ It waits indefinitely, unless the wait_secs argument is provided.
 
   * **build** (`str`, *optional*) – Specifies the actor build to run. It can be either a build tag or build number.
   By default, the run uses the build specified in the default run configuration for the actor (typically latest).
+
+  * **max_items** (`int`, *optional*) – Maximum number of results that will be returned by this run.
+  If the Actor is charged per result, you will not be charged for more results than the given limit.
 
   * **memory_mbytes** (`int`, *optional*) – Memory limit for the run, in megabytes.
   By default, the run uses a memory limit specified in the default run configuration for the actor.
@@ -1177,7 +1186,7 @@ Retrieve the actor.
 
 ***
 
-#### [](#actorclientasync-update) `async ActorClientAsync.update(*, name=None, title=None, description=None, seo_title=None, seo_description=None, versions=None, restart_on_error=None, is_public=None, is_deprecated=None, is_anonymously_runnable=None, categories=None, default_run_build=None, default_run_memory_mbytes=None, default_run_timeout_secs=None, example_run_input_body=None, example_run_input_content_type=None)`
+#### [](#actorclientasync-update) `async ActorClientAsync.update(*, name=None, title=None, description=None, seo_title=None, seo_description=None, versions=None, restart_on_error=None, is_public=None, is_deprecated=None, is_anonymously_runnable=None, categories=None, default_run_build=None, default_run_max_items=None, default_run_memory_mbytes=None, default_run_timeout_secs=None, example_run_input_body=None, example_run_input_content_type=None)`
 
 Update the actor with the specified fields.
 
@@ -1209,6 +1218,9 @@ Update the actor with the specified fields.
 
   * **default_run_build** (`str`, *optional*) – Tag or number of the build that you want to run by default.
 
+  * **default_run_max_items** (`int`, *optional*) – Default limit of the number of results that will be returned by runs of this Actor,
+  if the Actor is charged per result.
+
   * **default_run_memory_mbytes** (`int`, *optional*) – Default amount of memory allocated for the runs of this actor, in megabytes.
 
   * **default_run_timeout_secs** (`int`, *optional*) – Default timeout for the runs of this actor in seconds.
@@ -1239,7 +1251,7 @@ Delete the actor.
 
 ***
 
-#### [](#actorclientasync-start) `async ActorClientAsync.start(*, run_input=None, content_type=None, build=None, memory_mbytes=None, timeout_secs=None, wait_for_finish=None, webhooks=None)`
+#### [](#actorclientasync-start) `async ActorClientAsync.start(*, run_input=None, content_type=None, build=None, max_items=None, memory_mbytes=None, timeout_secs=None, wait_for_finish=None, webhooks=None)`
 
 Start the actor and immediately return the Run object.
 
@@ -1253,6 +1265,9 @@ Start the actor and immediately return the Run object.
 
   * **build** (`str`, *optional*) – Specifies the actor build to run. It can be either a build tag or build number.
   By default, the run uses the build specified in the default run configuration for the actor (typically latest).
+
+  * **max_items** (`int`, *optional*) – Maximum number of results that will be returned by this run.
+  If the Actor is charged per result, you will not be charged for more results than the given limit.
 
   * **memory_mbytes** (`int`, *optional*) – Memory limit for the run, in megabytes.
   By default, the run uses a memory limit specified in the default run configuration for the actor.
@@ -1282,7 +1297,7 @@ Start the actor and immediately return the Run object.
 
 ***
 
-#### [](#actorclientasync-call) `async ActorClientAsync.call(*, run_input=None, content_type=None, build=None, memory_mbytes=None, timeout_secs=None, webhooks=None, wait_secs=None)`
+#### [](#actorclientasync-call) `async ActorClientAsync.call(*, run_input=None, content_type=None, build=None, max_items=None, memory_mbytes=None, timeout_secs=None, webhooks=None, wait_secs=None)`
 
 Start the actor and wait for it to finish before returning the Run object.
 
@@ -1298,6 +1313,9 @@ It waits indefinitely, unless the wait_secs argument is provided.
 
   * **build** (`str`, *optional*) – Specifies the actor build to run. It can be either a build tag or build number.
   By default, the run uses the build specified in the default run configuration for the actor (typically latest).
+
+  * **max_items** (`int`, *optional*) – Maximum number of results that will be returned by this run.
+  If the Actor is charged per result, you will not be charged for more results than the given limit.
 
   * **memory_mbytes** (`int`, *optional*) – Memory limit for the run, in megabytes.
   By default, the run uses a memory limit specified in the default run configuration for the actor.
@@ -1469,7 +1487,7 @@ List the actors the user has created or used.
 
 ***
 
-#### [](#actorcollectionclient-create) `ActorCollectionClient.create(*, name, title=None, description=None, seo_title=None, seo_description=None, versions=None, restart_on_error=None, is_public=None, is_deprecated=None, is_anonymously_runnable=None, categories=None, default_run_build=None, default_run_memory_mbytes=None, default_run_timeout_secs=None, example_run_input_body=None, example_run_input_content_type=None)`
+#### [](#actorcollectionclient-create) `ActorCollectionClient.create(*, name, title=None, description=None, seo_title=None, seo_description=None, versions=None, restart_on_error=None, is_public=None, is_deprecated=None, is_anonymously_runnable=None, categories=None, default_run_build=None, default_run_max_items=None, default_run_memory_mbytes=None, default_run_timeout_secs=None, example_run_input_body=None, example_run_input_content_type=None)`
 
 Create a new actor.
 
@@ -1500,6 +1518,9 @@ Create a new actor.
   * **categories** (`list of str`, *optional*) – The categories to which the actor belongs to.
 
   * **default_run_build** (`str`, *optional*) – Tag or number of the build that you want to run by default.
+
+  * **default_run_max_items** (`int`, *optional*) – Default limit of the number of results that will be returned by runs of this Actor,
+  if the Actor is charged per result.
 
   * **default_run_memory_mbytes** (`int`, *optional*) – Default amount of memory allocated for the runs of this actor, in megabytes.
 
@@ -1554,7 +1575,7 @@ List the actors the user has created or used.
 
 ***
 
-#### [](#actorcollectionclientasync-create) `async ActorCollectionClientAsync.create(*, name, title=None, description=None, seo_title=None, seo_description=None, versions=None, restart_on_error=None, is_public=None, is_deprecated=None, is_anonymously_runnable=None, categories=None, default_run_build=None, default_run_memory_mbytes=None, default_run_timeout_secs=None, example_run_input_body=None, example_run_input_content_type=None)`
+#### [](#actorcollectionclientasync-create) `async ActorCollectionClientAsync.create(*, name, title=None, description=None, seo_title=None, seo_description=None, versions=None, restart_on_error=None, is_public=None, is_deprecated=None, is_anonymously_runnable=None, categories=None, default_run_build=None, default_run_max_items=None, default_run_memory_mbytes=None, default_run_timeout_secs=None, example_run_input_body=None, example_run_input_content_type=None)`
 
 Create a new actor.
 
@@ -1585,6 +1606,9 @@ Create a new actor.
   * **categories** (`list of str`, *optional*) – The categories to which the actor belongs to.
 
   * **default_run_build** (`str`, *optional*) – Tag or number of the build that you want to run by default.
+
+  * **default_run_max_items** (`int`, *optional*) – Default limit of the number of results that will be returned by runs of this Actor,
+  if the Actor is charged per result.
 
   * **default_run_memory_mbytes** (`int`, *optional*) – Default amount of memory allocated for the runs of this actor, in megabytes.
 
@@ -5153,7 +5177,7 @@ Retrieve the task.
 
 ***
 
-#### [](#taskclientasync-update) `async TaskClientAsync.update(*, name=None, task_input=None, build=None, memory_mbytes=None, timeout_secs=None, title=None)`
+#### [](#taskclientasync-update) `async TaskClientAsync.update(*, name=None, task_input=None, build=None, max_items=None, memory_mbytes=None, timeout_secs=None, title=None)`
 
 Update the task with specified fields.
 
@@ -5165,6 +5189,9 @@ Update the task with specified fields.
 
   * **build** (`str`, *optional*) – Actor build to run. It can be either a build tag or build number.
   By default, the run uses the build specified in the task settings (typically latest).
+
+  * **max_items** (`int`, *optional*) – Maximum number of results that will be returned by this run.
+  If the Actor is charged per result, you will not be charged for more results than the given limit.
 
   * **memory_mbytes** (`int`, *optional*) – Memory limit for the run, in megabytes.
   By default, the run uses a memory limit specified in the task settings.
@@ -5197,7 +5224,7 @@ Delete the task.
 
 ***
 
-#### [](#taskclientasync-start) `async TaskClientAsync.start(*, task_input=None, build=None, memory_mbytes=None, timeout_secs=None, wait_for_finish=None, webhooks=None)`
+#### [](#taskclientasync-start) `async TaskClientAsync.start(*, task_input=None, build=None, max_items=None, memory_mbytes=None, timeout_secs=None, wait_for_finish=None, webhooks=None)`
 
 Start the task and immediately return the Run object.
 
@@ -5209,6 +5236,9 @@ Start the task and immediately return the Run object.
 
   * **build** (`str`, *optional*) – Specifies the actor build to run. It can be either a build tag or build number.
   By default, the run uses the build specified in the task settings (typically latest).
+
+  * **max_items** (`int`, *optional*) – Maximum number of results that will be returned by this run.
+  If the Actor is charged per result, you will not be charged for more results than the given limit.
 
   * **memory_mbytes** (`int`, *optional*) – Memory limit for the run, in megabytes.
   By default, the run uses a memory limit specified in the task settings.
@@ -5237,7 +5267,7 @@ Start the task and immediately return the Run object.
 
 ***
 
-#### [](#taskclientasync-call) `async TaskClientAsync.call(*, task_input=None, build=None, memory_mbytes=None, timeout_secs=None, webhooks=None, wait_secs=None)`
+#### [](#taskclientasync-call) `async TaskClientAsync.call(*, task_input=None, build=None, max_items=None, memory_mbytes=None, timeout_secs=None, webhooks=None, wait_secs=None)`
 
 Start a task and wait for it to finish before returning the Run object.
 
@@ -5251,6 +5281,9 @@ It waits indefinitely, unless the wait_secs argument is provided.
 
   * **build** (`str`, *optional*) – Specifies the actor build to run. It can be either a build tag or build number.
   By default, the run uses the build specified in the task settings (typically latest).
+
+  * **max_items** (`int`, *optional*) – Maximum number of results that will be returned by this run.
+  If the Actor is charged per result, you will not be charged for more results than the given limit.
 
   * **memory_mbytes** (`int`, *optional*) – Memory limit for the run, in megabytes.
   By default, the run uses a memory limit specified in the task settings.
@@ -5412,7 +5445,7 @@ List the available tasks.
 
 ***
 
-#### [](#taskcollectionclientasync-create) `async TaskCollectionClientAsync.create(*, actor_id, name, build=None, timeout_secs=None, memory_mbytes=None, task_input=None, title=None)`
+#### [](#taskcollectionclientasync-create) `async TaskCollectionClientAsync.create(*, actor_id, name, build=None, timeout_secs=None, memory_mbytes=None, max_items=None, task_input=None, title=None)`
 
 Create a new task.
 
@@ -5429,6 +5462,9 @@ Create a new task.
 
   * **memory_mbytes** (`int`, *optional*) – Memory limit for the run, in megabytes.
   By default, the run uses a memory limit specified in the task settings.
+
+  * **max_items** (`int`, *optional*) – Maximum number of results that will be returned by runs of this task.
+  If the Actor of this task is charged per result, you will not be charged for more results than the given limit.
 
   * **timeout_secs** (`int`, *optional*) – Optional timeout for the run, in seconds. By default, the run uses timeout specified in the task settings.
 
@@ -5479,7 +5515,7 @@ Retrieve the task.
 
 ***
 
-#### [](#taskclient-update) `TaskClient.update(*, name=None, task_input=None, build=None, memory_mbytes=None, timeout_secs=None, title=None)`
+#### [](#taskclient-update) `TaskClient.update(*, name=None, task_input=None, build=None, max_items=None, memory_mbytes=None, timeout_secs=None, title=None)`
 
 Update the task with specified fields.
 
@@ -5491,6 +5527,9 @@ Update the task with specified fields.
 
   * **build** (`str`, *optional*) – Actor build to run. It can be either a build tag or build number.
   By default, the run uses the build specified in the task settings (typically latest).
+
+  * **max_items** (`int`, *optional*) – Maximum number of results that will be returned by this run.
+  If the Actor is charged per result, you will not be charged for more results than the given limit.
 
   * **memory_mbytes** (`int`, *optional*) – Memory limit for the run, in megabytes.
   By default, the run uses a memory limit specified in the task settings.
@@ -5523,7 +5562,7 @@ Delete the task.
 
 ***
 
-#### [](#taskclient-start) `TaskClient.start(*, task_input=None, build=None, memory_mbytes=None, timeout_secs=None, wait_for_finish=None, webhooks=None)`
+#### [](#taskclient-start) `TaskClient.start(*, task_input=None, build=None, max_items=None, memory_mbytes=None, timeout_secs=None, wait_for_finish=None, webhooks=None)`
 
 Start the task and immediately return the Run object.
 
@@ -5535,6 +5574,9 @@ Start the task and immediately return the Run object.
 
   * **build** (`str`, *optional*) – Specifies the actor build to run. It can be either a build tag or build number.
   By default, the run uses the build specified in the task settings (typically latest).
+
+  * **max_items** (`int`, *optional*) – Maximum number of results that will be returned by this run.
+  If the Actor is charged per result, you will not be charged for more results than the given limit.
 
   * **memory_mbytes** (`int`, *optional*) – Memory limit for the run, in megabytes.
   By default, the run uses a memory limit specified in the task settings.
@@ -5563,7 +5605,7 @@ Start the task and immediately return the Run object.
 
 ***
 
-#### [](#taskclient-call) `TaskClient.call(*, task_input=None, build=None, memory_mbytes=None, timeout_secs=None, webhooks=None, wait_secs=None)`
+#### [](#taskclient-call) `TaskClient.call(*, task_input=None, build=None, max_items=None, memory_mbytes=None, timeout_secs=None, webhooks=None, wait_secs=None)`
 
 Start a task and wait for it to finish before returning the Run object.
 
@@ -5577,6 +5619,9 @@ It waits indefinitely, unless the wait_secs argument is provided.
 
   * **build** (`str`, *optional*) – Specifies the actor build to run. It can be either a build tag or build number.
   By default, the run uses the build specified in the task settings (typically latest).
+
+  * **max_items** (`int`, *optional*) – Maximum number of results that will be returned by this run.
+  If the Actor is charged per result, you will not be charged for more results than the given limit.
 
   * **memory_mbytes** (`int`, *optional*) – Memory limit for the run, in megabytes.
   By default, the run uses a memory limit specified in the task settings.
@@ -5732,7 +5777,7 @@ List the available tasks.
 
 ***
 
-#### [](#taskcollectionclient-create) `TaskCollectionClient.create(*, actor_id, name, build=None, timeout_secs=None, memory_mbytes=None, task_input=None, title=None)`
+#### [](#taskcollectionclient-create) `TaskCollectionClient.create(*, actor_id, name, build=None, timeout_secs=None, memory_mbytes=None, max_items=None, task_input=None, title=None)`
 
 Create a new task.
 
@@ -5749,6 +5794,9 @@ Create a new task.
 
   * **memory_mbytes** (`int`, *optional*) – Memory limit for the run, in megabytes.
   By default, the run uses a memory limit specified in the task settings.
+
+  * **max_items** (`int`, *optional*) – Maximum number of results that will be returned by runs of this task.
+  If the Actor of this task is charged per result, you will not be charged for more results than the given limit.
 
   * **timeout_secs** (`int`, *optional*) – Optional timeout for the run, in seconds. By default, the run uses timeout specified in the task settings.
 

--- a/src/apify_client/clients/resource_clients/actor.py
+++ b/src/apify_client/clients/resource_clients/actor.py
@@ -27,6 +27,7 @@ def _get_actor_representation(
     is_anonymously_runnable: Optional[bool] = None,
     categories: Optional[List[str]] = None,
     default_run_build: Optional[str] = None,
+    default_run_max_items: Optional[int] = None,
     default_run_memory_mbytes: Optional[int] = None,
     default_run_timeout_secs: Optional[int] = None,
     example_run_input_body: Optional[Any] = None,
@@ -46,6 +47,7 @@ def _get_actor_representation(
         'categories': categories,
         'defaultRunOptions': {
             'build': default_run_build,
+            'maxItems': default_run_max_items,
             'memoryMbytes': default_run_memory_mbytes,
             'timeoutSecs': default_run_timeout_secs,
         },
@@ -90,6 +92,7 @@ class ActorClient(ResourceClient):
         is_anonymously_runnable: Optional[bool] = None,
         categories: Optional[List[str]] = None,
         default_run_build: Optional[str] = None,
+        default_run_max_items: Optional[int] = None,
         default_run_memory_mbytes: Optional[int] = None,
         default_run_timeout_secs: Optional[int] = None,
         example_run_input_body: Optional[Any] = None,
@@ -112,6 +115,8 @@ class ActorClient(ResourceClient):
             is_anonymously_runnable (bool, optional): Whether the actor is anonymously runnable.
             categories (list of str, optional): The categories to which the actor belongs to.
             default_run_build (str, optional): Tag or number of the build that you want to run by default.
+            default_run_max_items (int, optional): Default limit of the number of results that will be returned by runs of this Actor,
+                                                   if the Actor is charged per result.
             default_run_memory_mbytes (int, optional): Default amount of memory allocated for the runs of this actor, in megabytes.
             default_run_timeout_secs (int, optional): Default timeout for the runs of this actor in seconds.
             example_run_input_body (Any, optional): Input to be prefilled as default input to new users of this actor.
@@ -133,6 +138,7 @@ class ActorClient(ResourceClient):
             is_anonymously_runnable=is_anonymously_runnable,
             categories=categories,
             default_run_build=default_run_build,
+            default_run_max_items=default_run_max_items,
             default_run_memory_mbytes=default_run_memory_mbytes,
             default_run_timeout_secs=default_run_timeout_secs,
             example_run_input_body=example_run_input_body,
@@ -154,6 +160,7 @@ class ActorClient(ResourceClient):
         run_input: Optional[Any] = None,
         content_type: Optional[str] = None,
         build: Optional[str] = None,
+        max_items: Optional[int] = None,
         memory_mbytes: Optional[int] = None,
         timeout_secs: Optional[int] = None,
         wait_for_finish: Optional[int] = None,
@@ -168,6 +175,8 @@ class ActorClient(ResourceClient):
             content_type (str, optional): The content type of the input.
             build (str, optional): Specifies the actor build to run. It can be either a build tag or build number.
                                    By default, the run uses the build specified in the default run configuration for the actor (typically latest).
+            max_items (int, optional): Maximum number of results that will be returned by this run.
+                                       If the Actor is charged per result, you will not be charged for more results than the given limit.
             memory_mbytes (int, optional): Memory limit for the run, in megabytes.
                                            By default, the run uses a memory limit specified in the default run configuration for the actor.
             timeout_secs (int, optional): Optional timeout for the run, in seconds.
@@ -190,6 +199,7 @@ class ActorClient(ResourceClient):
 
         request_params = self._params(
             build=build,
+            maxItems=max_items,
             memory=memory_mbytes,
             timeout=timeout_secs,
             waitForFinish=wait_for_finish,
@@ -212,6 +222,7 @@ class ActorClient(ResourceClient):
         run_input: Optional[Any] = None,
         content_type: Optional[str] = None,
         build: Optional[str] = None,
+        max_items: Optional[int] = None,
         memory_mbytes: Optional[int] = None,
         timeout_secs: Optional[int] = None,
         webhooks: Optional[List[Dict]] = None,
@@ -228,6 +239,8 @@ class ActorClient(ResourceClient):
             content_type (str, optional): The content type of the input.
             build (str, optional): Specifies the actor build to run. It can be either a build tag or build number.
                                    By default, the run uses the build specified in the default run configuration for the actor (typically latest).
+            max_items (int, optional): Maximum number of results that will be returned by this run.
+                                       If the Actor is charged per result, you will not be charged for more results than the given limit.
             memory_mbytes (int, optional): Memory limit for the run, in megabytes.
                                            By default, the run uses a memory limit specified in the default run configuration for the actor.
             timeout_secs (int, optional): Optional timeout for the run, in seconds.
@@ -244,6 +257,7 @@ class ActorClient(ResourceClient):
             run_input=run_input,
             content_type=content_type,
             build=build,
+            max_items=max_items,
             memory_mbytes=memory_mbytes,
             timeout_secs=timeout_secs,
             webhooks=webhooks,
@@ -378,6 +392,7 @@ class ActorClientAsync(ResourceClientAsync):
         is_anonymously_runnable: Optional[bool] = None,
         categories: Optional[List[str]] = None,
         default_run_build: Optional[str] = None,
+        default_run_max_items: Optional[int] = None,
         default_run_memory_mbytes: Optional[int] = None,
         default_run_timeout_secs: Optional[int] = None,
         example_run_input_body: Optional[Any] = None,
@@ -400,6 +415,8 @@ class ActorClientAsync(ResourceClientAsync):
             is_anonymously_runnable (bool, optional): Whether the actor is anonymously runnable.
             categories (list of str, optional): The categories to which the actor belongs to.
             default_run_build (str, optional): Tag or number of the build that you want to run by default.
+            default_run_max_items (int, optional): Default limit of the number of results that will be returned by runs of this Actor,
+                                                   if the Actor is charged per result.
             default_run_memory_mbytes (int, optional): Default amount of memory allocated for the runs of this actor, in megabytes.
             default_run_timeout_secs (int, optional): Default timeout for the runs of this actor in seconds.
             example_run_input_body (Any, optional): Input to be prefilled as default input to new users of this actor.
@@ -421,6 +438,7 @@ class ActorClientAsync(ResourceClientAsync):
             is_anonymously_runnable=is_anonymously_runnable,
             categories=categories,
             default_run_build=default_run_build,
+            default_run_max_items=default_run_max_items,
             default_run_memory_mbytes=default_run_memory_mbytes,
             default_run_timeout_secs=default_run_timeout_secs,
             example_run_input_body=example_run_input_body,
@@ -442,6 +460,7 @@ class ActorClientAsync(ResourceClientAsync):
         run_input: Optional[Any] = None,
         content_type: Optional[str] = None,
         build: Optional[str] = None,
+        max_items: Optional[int] = None,
         memory_mbytes: Optional[int] = None,
         timeout_secs: Optional[int] = None,
         wait_for_finish: Optional[int] = None,
@@ -456,6 +475,8 @@ class ActorClientAsync(ResourceClientAsync):
             content_type (str, optional): The content type of the input.
             build (str, optional): Specifies the actor build to run. It can be either a build tag or build number.
                                    By default, the run uses the build specified in the default run configuration for the actor (typically latest).
+            max_items (int, optional): Maximum number of results that will be returned by this run.
+                                       If the Actor is charged per result, you will not be charged for more results than the given limit.
             memory_mbytes (int, optional): Memory limit for the run, in megabytes.
                                            By default, the run uses a memory limit specified in the default run configuration for the actor.
             timeout_secs (int, optional): Optional timeout for the run, in seconds.
@@ -478,6 +499,7 @@ class ActorClientAsync(ResourceClientAsync):
 
         request_params = self._params(
             build=build,
+            maxItems=max_items,
             memory=memory_mbytes,
             timeout=timeout_secs,
             waitForFinish=wait_for_finish,
@@ -500,6 +522,7 @@ class ActorClientAsync(ResourceClientAsync):
         run_input: Optional[Any] = None,
         content_type: Optional[str] = None,
         build: Optional[str] = None,
+        max_items: Optional[int] = None,
         memory_mbytes: Optional[int] = None,
         timeout_secs: Optional[int] = None,
         webhooks: Optional[List[Dict]] = None,
@@ -516,6 +539,8 @@ class ActorClientAsync(ResourceClientAsync):
             content_type (str, optional): The content type of the input.
             build (str, optional): Specifies the actor build to run. It can be either a build tag or build number.
                                    By default, the run uses the build specified in the default run configuration for the actor (typically latest).
+            max_items (int, optional): Maximum number of results that will be returned by this run.
+                                       If the Actor is charged per result, you will not be charged for more results than the given limit.
             memory_mbytes (int, optional): Memory limit for the run, in megabytes.
                                            By default, the run uses a memory limit specified in the default run configuration for the actor.
             timeout_secs (int, optional): Optional timeout for the run, in seconds.
@@ -532,6 +557,7 @@ class ActorClientAsync(ResourceClientAsync):
             run_input=run_input,
             content_type=content_type,
             build=build,
+            max_items=max_items,
             memory_mbytes=memory_mbytes,
             timeout_secs=timeout_secs,
             webhooks=webhooks,

--- a/src/apify_client/clients/resource_clients/actor_collection.py
+++ b/src/apify_client/clients/resource_clients/actor_collection.py
@@ -54,6 +54,7 @@ class ActorCollectionClient(ResourceCollectionClient):
         is_anonymously_runnable: Optional[bool] = None,
         categories: Optional[List[str]] = None,
         default_run_build: Optional[str] = None,
+        default_run_max_items: Optional[int] = None,
         default_run_memory_mbytes: Optional[int] = None,
         default_run_timeout_secs: Optional[int] = None,
         example_run_input_body: Optional[Any] = None,
@@ -76,6 +77,8 @@ class ActorCollectionClient(ResourceCollectionClient):
             is_anonymously_runnable (bool, optional): Whether the actor is anonymously runnable.
             categories (list of str, optional): The categories to which the actor belongs to.
             default_run_build (str, optional): Tag or number of the build that you want to run by default.
+            default_run_max_items (int, optional): Default limit of the number of results that will be returned by runs of this Actor,
+                                                   if the Actor is charged per result.
             default_run_memory_mbytes (int, optional): Default amount of memory allocated for the runs of this actor, in megabytes.
             default_run_timeout_secs (int, optional): Default timeout for the runs of this actor in seconds.
             example_run_input_body (Any, optional): Input to be prefilled as default input to new users of this actor.
@@ -97,6 +100,7 @@ class ActorCollectionClient(ResourceCollectionClient):
             is_anonymously_runnable=is_anonymously_runnable,
             categories=categories,
             default_run_build=default_run_build,
+            default_run_max_items=default_run_max_items,
             default_run_memory_mbytes=default_run_memory_mbytes,
             default_run_timeout_secs=default_run_timeout_secs,
             example_run_input_body=example_run_input_body,
@@ -153,6 +157,7 @@ class ActorCollectionClientAsync(ResourceCollectionClientAsync):
         is_anonymously_runnable: Optional[bool] = None,
         categories: Optional[List[str]] = None,
         default_run_build: Optional[str] = None,
+        default_run_max_items: Optional[int] = None,
         default_run_memory_mbytes: Optional[int] = None,
         default_run_timeout_secs: Optional[int] = None,
         example_run_input_body: Optional[Any] = None,
@@ -175,6 +180,8 @@ class ActorCollectionClientAsync(ResourceCollectionClientAsync):
             is_anonymously_runnable (bool, optional): Whether the actor is anonymously runnable.
             categories (list of str, optional): The categories to which the actor belongs to.
             default_run_build (str, optional): Tag or number of the build that you want to run by default.
+            default_run_max_items (int, optional): Default limit of the number of results that will be returned by runs of this Actor,
+                                                   if the Actor is charged per result.
             default_run_memory_mbytes (int, optional): Default amount of memory allocated for the runs of this actor, in megabytes.
             default_run_timeout_secs (int, optional): Default timeout for the runs of this actor in seconds.
             example_run_input_body (Any, optional): Input to be prefilled as default input to new users of this actor.
@@ -196,6 +203,7 @@ class ActorCollectionClientAsync(ResourceCollectionClientAsync):
             is_anonymously_runnable=is_anonymously_runnable,
             categories=categories,
             default_run_build=default_run_build,
+            default_run_max_items=default_run_max_items,
             default_run_memory_mbytes=default_run_memory_mbytes,
             default_run_timeout_secs=default_run_timeout_secs,
             example_run_input_body=example_run_input_body,

--- a/src/apify_client/clients/resource_clients/task.py
+++ b/src/apify_client/clients/resource_clients/task.py
@@ -16,6 +16,7 @@ def _get_task_representation(
     name: Optional[str] = None,
     task_input: Optional[Dict] = None,
     build: Optional[str] = None,
+    max_items: Optional[int] = None,
     memory_mbytes: Optional[int] = None,
     timeout_secs: Optional[int] = None,
     title: Optional[str] = None,
@@ -25,6 +26,7 @@ def _get_task_representation(
         'name': name,
         'options': {
             'build': build,
+            'maxItems': max_items,
             'memoryMbytes': memory_mbytes,
             'timeoutSecs': timeout_secs,
         },
@@ -58,6 +60,7 @@ class TaskClient(ResourceClient):
         name: Optional[str] = None,
         task_input: Optional[Dict] = None,
         build: Optional[str] = None,
+        max_items: Optional[int] = None,
         memory_mbytes: Optional[int] = None,
         timeout_secs: Optional[int] = None,
         title: Optional[str] = None,
@@ -70,6 +73,8 @@ class TaskClient(ResourceClient):
             name (str, optional): Name of the task
             build (str, optional): Actor build to run. It can be either a build tag or build number.
                                    By default, the run uses the build specified in the task settings (typically latest).
+            max_items (int, optional): Maximum number of results that will be returned by this run.
+                                       If the Actor is charged per result, you will not be charged for more results than the given limit.
             memory_mbytes (int, optional): Memory limit for the run, in megabytes.
                                            By default, the run uses a memory limit specified in the task settings.
             timeout_secs (int, optional): Optional timeout for the run, in seconds. By default, the run uses timeout specified in the task settings.
@@ -83,6 +88,7 @@ class TaskClient(ResourceClient):
             name=name,
             task_input=task_input,
             build=build,
+            max_items=max_items,
             memory_mbytes=memory_mbytes,
             timeout_secs=timeout_secs,
             title=title,
@@ -102,6 +108,7 @@ class TaskClient(ResourceClient):
         *,
         task_input: Optional[Dict[str, Any]] = None,
         build: Optional[str] = None,
+        max_items: Optional[int] = None,
         memory_mbytes: Optional[int] = None,
         timeout_secs: Optional[int] = None,
         wait_for_finish: Optional[int] = None,
@@ -115,6 +122,8 @@ class TaskClient(ResourceClient):
             task_input (dict, optional): Task input dictionary
             build (str, optional): Specifies the actor build to run. It can be either a build tag or build number.
                                    By default, the run uses the build specified in the task settings (typically latest).
+            max_items (int, optional): Maximum number of results that will be returned by this run.
+                                       If the Actor is charged per result, you will not be charged for more results than the given limit.
             memory_mbytes (int, optional): Memory limit for the run, in megabytes.
                                            By default, the run uses a memory limit specified in the task settings.
             timeout_secs (int, optional): Optional timeout for the run, in seconds. By default, the run uses timeout specified in the task settings.
@@ -134,6 +143,7 @@ class TaskClient(ResourceClient):
         """
         request_params = self._params(
             build=build,
+            maxItems=max_items,
             memory=memory_mbytes,
             timeout=timeout_secs,
             waitForFinish=wait_for_finish,
@@ -155,6 +165,7 @@ class TaskClient(ResourceClient):
         *,
         task_input: Optional[Dict[str, Any]] = None,
         build: Optional[str] = None,
+        max_items: Optional[int] = None,
         memory_mbytes: Optional[int] = None,
         timeout_secs: Optional[int] = None,
         webhooks: Optional[List[Dict]] = None,
@@ -170,6 +181,8 @@ class TaskClient(ResourceClient):
             task_input (dict, optional): Task input dictionary
             build (str, optional): Specifies the actor build to run. It can be either a build tag or build number.
                                    By default, the run uses the build specified in the task settings (typically latest).
+            max_items (int, optional): Maximum number of results that will be returned by this run.
+                                       If the Actor is charged per result, you will not be charged for more results than the given limit.
             memory_mbytes (int, optional): Memory limit for the run, in megabytes.
                                            By default, the run uses a memory limit specified in the task settings.
             timeout_secs (int, optional): Optional timeout for the run, in seconds. By default, the run uses timeout specified in the task settings.
@@ -184,6 +197,7 @@ class TaskClient(ResourceClient):
         started_run = self.start(
             task_input=task_input,
             build=build,
+            max_items=max_items,
             memory_mbytes=memory_mbytes,
             timeout_secs=timeout_secs,
             webhooks=webhooks,
@@ -281,6 +295,7 @@ class TaskClientAsync(ResourceClientAsync):
         name: Optional[str] = None,
         task_input: Optional[Dict] = None,
         build: Optional[str] = None,
+        max_items: Optional[int] = None,
         memory_mbytes: Optional[int] = None,
         timeout_secs: Optional[int] = None,
         title: Optional[str] = None,
@@ -293,6 +308,8 @@ class TaskClientAsync(ResourceClientAsync):
             name (str, optional): Name of the task
             build (str, optional): Actor build to run. It can be either a build tag or build number.
                                    By default, the run uses the build specified in the task settings (typically latest).
+            max_items (int, optional): Maximum number of results that will be returned by this run.
+                                       If the Actor is charged per result, you will not be charged for more results than the given limit.
             memory_mbytes (int, optional): Memory limit for the run, in megabytes.
                                            By default, the run uses a memory limit specified in the task settings.
             timeout_secs (int, optional): Optional timeout for the run, in seconds. By default, the run uses timeout specified in the task settings.
@@ -306,6 +323,7 @@ class TaskClientAsync(ResourceClientAsync):
             name=name,
             task_input=task_input,
             build=build,
+            max_items=max_items,
             memory_mbytes=memory_mbytes,
             timeout_secs=timeout_secs,
             title=title,
@@ -325,6 +343,7 @@ class TaskClientAsync(ResourceClientAsync):
         *,
         task_input: Optional[Dict[str, Any]] = None,
         build: Optional[str] = None,
+        max_items: Optional[int] = None,
         memory_mbytes: Optional[int] = None,
         timeout_secs: Optional[int] = None,
         wait_for_finish: Optional[int] = None,
@@ -338,6 +357,8 @@ class TaskClientAsync(ResourceClientAsync):
             task_input (dict, optional): Task input dictionary
             build (str, optional): Specifies the actor build to run. It can be either a build tag or build number.
                                    By default, the run uses the build specified in the task settings (typically latest).
+            max_items (int, optional): Maximum number of results that will be returned by this run.
+                                       If the Actor is charged per result, you will not be charged for more results than the given limit.
             memory_mbytes (int, optional): Memory limit for the run, in megabytes.
                                            By default, the run uses a memory limit specified in the task settings.
             timeout_secs (int, optional): Optional timeout for the run, in seconds. By default, the run uses timeout specified in the task settings.
@@ -357,6 +378,7 @@ class TaskClientAsync(ResourceClientAsync):
         """
         request_params = self._params(
             build=build,
+            maxItems=max_items,
             memory=memory_mbytes,
             timeout=timeout_secs,
             waitForFinish=wait_for_finish,
@@ -378,6 +400,7 @@ class TaskClientAsync(ResourceClientAsync):
         *,
         task_input: Optional[Dict[str, Any]] = None,
         build: Optional[str] = None,
+        max_items: Optional[int] = None,
         memory_mbytes: Optional[int] = None,
         timeout_secs: Optional[int] = None,
         webhooks: Optional[List[Dict]] = None,
@@ -393,6 +416,8 @@ class TaskClientAsync(ResourceClientAsync):
             task_input (dict, optional): Task input dictionary
             build (str, optional): Specifies the actor build to run. It can be either a build tag or build number.
                                    By default, the run uses the build specified in the task settings (typically latest).
+            max_items (int, optional): Maximum number of results that will be returned by this run.
+                                       If the Actor is charged per result, you will not be charged for more results than the given limit.
             memory_mbytes (int, optional): Memory limit for the run, in megabytes.
                                            By default, the run uses a memory limit specified in the task settings.
             timeout_secs (int, optional): Optional timeout for the run, in seconds. By default, the run uses timeout specified in the task settings.
@@ -407,6 +432,7 @@ class TaskClientAsync(ResourceClientAsync):
         started_run = await self.start(
             task_input=task_input,
             build=build,
+            max_items=max_items,
             memory_mbytes=memory_mbytes,
             timeout_secs=timeout_secs,
             webhooks=webhooks,

--- a/src/apify_client/clients/resource_clients/task_collection.py
+++ b/src/apify_client/clients/resource_clients/task_collection.py
@@ -45,6 +45,7 @@ class TaskCollectionClient(ResourceCollectionClient):
         build: Optional[str] = None,
         timeout_secs: Optional[int] = None,
         memory_mbytes: Optional[int] = None,
+        max_items: Optional[int] = None,
         task_input: Optional[Dict] = None,
         title: Optional[str] = None,
     ) -> Dict:
@@ -59,6 +60,8 @@ class TaskCollectionClient(ResourceCollectionClient):
                                    By default, the run uses the build specified in the task settings (typically latest).
             memory_mbytes (int, optional): Memory limit for the run, in megabytes.
                                            By default, the run uses a memory limit specified in the task settings.
+            max_items (int, optional): Maximum number of results that will be returned by runs of this task.
+                                       If the Actor of this task is charged per result, you will not be charged for more results than the given limit.
             timeout_secs (int, optional): Optional timeout for the run, in seconds. By default, the run uses timeout specified in the task settings.
             task_input (dict, optional): Task input object.
             title (str, optional): A human-friendly equivalent of the name
@@ -71,6 +74,7 @@ class TaskCollectionClient(ResourceCollectionClient):
             name=name,
             task_input=task_input,
             build=build,
+            max_items=max_items,
             memory_mbytes=memory_mbytes,
             timeout_secs=timeout_secs,
             title=title,
@@ -117,6 +121,7 @@ class TaskCollectionClientAsync(ResourceCollectionClientAsync):
         build: Optional[str] = None,
         timeout_secs: Optional[int] = None,
         memory_mbytes: Optional[int] = None,
+        max_items: Optional[int] = None,
         task_input: Optional[Dict] = None,
         title: Optional[str] = None,
     ) -> Dict:
@@ -131,6 +136,8 @@ class TaskCollectionClientAsync(ResourceCollectionClientAsync):
                                    By default, the run uses the build specified in the task settings (typically latest).
             memory_mbytes (int, optional): Memory limit for the run, in megabytes.
                                            By default, the run uses a memory limit specified in the task settings.
+            max_items (int, optional): Maximum number of results that will be returned by runs of this task.
+                                       If the Actor of this task is charged per result, you will not be charged for more results than the given limit.
             timeout_secs (int, optional): Optional timeout for the run, in seconds. By default, the run uses timeout specified in the task settings.
             task_input (dict, optional): Task input object.
             title (str, optional): A human-friendly equivalent of the name
@@ -143,6 +150,7 @@ class TaskCollectionClientAsync(ResourceCollectionClientAsync):
             name=name,
             task_input=task_input,
             build=build,
+            max_items=max_items,
             memory_mbytes=memory_mbytes,
             timeout_secs=timeout_secs,
             title=title,


### PR DESCRIPTION
When we introduced pay-per result Actors, we did not add support for specifying the max items limit to the Python API client. This adds it hopefully everywhere it's supported.

Closes #146.