### PR TITLE
docs: fix docs build with `poetry run`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ check-changelog-entry:
 	poetry run python scripts/check_version_in_changelog.py
 
 build-api-reference:
-	cd website && ./build_api_reference.sh
+	cd website && poetry run ./build_api_reference.sh
 
 run-doc: build-api-reference
 	cd website && npm clean-install && npm run start


### PR DESCRIPTION
Fixes the reference documentation build errors caused by the switch to `poetry` as the sole package manager.

![obrazek](https://github.com/user-attachments/assets/9fa3bb1d-0a68-4edd-a58d-9585a1b372c6)