### PR TITLE
fix: getting storages of last run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [1.7.1](../../releases/tag/v1.7.1) - Unreleased
 
-...
+### Fixed
+
+- fix breaking change (sync -> async) in 1.7.0
+- fix getting storages of last run
 
 ## [1.7.0](../../releases/tag/v1.7.0) - 2024-05-20
 

--- a/src/apify_client/clients/resource_clients/actor.py
+++ b/src/apify_client/clients/resource_clients/actor.py
@@ -344,31 +344,10 @@ class ActorClient(ResourceClient):
         Returns:
             RunClient: The resource client for the last run of this actor.
         """
-        # Note:
-        # The API does not provide a direct endpoint for aborting the last Actor run using a URL like:
-        # https://api.apify.com/v2/acts/{actor_id}/runs/last/abort
-        # To achieve this, we need to implement a workaround using the following URL format:
-        # https://api.apify.com/v2/acts/{actorId}/runs/{runId}/abort
-
-        last_run_client = RunClient(
+        return RunClient(
             **self._sub_resource_init_options(
                 resource_id='last',
                 resource_path='runs',
-                params=self._params(
-                    status=maybe_extract_enum_member_value(status),
-                    origin=maybe_extract_enum_member_value(origin),
-                ),
-            )
-        )
-
-        last_run_client_info = last_run_client.get()
-        actor_id = last_run_client_info['actId']  # type: ignore
-        actor_run_id = last_run_client_info['id']  # type: ignore
-
-        return RunClient(
-            **self._sub_resource_init_options(
-                base_url='https://api.apify.com/v2',
-                resource_path=f'acts/{actor_id}/runs/{actor_run_id}',
                 params=self._params(
                     status=maybe_extract_enum_member_value(status),
                     origin=maybe_extract_enum_member_value(origin),
@@ -655,7 +634,7 @@ class ActorClientAsync(ResourceClientAsync):
         """Retrieve a client for the runs of this actor."""
         return RunCollectionClientAsync(**self._sub_resource_init_options(resource_path='runs'))
 
-    async def last_run(self: ActorClientAsync, *, status: ActorJobStatus | None = None, origin: MetaOrigin | None = None) -> RunClientAsync:
+    def last_run(self: ActorClientAsync, *, status: ActorJobStatus | None = None, origin: MetaOrigin | None = None) -> RunClientAsync:
         """Retrieve the client for the last run of this actor.
 
         Last run is retrieved based on the start time of the runs.
@@ -667,31 +646,10 @@ class ActorClientAsync(ResourceClientAsync):
         Returns:
             RunClientAsync: The resource client for the last run of this actor.
         """
-        # Note:
-        # The API does not provide a direct endpoint for aborting the last Actor run using a URL like:
-        # https://api.apify.com/v2/acts/{actor_id}/runs/last/abort
-        # To achieve this, we need to implement a workaround using the following URL format:
-        # https://api.apify.com/v2/acts/{actorId}/runs/{runId}/abort
-
-        last_run_client = RunClientAsync(
+        return RunClientAsync(
             **self._sub_resource_init_options(
                 resource_id='last',
                 resource_path='runs',
-                params=self._params(
-                    status=maybe_extract_enum_member_value(status),
-                    origin=maybe_extract_enum_member_value(origin),
-                ),
-            )
-        )
-
-        last_run_client_info = await last_run_client.get()
-        actor_id = last_run_client_info['actId']  # type: ignore
-        actor_run_id = last_run_client_info['id']  # type: ignore
-
-        return RunClientAsync(
-            **self._sub_resource_init_options(
-                base_url='https://api.apify.com/v2',
-                resource_path=f'acts/{actor_id}/runs/{actor_run_id}',
                 params=self._params(
                     status=maybe_extract_enum_member_value(status),
                     origin=maybe_extract_enum_member_value(origin),

--- a/src/apify_client/clients/resource_clients/task.py
+++ b/src/apify_client/clients/resource_clients/task.py
@@ -266,31 +266,10 @@ class TaskClient(ResourceClient):
         Returns:
             RunClient: The resource client for the last run of this task.
         """
-        # Note:
-        # The API does not provide a direct endpoint for aborting the last task run using a URL like:
-        # https://api.apify.com/v2/actor-tasks/{task_id}/runs/last/abort
-        # To achieve this, we need to implement a workaround using the following URL format:
-        # https://api.apify.com/v2/acts/{actorId}/runs/{runId}/abort
-
-        last_run_client = RunClient(
+        return RunClient(
             **self._sub_resource_init_options(
                 resource_id='last',
                 resource_path='runs',
-                params=self._params(
-                    status=maybe_extract_enum_member_value(status),
-                    origin=maybe_extract_enum_member_value(origin),
-                ),
-            )
-        )
-
-        last_run_client_info = last_run_client.get()
-        actor_id = last_run_client_info['actId']  # type: ignore
-        actor_run_id = last_run_client_info['id']  # type: ignore
-
-        return RunClient(
-            **self._sub_resource_init_options(
-                base_url='https://api.apify.com/v2',
-                resource_path=f'acts/{actor_id}/runs/{actor_run_id}',
                 params=self._params(
                     status=maybe_extract_enum_member_value(status),
                     origin=maybe_extract_enum_member_value(origin),
@@ -512,7 +491,7 @@ class TaskClientAsync(ResourceClientAsync):
         """Retrieve a client for the runs of this task."""
         return RunCollectionClientAsync(**self._sub_resource_init_options(resource_path='runs'))
 
-    async def last_run(self: TaskClientAsync, *, status: ActorJobStatus | None = None, origin: MetaOrigin | None = None) -> RunClientAsync:
+    def last_run(self: TaskClientAsync, *, status: ActorJobStatus | None = None, origin: MetaOrigin | None = None) -> RunClientAsync:
         """Retrieve the client for the last run of this task.
 
         Last run is retrieved based on the start time of the runs.
@@ -524,31 +503,10 @@ class TaskClientAsync(ResourceClientAsync):
         Returns:
             RunClientAsync: The resource client for the last run of this task.
         """
-        # Note:
-        # The API does not provide a direct endpoint for aborting the last task run using a URL like:
-        # https://api.apify.com/v2/actor-tasks/{task_id}/runs/last/abort
-        # To achieve this, we need to implement a workaround using the following URL format:
-        # https://api.apify.com/v2/acts/{actorId}/runs/{runId}/abort
-
-        last_run_client = RunClientAsync(
+        return RunClientAsync(
             **self._sub_resource_init_options(
                 resource_id='last',
                 resource_path='runs',
-                params=self._params(
-                    status=maybe_extract_enum_member_value(status),
-                    origin=maybe_extract_enum_member_value(origin),
-                ),
-            )
-        )
-
-        last_run_client_info = await last_run_client.get()
-        actor_id = last_run_client_info['actId']  # type: ignore
-        actor_run_id = last_run_client_info['id']  # type: ignore
-
-        return RunClientAsync(
-            **self._sub_resource_init_options(
-                base_url='https://api.apify.com/v2',
-                resource_path=f'acts/{actor_id}/runs/{actor_run_id}',
                 params=self._params(
                     status=maybe_extract_enum_member_value(status),
                     origin=maybe_extract_enum_member_value(origin),


### PR DESCRIPTION
### Issues

- Closes #231 
- Closes #240 

### Testing - abort last run

Sync Actor - works:

```python
from apify_client import ApifyClient

TOKEN = '...'
ACTOR_ID = '...'


def actor_run_abort(apify_client: ApifyClient, actor_id: str) -> None:
    actor_client = apify_client.actor(actor_id)
    actor_client.call(wait_secs=1)
    last_run = actor_client.last_run(status='RUNNING', origin='API')
    aborted_info = last_run.abort()
    print(f'aborted_info: {aborted_info}')


if __name__ == '__main__':
    apify_client = ApifyClient(TOKEN)
    actor_run_abort(apify_client, ACTOR_ID)
```

Async Actor - works:

```python
import asyncio
from apify_client import ApifyClientAsync

TOKEN = '...'
ACTOR_ID = '...'

async def actor_run_abort_async(apify_client: ApifyClientAsync, actor_id: str) -> None:
    actor_client = apify_client.actor(actor_id)
    await actor_client.call(wait_secs=1)
    last_run = actor_client.last_run(status='RUNNING', origin='API')
    aborted_info = await last_run.abort()
    print(f'aborted_info: {aborted_info}')

if __name__ == '__main__':
    apify_client = ApifyClientAsync(TOKEN)
    asyncio.run(actor_run_abort_async(apify_client, ACTOR_ID))
```

Sync task - works:

```python
from apify_client import ApifyClient

TOKEN = '...'
TASK_ID = '...'

def task_run_abort(apify_client: ApifyClient, task_id: str) -> None:
    task_client = apify_client.task(task_id)
    task_client.call(wait_secs=1)
    last_run = task_client.last_run(status='RUNNING', origin='API')
    aborted_info = last_run.abort()
    print(f'aborted_info: {aborted_info}')

if __name__ == '__main__':
    apify_client = ApifyClient(TOKEN)
    task_run_abort(apify_client, TASK_ID)
```

Async task - works:

```python
import asyncio
from apify_client import ApifyClientAsync

TOKEN = '...'
TASK_ID = '...'


async def task_run_abort_async(apify_client: ApifyClientAsync, task_id: str) -> None:
    task_client = apify_client.task(task_id)
    await task_client.call(wait_secs=1)
    last_run = task_client.last_run(status='RUNNING', origin='API')
    aborted_info = await last_run.abort()
    print(f'aborted_info: {aborted_info}')


if __name__ == '__main__':
    apify_client = ApifyClientAsync(TOKEN)
    asyncio.run(task_run_abort_async(apify_client, TASK_ID))
```

### Testing - get storage of last run

Sync Actor - works:

```python
from apify_client import ApifyClient

TOKEN = '...'
ACTOR_ID = '...'


def actor_run_storage(apify_client: ApifyClient, actor_id: str) -> None:
    actor_client = apify_client.actor(actor_id)
    last_run = actor_client.last_run()
    last_run_dataset_client = last_run.dataset()
    info = last_run_dataset_client.get()
    print(f'info: {info}')


if __name__ == '__main__':
    apify_client = ApifyClient(TOKEN)
    task_run_storage(apify_client, ACTOR_ID)
```

Async Actor - works:

```python
import asyncio

from apify_client import ApifyClientAsync

TOKEN = '...'
ACTOR_ID = '...'


async def actor_run_storage(apify_client: ApifyClientAsync, actor_id: str) -> None:
    actor_client = apify_client.actor(actor_id)
    last_run = actor_client.last_run()
    last_run_dataset_client = last_run.dataset()
    info = await last_run_dataset_client.get()
    print(f'info: {info}')


if __name__ == '__main__':
    apify_client = ApifyClientAsync(TOKEN)
    asyncio.run(task_run_storage(apify_client, ACTOR_ID))
```

Sync task - works:

```python
from apify_client import ApifyClient

TOKEN = '...'
TASK_ID = '...'


def task_run_storage(apify_client: ApifyClient, task_id: str) -> None:
    task_client = apify_client.task(task_id)
    task_client.call(wait_secs=1)
    last_run = task_client.last_run()
    last_run_dataset_client = last_run.dataset()
    info = last_run_dataset_client.get()
    print(f'info: {info}')


if __name__ == '__main__':
    apify_client = ApifyClient(TOKEN)
    task_run_storage(apify_client, TASK_ID)
```

Async task - works:

```python
import asyncio

from apify_client import ApifyClientAsync

TOKEN = '...'
TASK_ID = '...'


async def task_run_storage(apify_client: ApifyClientAsync, task_id: str) -> None:
    task_client = apify_client.task(task_id)
    await task_client.call(wait_secs=1)
    last_run = task_client.last_run()
    last_run_dataset_client = last_run.dataset()
    info = await last_run_dataset_client.get()
    print(f'info: {info}')


if __name__ == '__main__':
    apify_client = ApifyClientAsync(TOKEN)
    asyncio.run(task_run_storage(apify_client, TASK_ID))
```