### PR TITLE
feat: add log() method to BuildClient (Python)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [1.6.3](../../releases/tag/v1.6.3) - Unreleased
 
-...
+- added `log()` method to `BuildClient`
 
 ## [1.6.2](../../releases/tag/v1.6.2) - 2023-01-08
 

--- a/src/apify_client/clients/resource_clients/build.py
+++ b/src/apify_client/clients/resource_clients/build.py
@@ -5,7 +5,7 @@ from typing import Any
 from apify_shared.utils import ignore_docs
 
 from apify_client.clients.base import ActorJobBaseClient, ActorJobBaseClientAsync
-from apify_client.clients.resource_clients.log import LogClient
+from apify_client.clients.resource_clients.log import LogClient, LogClientAsync
 
 
 class BuildClient(ActorJobBaseClient):
@@ -116,3 +116,15 @@ class BuildClientAsync(ActorJobBaseClientAsync):
                 (SUCEEDED, FAILED, TIMED_OUT, ABORTED), then the build has not yet finished.
         """
         return await self._wait_for_finish(wait_secs=wait_secs)
+
+    def log(self: BuildClientAsync) -> LogClientAsync:
+        """Get the client for the log of the actor build.
+
+        https://docs.apify.com/api/v2/#/reference/actor-builds/build-log/get-log
+
+        Returns:
+            LogClientAsync: A client allowing access to the log of this actor build.
+        """
+        return LogClientAsync(
+            **self._sub_resource_init_options(resource_path='log'),
+        )

--- a/src/apify_client/clients/resource_clients/build.py
+++ b/src/apify_client/clients/resource_clients/build.py
@@ -59,7 +59,7 @@ class BuildClient(ActorJobBaseClient):
     def log(self: BuildClient) -> LogClient:
         """Get the client for the log of the actor build.
 
-        // TODO: Add documentation link when it's available
+        https://docs.apify.com/api/v2/#/reference/actor-builds/build-log/get-log
 
         Returns:
             LogClient: A client allowing access to the log of this actor build.

--- a/src/apify_client/clients/resource_clients/build.py
+++ b/src/apify_client/clients/resource_clients/build.py
@@ -5,6 +5,7 @@ from typing import Any
 from apify_shared.utils import ignore_docs
 
 from apify_client.clients.base import ActorJobBaseClient, ActorJobBaseClientAsync
+from apify_client.clients.resource_clients.log import LogClient
 
 
 class BuildClient(ActorJobBaseClient):
@@ -54,6 +55,18 @@ class BuildClient(ActorJobBaseClient):
                 (SUCEEDED, FAILED, TIMED_OUT, ABORTED), then the build has not yet finished.
         """
         return self._wait_for_finish(wait_secs=wait_secs)
+
+    def log(self: BuildClient) -> LogClient:
+        """Get the client for the log of the actor build.
+
+        // TODO: Add documentation link when it's available
+
+        Returns:
+            LogClient: A client allowing access to the log of this actor build.
+        """
+        return LogClient(
+            **self._sub_resource_init_options(resource_path='log'),
+        )
 
 
 class BuildClientAsync(ActorJobBaseClientAsync):


### PR DESCRIPTION
This wraps the new `/actor-builds/:build_id/log` endpoint. See [API reference](https://docs.apify.com/api/v2/#/reference/actor-builds/build-log/get-log) for more information.