### PR TITLE
fix: aborting of last Actor/task run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## [1.6.5](../../releases/tag/v1.6.5) - Not released yet
+## [1.7.0](../../releases/tag/v1.7.0) - Not released yet
 
-...
+### Fixed
+
+- fix abort of last task run
+- fix abort of last Actor run
 
 ## [1.6.4](../../releases/tag/v1.6.4) - 2024-02-27
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apify_client"
-version = "1.6.5"
+version = "1.7.0"
 description = "Apify API client for Python"
 readme = "README.md"
 license = { text = "Apache Software License" }

--- a/src/apify_client/clients/resource_clients/actor.py
+++ b/src/apify_client/clients/resource_clients/actor.py
@@ -344,10 +344,31 @@ class ActorClient(ResourceClient):
         Returns:
             RunClient: The resource client for the last run of this actor.
         """
-        return RunClient(
+        # Note:
+        # The API does not provide a direct endpoint for aborting the last Actor run using a URL like:
+        # https://api.apify.com/v2/acts/{actor_id}/runs/last/abort
+        # To achieve this, we need to implement a workaround using the following URL format:
+        # https://api.apify.com/v2/acts/{actorId}/runs/{runId}/abort
+
+        last_run_client = RunClient(
             **self._sub_resource_init_options(
                 resource_id='last',
                 resource_path='runs',
+                params=self._params(
+                    status=maybe_extract_enum_member_value(status),
+                    origin=maybe_extract_enum_member_value(origin),
+                ),
+            )
+        )
+
+        last_run_client_info = last_run_client.get()
+        actor_id = last_run_client_info['actId']  # type: ignore
+        actor_run_id = last_run_client_info['id']  # type: ignore
+
+        return RunClient(
+            **self._sub_resource_init_options(
+                base_url='https://api.apify.com/v2',
+                resource_path=f'acts/{actor_id}/runs/{actor_run_id}',
                 params=self._params(
                     status=maybe_extract_enum_member_value(status),
                     origin=maybe_extract_enum_member_value(origin),
@@ -634,7 +655,7 @@ class ActorClientAsync(ResourceClientAsync):
         """Retrieve a client for the runs of this actor."""
         return RunCollectionClientAsync(**self._sub_resource_init_options(resource_path='runs'))
 
-    def last_run(self: ActorClientAsync, *, status: ActorJobStatus | None = None, origin: MetaOrigin | None = None) -> RunClientAsync:
+    async def last_run(self: ActorClientAsync, *, status: ActorJobStatus | None = None, origin: MetaOrigin | None = None) -> RunClientAsync:
         """Retrieve the client for the last run of this actor.
 
         Last run is retrieved based on the start time of the runs.
@@ -646,10 +667,31 @@ class ActorClientAsync(ResourceClientAsync):
         Returns:
             RunClientAsync: The resource client for the last run of this actor.
         """
-        return RunClientAsync(
+        # Note:
+        # The API does not provide a direct endpoint for aborting the last Actor run using a URL like:
+        # https://api.apify.com/v2/acts/{actor_id}/runs/last/abort
+        # To achieve this, we need to implement a workaround using the following URL format:
+        # https://api.apify.com/v2/acts/{actorId}/runs/{runId}/abort
+
+        last_run_client = RunClientAsync(
             **self._sub_resource_init_options(
                 resource_id='last',
                 resource_path='runs',
+                params=self._params(
+                    status=maybe_extract_enum_member_value(status),
+                    origin=maybe_extract_enum_member_value(origin),
+                ),
+            )
+        )
+
+        last_run_client_info = await last_run_client.get()
+        actor_id = last_run_client_info['actId']  # type: ignore
+        actor_run_id = last_run_client_info['id']  # type: ignore
+
+        return RunClientAsync(
+            **self._sub_resource_init_options(
+                base_url='https://api.apify.com/v2',
+                resource_path=f'acts/{actor_id}/runs/{actor_run_id}',
                 params=self._params(
                     status=maybe_extract_enum_member_value(status),
                     origin=maybe_extract_enum_member_value(origin),

--- a/src/apify_client/clients/resource_clients/task.py
+++ b/src/apify_client/clients/resource_clients/task.py
@@ -266,10 +266,31 @@ class TaskClient(ResourceClient):
         Returns:
             RunClient: The resource client for the last run of this task.
         """
-        return RunClient(
+        # Note:
+        # The API does not provide a direct endpoint for aborting the last task run using a URL like:
+        # https://api.apify.com/v2/actor-tasks/{task_id}/runs/last/abort
+        # To achieve this, we need to implement a workaround using the following URL format:
+        # https://api.apify.com/v2/acts/{actorId}/runs/{runId}/abort
+
+        last_run_client = RunClient(
             **self._sub_resource_init_options(
                 resource_id='last',
                 resource_path='runs',
+                params=self._params(
+                    status=maybe_extract_enum_member_value(status),
+                    origin=maybe_extract_enum_member_value(origin),
+                ),
+            )
+        )
+
+        last_run_client_info = last_run_client.get()
+        actor_id = last_run_client_info['actId']  # type: ignore
+        actor_run_id = last_run_client_info['id']  # type: ignore
+
+        return RunClient(
+            **self._sub_resource_init_options(
+                base_url='https://api.apify.com/v2',
+                resource_path=f'acts/{actor_id}/runs/{actor_run_id}',
                 params=self._params(
                     status=maybe_extract_enum_member_value(status),
                     origin=maybe_extract_enum_member_value(origin),
@@ -491,7 +512,7 @@ class TaskClientAsync(ResourceClientAsync):
         """Retrieve a client for the runs of this task."""
         return RunCollectionClientAsync(**self._sub_resource_init_options(resource_path='runs'))
 
-    def last_run(self: TaskClientAsync, *, status: ActorJobStatus | None = None, origin: MetaOrigin | None = None) -> RunClientAsync:
+    async def last_run(self: TaskClientAsync, *, status: ActorJobStatus | None = None, origin: MetaOrigin | None = None) -> RunClientAsync:
         """Retrieve the client for the last run of this task.
 
         Last run is retrieved based on the start time of the runs.
@@ -503,10 +524,31 @@ class TaskClientAsync(ResourceClientAsync):
         Returns:
             RunClientAsync: The resource client for the last run of this task.
         """
-        return RunClientAsync(
+        # Note:
+        # The API does not provide a direct endpoint for aborting the last task run using a URL like:
+        # https://api.apify.com/v2/actor-tasks/{task_id}/runs/last/abort
+        # To achieve this, we need to implement a workaround using the following URL format:
+        # https://api.apify.com/v2/acts/{actorId}/runs/{runId}/abort
+
+        last_run_client = RunClientAsync(
             **self._sub_resource_init_options(
                 resource_id='last',
                 resource_path='runs',
+                params=self._params(
+                    status=maybe_extract_enum_member_value(status),
+                    origin=maybe_extract_enum_member_value(origin),
+                ),
+            )
+        )
+
+        last_run_client_info = await last_run_client.get()
+        actor_id = last_run_client_info['actId']  # type: ignore
+        actor_run_id = last_run_client_info['id']  # type: ignore
+
+        return RunClientAsync(
+            **self._sub_resource_init_options(
+                base_url='https://api.apify.com/v2',
+                resource_path=f'acts/{actor_id}/runs/{actor_run_id}',
                 params=self._params(
                     status=maybe_extract_enum_member_value(status),
                     origin=maybe_extract_enum_member_value(origin),


### PR DESCRIPTION
## Problem description

### Aborting the last Actor run does not work

- Resulting in:
```
apify_client._errors.ApifyApiError: We have bad news: there is no API endpoint at this URL. 
Did you specify it correctly?
```

- Code to reproduce it:

```python
# sync version
from apify_client import ApifyClient

TOKEN = '...'
ACTOR_ID = '...'

def actor_run_abort(apify_client: ApifyClient, actor_id: str) -> None:
    actor_client = apify_client.actor(actor_id)
    actor_client.call(wait_secs=1)
    last_run = actor_client.last_run(status='RUNNING', origin='API')
    aborted_info = last_run.abort()
    print(f'aborted_info: {aborted_info}')
    
if __name__ == '__main__':
    apify_client = ApifyClient(TOKEN)
    actor_run_abort(apify_client, ACTOR_ID)   
```

```python
# async version
import asyncio
from apify_client import ApifyClientAsync

TOKEN = '...'
ACTOR_ID = '...'

async def actor_run_abort_async(apify_client: ApifyClientAsync, actor_id: str) -> None:
    actor_client = apify_client.actor(actor_id)
    await actor_client.call(wait_secs=1)
    last_run = await actor_client.last_run(status='RUNNING', origin='API')
    aborted_info = await last_run.abort()
    print(f'aborted_info: {aborted_info}')

if __name__ == '__main__':
    apify_client = ApifyClientAsync(TOKEN)
    asyncio.run(actor_run_abort_async(apify_client, ACTOR_ID))
```

### Aborting of the last task run does not work

- Resulting in:
```
apify_client._errors.ApifyApiError: We have bad news: there is no API endpoint at this URL. 
Did you specify it correctly?
```

- Code to reproduce it:

```python
# sync version
from apify_client import ApifyClient

TOKEN = '...'
TASK_ID = '...'

def task_run_abort(apify_client: ApifyClient, task_id: str) -> None:
    task_client = apify_client.task(task_id)
    task_client.call(wait_secs=1)
    last_run = task_client.last_run(status='RUNNING', origin='API')
    aborted_info = last_run.abort()
    print(f'aborted_info: {aborted_info}')

if __name__ == '__main__':
    apify_client = ApifyClient(TOKEN)
    task_run_abort(apify_client, TASK_ID)

```

```python
# async version
import asyncio
from apify_client import ApifyClientAsync

TOKEN = '...'
TASK_ID = '...'

async def task_run_abort_async(apify_client: ApifyClientAsync, task_id: str) -> None:
    task_client = apify_client.task(task_id)
    await task_client.call(wait_secs=1)
    last_run = await task_client.last_run(status='RUNNING', origin='API')
    aborted_info = await last_run.abort()
    print(f'aborted_info: {aborted_info}')

if __name__ == '__main__':
    apify_client = ApifyClientAsync(TOKEN)
    asyncio.run(task_run_abort_async(apify_client, TASK_ID))
```

### Related issues

- The aborting of the last task run was reported in https://github.com/apify/apify-client-python/issues/190. The aborting of the last Actor run does not work as well as was described above.

### Solution

- Using additional API call to be able to call `https://api.apify.com/v2/acts/{actorId}/runs/{runId}/abort` in both cases.
- In the async version it results in `last_run` method being `async` (should not be released as patch version).
- Copied from source code (Actor run):

```python
# Note:
# The API does not provide a direct endpoint for aborting the last Actor run using a URL like:
# https://api.apify.com/v2/acts/{actor_id}/runs/last/abort
# To achieve this, we need to implement a workaround using the following URL format:
# https://api.apify.com/v2/acts/{actorId}/runs/{runId}/abort
```

- Copied from source code (task run):

```python
# Note:
# The API does not provide a direct endpoint for aborting the last task run using a URL like:
# https://api.apify.com/v2/actor-tasks/{task_id}/runs/last/abort
# To achieve this, we need to implement a workaround using the following URL format:
# https://api.apify.com/v2/acts/{actorId}/runs/{runId}/abort
```

### Testing

- As we do not have a proper testing framework here, it was tested just manually with the code examples provided at the beginning.