### PR TITLE
Relative imports are replaced with absolute imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [1.6.2](../../releases/tag/v1.6.2) - Unreleased
 
-...
+### Internal changes
+
+- Relative imports were replaced for absolute imports
 
 ## [1.6.1](../../releases/tag/v1.6.1) - 2023-12-11
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,6 @@ ignore = [
     "S303",    # Use of insecure MD2, MD4, MD5, or SHA1 hash function
     "S311",    # Standard pseudo-random generators are not suitable for cryptographic purposes
     "TD002",   # Missing author in TODO; try: `# TODO(<author_name>): ...` or `# TODO @<author_name>: ...
-    "TID252",  # Relative imports from parent modules are bannedRuff
     "TRY003",  # Avoid specifying long messages outside the exception class
 ]
 
@@ -126,7 +125,7 @@ docstring-quotes = "double"
 inline-quotes = "single"
 
 [tool.ruff.lint.isort]
-known-first-party = ["apify", "apify_client", "apify_shared"]
+known-local-folder = ["apify_client"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.8"
 # compatibility with a wide range of external packages. This decision was discussed in detail in the following PR:
 # https://github.com/apify/apify-sdk-python/pull/154
 dependencies = [
-    "apify-shared ~= 1.1.0",
+    "apify-shared ~= 1.1.1",
     "httpx >= 0.25.1",
 ]
 

--- a/src/apify_client/_errors.py
+++ b/src/apify_client/_errors.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import httpx
-
 from apify_shared.utils import ignore_docs
 
 

--- a/src/apify_client/_http_client.py
+++ b/src/apify_client/_http_client.py
@@ -10,12 +10,11 @@ from importlib import metadata
 from typing import TYPE_CHECKING, Any, Callable
 
 import httpx
-
 from apify_shared.utils import ignore_docs, is_content_type_json, is_content_type_text, is_content_type_xml
 
-from ._errors import ApifyApiError, InvalidResponseBodyError, is_retryable_error
-from ._logging import log_context, logger_name
-from ._utils import retry_with_exp_backoff, retry_with_exp_backoff_async
+from apify_client._errors import ApifyApiError, InvalidResponseBodyError, is_retryable_error
+from apify_client._logging import log_context, logger_name
+from apify_client._utils import retry_with_exp_backoff, retry_with_exp_backoff_async
 
 if TYPE_CHECKING:
     from apify_shared.types import JSONSerializable

--- a/src/apify_client/_logging.py
+++ b/src/apify_client/_logging.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable, NamedTuple, cast
 
 # Conditional import only executed when type checking, otherwise we'd get circular dependency issues
 if TYPE_CHECKING:
-    from .clients.base.base_client import _BaseBaseClient
+    from apify_client.clients.base.base_client import _BaseBaseClient
 
 # Name of the logger used throughout the library
 logger_name = __name__.split('.')[0]

--- a/src/apify_client/_utils.py
+++ b/src/apify_client/_utils.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, TypeVar,
 from apify_shared.utils import is_file_or_bytes, maybe_extract_enum_member_value
 
 if TYPE_CHECKING:
-    from ._errors import ApifyApiError
+    from apify_client._errors import ApifyApiError
 
 PARSE_DATE_FIELDS_MAX_DEPTH = 3
 PARSE_DATE_FIELDS_KEY_SUFFIX = 'At'

--- a/src/apify_client/client.py
+++ b/src/apify_client/client.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from apify_shared.utils import ignore_docs
 
-from ._http_client import HTTPClient, HTTPClientAsync
-from .clients import (
+from apify_client._http_client import HTTPClient, HTTPClientAsync
+from apify_client.clients import (
     ActorClient,
     ActorClientAsync,
     ActorCollectionClient,

--- a/src/apify_client/clients/base/actor_job_base_client.py
+++ b/src/apify_client/clients/base/actor_job_base_client.py
@@ -8,9 +8,9 @@ from datetime import datetime, timezone
 from apify_shared.consts import ActorJobStatus
 from apify_shared.utils import ignore_docs, parse_date_fields
 
-from ..._errors import ApifyApiError
-from ..._utils import catch_not_found_or_throw, pluck_data
-from .resource_client import ResourceClient, ResourceClientAsync
+from apify_client._errors import ApifyApiError
+from apify_client._utils import catch_not_found_or_throw, pluck_data
+from apify_client.clients.base.resource_client import ResourceClient, ResourceClientAsync
 
 DEFAULT_WAIT_FOR_FINISH_SEC = 999999
 

--- a/src/apify_client/clients/base/base_client.py
+++ b/src/apify_client/clients/base/base_client.py
@@ -4,13 +4,13 @@ from typing import TYPE_CHECKING, Any
 
 from apify_shared.utils import ignore_docs
 
-from ..._logging import WithLogDetailsClient
-from ..._utils import to_safe_id
+from apify_client._logging import WithLogDetailsClient
+from apify_client._utils import to_safe_id
 
 # Conditional import only executed when type checking, otherwise we'd get circular dependency issues
 if TYPE_CHECKING:
-    from ..._http_client import HTTPClient, HTTPClientAsync
-    from ...client import ApifyClient, ApifyClientAsync
+    from apify_client import ApifyClient, ApifyClientAsync
+    from apify_client._http_client import HTTPClient, HTTPClientAsync
 
 
 class _BaseBaseClient(metaclass=WithLogDetailsClient):

--- a/src/apify_client/clients/base/resource_client.py
+++ b/src/apify_client/clients/base/resource_client.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from apify_shared.utils import ignore_docs, parse_date_fields
 
-from ..._errors import ApifyApiError
-from ..._utils import catch_not_found_or_throw, pluck_data
-from .base_client import BaseClient, BaseClientAsync
+from apify_client._errors import ApifyApiError
+from apify_client._utils import catch_not_found_or_throw, pluck_data
+from apify_client.clients.base.base_client import BaseClient, BaseClientAsync
 
 
 @ignore_docs

--- a/src/apify_client/clients/base/resource_collection_client.py
+++ b/src/apify_client/clients/base/resource_collection_client.py
@@ -5,8 +5,8 @@ from typing import Any
 from apify_shared.models import ListPage
 from apify_shared.utils import ignore_docs, parse_date_fields
 
-from ..._utils import pluck_data
-from .base_client import BaseClient, BaseClientAsync
+from apify_client._utils import pluck_data
+from apify_client.clients.base.base_client import BaseClient, BaseClientAsync
 
 
 @ignore_docs

--- a/src/apify_client/clients/resource_clients/actor.py
+++ b/src/apify_client/clients/resource_clients/actor.py
@@ -9,14 +9,14 @@ from apify_shared.utils import (
     parse_date_fields,
 )
 
-from ..._utils import encode_key_value_store_record_value, encode_webhook_list_to_base64, pluck_data
-from ..base import ResourceClient, ResourceClientAsync
-from .actor_version import ActorVersionClient, ActorVersionClientAsync
-from .actor_version_collection import ActorVersionCollectionClient, ActorVersionCollectionClientAsync
-from .build_collection import BuildCollectionClient, BuildCollectionClientAsync
-from .run import RunClient, RunClientAsync
-from .run_collection import RunCollectionClient, RunCollectionClientAsync
-from .webhook_collection import WebhookCollectionClient, WebhookCollectionClientAsync
+from apify_client._utils import encode_key_value_store_record_value, encode_webhook_list_to_base64, pluck_data
+from apify_client.clients.base import ResourceClient, ResourceClientAsync
+from apify_client.clients.resource_clients.actor_version import ActorVersionClient, ActorVersionClientAsync
+from apify_client.clients.resource_clients.actor_version_collection import ActorVersionCollectionClient, ActorVersionCollectionClientAsync
+from apify_client.clients.resource_clients.build_collection import BuildCollectionClient, BuildCollectionClientAsync
+from apify_client.clients.resource_clients.run import RunClient, RunClientAsync
+from apify_client.clients.resource_clients.run_collection import RunCollectionClient, RunCollectionClientAsync
+from apify_client.clients.resource_clients.webhook_collection import WebhookCollectionClient, WebhookCollectionClientAsync
 
 if TYPE_CHECKING:
     from apify_shared.consts import ActorJobStatus, MetaOrigin

--- a/src/apify_client/clients/resource_clients/actor_collection.py
+++ b/src/apify_client/clients/resource_clients/actor_collection.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, Any
 
 from apify_shared.utils import filter_out_none_values_recursively, ignore_docs
 
-from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
-from .actor import get_actor_representation
+from apify_client.clients.base import ResourceCollectionClient, ResourceCollectionClientAsync
+from apify_client.clients.resource_clients.actor import get_actor_representation
 
 if TYPE_CHECKING:
     from apify_shared.models import ListPage

--- a/src/apify_client/clients/resource_clients/actor_env_var.py
+++ b/src/apify_client/clients/resource_clients/actor_env_var.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from apify_shared.utils import filter_out_none_values_recursively, ignore_docs
 
-from ..base import ResourceClient, ResourceClientAsync
+from apify_client.clients.base import ResourceClient, ResourceClientAsync
 
 
 def get_actor_env_var_representation(

--- a/src/apify_client/clients/resource_clients/actor_env_var_collection.py
+++ b/src/apify_client/clients/resource_clients/actor_env_var_collection.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, Any
 
 from apify_shared.utils import filter_out_none_values_recursively, ignore_docs
 
-from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
-from .actor_env_var import get_actor_env_var_representation
+from apify_client.clients.base import ResourceCollectionClient, ResourceCollectionClientAsync
+from apify_client.clients.resource_clients.actor_env_var import get_actor_env_var_representation
 
 if TYPE_CHECKING:
     from apify_shared.models import ListPage

--- a/src/apify_client/clients/resource_clients/actor_version.py
+++ b/src/apify_client/clients/resource_clients/actor_version.py
@@ -4,9 +4,9 @@ from typing import TYPE_CHECKING, Any
 
 from apify_shared.utils import filter_out_none_values_recursively, ignore_docs, maybe_extract_enum_member_value
 
-from ..base import ResourceClient, ResourceClientAsync
-from .actor_env_var import ActorEnvVarClient, ActorEnvVarClientAsync
-from .actor_env_var_collection import ActorEnvVarCollectionClient, ActorEnvVarCollectionClientAsync
+from apify_client.clients.base import ResourceClient, ResourceClientAsync
+from apify_client.clients.resource_clients.actor_env_var import ActorEnvVarClient, ActorEnvVarClientAsync
+from apify_client.clients.resource_clients.actor_env_var_collection import ActorEnvVarCollectionClient, ActorEnvVarCollectionClientAsync
 
 if TYPE_CHECKING:
     from apify_shared.consts import ActorSourceType

--- a/src/apify_client/clients/resource_clients/actor_version_collection.py
+++ b/src/apify_client/clients/resource_clients/actor_version_collection.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, Any
 
 from apify_shared.utils import filter_out_none_values_recursively, ignore_docs
 
-from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
-from .actor_version import _get_actor_version_representation
+from apify_client.clients.base import ResourceCollectionClient, ResourceCollectionClientAsync
+from apify_client.clients.resource_clients.actor_version import _get_actor_version_representation
 
 if TYPE_CHECKING:
     from apify_shared.consts import ActorSourceType

--- a/src/apify_client/clients/resource_clients/build.py
+++ b/src/apify_client/clients/resource_clients/build.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from apify_shared.utils import ignore_docs
 
-from ..base import ActorJobBaseClient, ActorJobBaseClientAsync
+from apify_client.clients.base import ActorJobBaseClient, ActorJobBaseClientAsync
 
 
 class BuildClient(ActorJobBaseClient):

--- a/src/apify_client/clients/resource_clients/build_collection.py
+++ b/src/apify_client/clients/resource_clients/build_collection.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from apify_shared.utils import ignore_docs
 
-from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
+from apify_client.clients.base import ResourceCollectionClient, ResourceCollectionClientAsync
 
 if TYPE_CHECKING:
     from apify_shared.models import ListPage

--- a/src/apify_client/clients/resource_clients/dataset.py
+++ b/src/apify_client/clients/resource_clients/dataset.py
@@ -7,11 +7,10 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, Iterator
 from apify_shared.models import ListPage
 from apify_shared.utils import filter_out_none_values_recursively, ignore_docs
 
-from ..base import ResourceClient, ResourceClientAsync
+from apify_client.clients.base import ResourceClient, ResourceClientAsync
 
 if TYPE_CHECKING:
     import httpx
-
     from apify_shared.types import JSONSerializable
 
 

--- a/src/apify_client/clients/resource_clients/dataset_collection.py
+++ b/src/apify_client/clients/resource_clients/dataset_collection.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from apify_shared.utils import filter_out_none_values_recursively, ignore_docs
 
-from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
+from apify_client.clients.base import ResourceCollectionClient, ResourceCollectionClientAsync
 
 if TYPE_CHECKING:
     from apify_shared.models import ListPage

--- a/src/apify_client/clients/resource_clients/key_value_store.py
+++ b/src/apify_client/clients/resource_clients/key_value_store.py
@@ -6,9 +6,9 @@ from typing import Any, AsyncIterator, Iterator
 
 from apify_shared.utils import filter_out_none_values_recursively, ignore_docs, parse_date_fields
 
-from ..._errors import ApifyApiError
-from ..._utils import catch_not_found_or_throw, encode_key_value_store_record_value, pluck_data
-from ..base import ResourceClient, ResourceClientAsync
+from apify_client._errors import ApifyApiError
+from apify_client._utils import catch_not_found_or_throw, encode_key_value_store_record_value, pluck_data
+from apify_client.clients.base import ResourceClient, ResourceClientAsync
 
 
 class KeyValueStoreClient(ResourceClient):

--- a/src/apify_client/clients/resource_clients/key_value_store_collection.py
+++ b/src/apify_client/clients/resource_clients/key_value_store_collection.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from apify_shared.utils import filter_out_none_values_recursively, ignore_docs
 
-from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
+from apify_client.clients.base import ResourceCollectionClient, ResourceCollectionClientAsync
 
 if TYPE_CHECKING:
     from apify_shared.models import ListPage

--- a/src/apify_client/clients/resource_clients/log.py
+++ b/src/apify_client/clients/resource_clients/log.py
@@ -5,9 +5,9 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, Iterator
 
 from apify_shared.utils import ignore_docs
 
-from ..._errors import ApifyApiError
-from ..._utils import catch_not_found_or_throw
-from ..base import ResourceClient, ResourceClientAsync
+from apify_client._errors import ApifyApiError
+from apify_client._utils import catch_not_found_or_throw
+from apify_client.clients.base import ResourceClient, ResourceClientAsync
 
 if TYPE_CHECKING:
     import httpx

--- a/src/apify_client/clients/resource_clients/request_queue.py
+++ b/src/apify_client/clients/resource_clients/request_queue.py
@@ -4,9 +4,9 @@ from typing import Any
 
 from apify_shared.utils import filter_out_none_values_recursively, ignore_docs, parse_date_fields
 
-from ..._errors import ApifyApiError
-from ..._utils import catch_not_found_or_throw, pluck_data
-from ..base import ResourceClient, ResourceClientAsync
+from apify_client._errors import ApifyApiError
+from apify_client._utils import catch_not_found_or_throw, pluck_data
+from apify_client.clients.base import ResourceClient, ResourceClientAsync
 
 
 class RequestQueueClient(ResourceClient):

--- a/src/apify_client/clients/resource_clients/request_queue_collection.py
+++ b/src/apify_client/clients/resource_clients/request_queue_collection.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from apify_shared.utils import ignore_docs
 
-from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
+from apify_client.clients.base import ResourceCollectionClient, ResourceCollectionClientAsync
 
 if TYPE_CHECKING:
     from apify_shared.models import ListPage

--- a/src/apify_client/clients/resource_clients/run.py
+++ b/src/apify_client/clients/resource_clients/run.py
@@ -4,12 +4,12 @@ from typing import Any
 
 from apify_shared.utils import filter_out_none_values_recursively, ignore_docs, parse_date_fields
 
-from ..._utils import encode_key_value_store_record_value, pluck_data, to_safe_id
-from ..base import ActorJobBaseClient, ActorJobBaseClientAsync
-from .dataset import DatasetClient, DatasetClientAsync
-from .key_value_store import KeyValueStoreClient, KeyValueStoreClientAsync
-from .log import LogClient, LogClientAsync
-from .request_queue import RequestQueueClient, RequestQueueClientAsync
+from apify_client._utils import encode_key_value_store_record_value, pluck_data, to_safe_id
+from apify_client.clients.base import ActorJobBaseClient, ActorJobBaseClientAsync
+from apify_client.clients.resource_clients.dataset import DatasetClient, DatasetClientAsync
+from apify_client.clients.resource_clients.key_value_store import KeyValueStoreClient, KeyValueStoreClientAsync
+from apify_client.clients.resource_clients.log import LogClient, LogClientAsync
+from apify_client.clients.resource_clients.request_queue import RequestQueueClient, RequestQueueClientAsync
 
 
 class RunClient(ActorJobBaseClient):

--- a/src/apify_client/clients/resource_clients/run_collection.py
+++ b/src/apify_client/clients/resource_clients/run_collection.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from apify_shared.utils import ignore_docs, maybe_extract_enum_member_value
 
-from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
+from apify_client.clients.base import ResourceCollectionClient, ResourceCollectionClientAsync
 
 if TYPE_CHECKING:
     from apify_shared.consts import ActorJobStatus

--- a/src/apify_client/clients/resource_clients/schedule.py
+++ b/src/apify_client/clients/resource_clients/schedule.py
@@ -4,9 +4,9 @@ from typing import Any
 
 from apify_shared.utils import filter_out_none_values_recursively, ignore_docs
 
-from ..._errors import ApifyApiError
-from ..._utils import catch_not_found_or_throw, pluck_data_as_list
-from ..base import ResourceClient, ResourceClientAsync
+from apify_client._errors import ApifyApiError
+from apify_client._utils import catch_not_found_or_throw, pluck_data_as_list
+from apify_client.clients.base import ResourceClient, ResourceClientAsync
 
 
 def _get_schedule_representation(

--- a/src/apify_client/clients/resource_clients/schedule_collection.py
+++ b/src/apify_client/clients/resource_clients/schedule_collection.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, Any
 
 from apify_shared.utils import filter_out_none_values_recursively, ignore_docs
 
-from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
-from .schedule import _get_schedule_representation
+from apify_client.clients.base import ResourceCollectionClient, ResourceCollectionClientAsync
+from apify_client.clients.resource_clients.schedule import _get_schedule_representation
 
 if TYPE_CHECKING:
     from apify_shared.models import ListPage

--- a/src/apify_client/clients/resource_clients/store_collection.py
+++ b/src/apify_client/clients/resource_clients/store_collection.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from apify_shared.utils import ignore_docs
 
-from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
+from apify_client.clients.base import ResourceCollectionClient, ResourceCollectionClientAsync
 
 if TYPE_CHECKING:
     from apify_shared.models import ListPage

--- a/src/apify_client/clients/resource_clients/task.py
+++ b/src/apify_client/clients/resource_clients/task.py
@@ -9,12 +9,12 @@ from apify_shared.utils import (
     parse_date_fields,
 )
 
-from ..._errors import ApifyApiError
-from ..._utils import catch_not_found_or_throw, encode_webhook_list_to_base64, pluck_data
-from ..base import ResourceClient, ResourceClientAsync
-from .run import RunClient, RunClientAsync
-from .run_collection import RunCollectionClient, RunCollectionClientAsync
-from .webhook_collection import WebhookCollectionClient, WebhookCollectionClientAsync
+from apify_client._errors import ApifyApiError
+from apify_client._utils import catch_not_found_or_throw, encode_webhook_list_to_base64, pluck_data
+from apify_client.clients.base import ResourceClient, ResourceClientAsync
+from apify_client.clients.resource_clients.run import RunClient, RunClientAsync
+from apify_client.clients.resource_clients.run_collection import RunCollectionClient, RunCollectionClientAsync
+from apify_client.clients.resource_clients.webhook_collection import WebhookCollectionClient, WebhookCollectionClientAsync
 
 if TYPE_CHECKING:
     from apify_shared.consts import ActorJobStatus, MetaOrigin

--- a/src/apify_client/clients/resource_clients/task_collection.py
+++ b/src/apify_client/clients/resource_clients/task_collection.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, Any
 
 from apify_shared.utils import filter_out_none_values_recursively, ignore_docs
 
-from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
-from .task import get_task_representation
+from apify_client.clients.base import ResourceCollectionClient, ResourceCollectionClientAsync
+from apify_client.clients.resource_clients.task import get_task_representation
 
 if TYPE_CHECKING:
     from apify_shared.models import ListPage

--- a/src/apify_client/clients/resource_clients/user.py
+++ b/src/apify_client/clients/resource_clients/user.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from apify_shared.utils import ignore_docs
 
-from ..base import ResourceClient, ResourceClientAsync
+from apify_client.clients.base import ResourceClient, ResourceClientAsync
 
 
 class UserClient(ResourceClient):

--- a/src/apify_client/clients/resource_clients/webhook.py
+++ b/src/apify_client/clients/resource_clients/webhook.py
@@ -9,10 +9,10 @@ from apify_shared.utils import (
     parse_date_fields,
 )
 
-from ..._errors import ApifyApiError
-from ..._utils import catch_not_found_or_throw, pluck_data
-from ..base import ResourceClient, ResourceClientAsync
-from .webhook_dispatch_collection import WebhookDispatchCollectionClient, WebhookDispatchCollectionClientAsync
+from apify_client._errors import ApifyApiError
+from apify_client._utils import catch_not_found_or_throw, pluck_data
+from apify_client.clients.base import ResourceClient, ResourceClientAsync
+from apify_client.clients.resource_clients.webhook_dispatch_collection import WebhookDispatchCollectionClient, WebhookDispatchCollectionClientAsync
 
 if TYPE_CHECKING:
     from apify_shared.consts import WebhookEventType

--- a/src/apify_client/clients/resource_clients/webhook_collection.py
+++ b/src/apify_client/clients/resource_clients/webhook_collection.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, Any
 
 from apify_shared.utils import filter_out_none_values_recursively, ignore_docs
 
-from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
-from .webhook import get_webhook_representation
+from apify_client.clients.base import ResourceCollectionClient, ResourceCollectionClientAsync
+from apify_client.clients.resource_clients.webhook import get_webhook_representation
 
 if TYPE_CHECKING:
     from apify_shared.consts import WebhookEventType

--- a/src/apify_client/clients/resource_clients/webhook_dispatch.py
+++ b/src/apify_client/clients/resource_clients/webhook_dispatch.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from apify_shared.utils import ignore_docs
 
-from ..base import ResourceClient, ResourceClientAsync
+from apify_client.clients.base import ResourceClient, ResourceClientAsync
 
 
 class WebhookDispatchClient(ResourceClient):

--- a/src/apify_client/clients/resource_clients/webhook_dispatch_collection.py
+++ b/src/apify_client/clients/resource_clients/webhook_dispatch_collection.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from apify_shared.utils import ignore_docs
 
-from ..base import ResourceCollectionClient, ResourceCollectionClientAsync
+from apify_client.clients.base import ResourceCollectionClient, ResourceCollectionClientAsync
 
 if TYPE_CHECKING:
     from apify_shared.models import ListPage

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,6 +2,7 @@ import time
 from typing import Any, Callable
 
 import pytest
+from apify_shared.consts import WebhookEventType
 
 from apify_client._utils import (
     encode_webhook_list_to_base64,
@@ -10,7 +11,6 @@ from apify_client._utils import (
     retry_with_exp_backoff_async,
     to_safe_id,
 )
-from apify_shared.consts import WebhookEventType
 
 
 def test__to_safe_id() -> None:


### PR DESCRIPTION
- I left relative imports in `__init__.py` files.
- Closes #175 
- CI: gonna pass once `apify-shared` 1.1.1 is released