### PR TITLE
Add comment why not to use `~=` clause in deps definition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,13 @@ classifiers = [
 ]
 
 requires-python = ">=3.8"
+
+# We use inclusive ordered comparison clause for non-Apify packages intentionally in order to enhance the Apify client's
+# compatibility with a wide range of external packages. This decision was discussed in detail in the following PR:
+# https://github.com/apify/apify-sdk-python/pull/154
 dependencies = [
     "apify-shared ~= 1.1.0",
-    "httpx ~= 0.25.1",
+    "httpx >= 0.25.1",
 ]
 
 [project.optional-dependencies]
@@ -67,17 +71,27 @@ select = ["ALL"]
 ignore = [
     "ANN401",  # Dynamically typed expressions (typing.Any) are disallowed in {filename}
     "BLE001",  # Do not catch blind exception
+    "C901",    # `{name}` is too complex
     "COM812",  # This rule may cause conflicts when used with the formatter
     "D100",    # Missing docstring in public module
     "D104",    # Missing docstring in public package
     "EM",      # flake8-errmsg
+    "G004",    # Logging statement uses f-string
     "ISC001",  # This rule may cause conflicts when used with the formatter
     "FIX",     # flake8-fixme
     "PGH003",  # Use specific rule codes when ignoring type issues
+    "PLR0911", # Too many return statements
     "PLR0913", # Too many arguments in function definition
+    "PLR0915", # Too many statements
     "PTH",     # flake8-use-pathlib
+    "PYI034",  # `__aenter__` methods in classes like `{name}` usually return `self` at runtime
+    "PYI036",  # The second argument in `__aexit__` should be annotated with `object` or `BaseException | None`
     "S102",    # Use of `exec` detected
     "S105",    # Possible hardcoded password assigned to
+    "S106",    # Possible hardcoded password assigned to argument: "{name}"
+    "S301",    # `pickle` and modules that wrap it can be unsafe when used to deserialize untrusted data, possible security issue
+    "S303",    # Use of insecure MD2, MD4, MD5, or SHA1 hash function
+    "S311",    # Standard pseudo-random generators are not suitable for cryptographic purposes
     "TD002",   # Missing author in TODO; try: `# TODO(<author_name>): ...` or `# TODO @<author_name>: ...
     "TID252",  # Relative imports from parent modules are bannedRuff
     "TRY003",  # Avoid specifying long messages outside the exception class
@@ -101,8 +115,9 @@ indent-style = "space"
     "D",       # Everything from the pydocstyle
     "INP001",  # File {filename} is part of an implicit namespace package, add an __init__.py
     "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
-    "T20",     # flake8-print
     "S101",    # Use of assert detected
+    "T20",     # flake8-print
+    "TRY301",  # Abstract `raise` to an inner function
 ]
 
 [tool.ruff.lint.flake8-quotes]

--- a/src/apify_client/_utils.py
+++ b/src/apify_client/_utils.py
@@ -66,7 +66,7 @@ def retry_with_exp_backoff(
             if not swallow:
                 raise
 
-        random_sleep_factor = random.uniform(1, 1 + random_factor)  # noqa: S311
+        random_sleep_factor = random.uniform(1, 1 + random_factor)
         backoff_base_secs = backoff_base_millis / 1000
         backoff_exp_factor = backoff_factor ** (attempt - 1)
 
@@ -99,7 +99,7 @@ async def retry_with_exp_backoff_async(
             if not swallow:
                 raise
 
-        random_sleep_factor = random.uniform(1, 1 + random_factor)  # noqa: S311
+        random_sleep_factor = random.uniform(1, 1 + random_factor)
         backoff_base_secs = backoff_base_millis / 1000
         backoff_exp_factor = backoff_factor ** (attempt - 1)
 


### PR DESCRIPTION
Use `>=` rather than `~=` for general dependencies.

See https://github.com/apify/apify-sdk-python/pull/154 for context.

Also updates ruff config from Apify SDK Python.