### PR TITLE
fix: batch add requests can handle more than 25 requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ keywords = [
 python = "^3.9"
 apify-shared = ">=1.1.2"
 httpx = ">=0.25.0"
+more_itertools = ">=10.0.0"
 
 [tool.poetry.group.dev.dependencies]
 build = "~1.2.0"

--- a/scripts/check_async_docstrings.py
+++ b/scripts/check_async_docstrings.py
@@ -36,7 +36,7 @@ for client_source_path in clients_path.glob('**/*.py'):
                 continue
 
             # If the sync method has a docstring, check if it matches the async dostring
-            if isinstance(sync_method.value[0].value, str):
+            if sync_method and isinstance(sync_method.value[0].value, str):
                 sync_docstring = sync_method.value[0].value
                 async_docstring = async_method.value[0].value
                 expected_docstring = sync_to_async_docstring(sync_docstring)

--- a/src/apify_client/clients/resource_clients/request_queue.py
+++ b/src/apify_client/clients/resource_clients/request_queue.py
@@ -344,8 +344,6 @@ class RequestQueueClient(ResourceClient):
                 json=list(batch.requests),
             )
 
-            response_parsed = parse_date_fields(pluck_data(response.json()))
-
             # Retry if the request failed and the retry limit has not been reached.
             if not response.is_success and batch.num_of_retries < max_unprocessed_requests_retries:
                 batch.num_of_retries += 1
@@ -354,6 +352,7 @@ class RequestQueueClient(ResourceClient):
 
             # Otherwise, add the processed/unprocessed requests to their respective lists.
             else:
+                response_parsed = parse_date_fields(pluck_data(response.json()))
                 processed_requests.extend(response_parsed.get('processedRequests', []))
                 unprocessed_requests.extend(response_parsed.get('unprocessedRequests', []))
 

--- a/src/apify_client/clients/resource_clients/request_queue.py
+++ b/src/apify_client/clients/resource_clients/request_queue.py
@@ -286,24 +286,31 @@ class RequestQueueClient(ResourceClient):
         requests: list[dict],
         *,
         forefront: bool = False,
+        max_parallel: int = 1,
         max_unprocessed_requests_retries: int = 3,
         min_delay_between_unprocessed_requests_retries: timedelta = timedelta(milliseconds=500),
     ) -> BatchAddRequestsResult:
         """Add requests to the request queue in batches.
 
-        Requests are split into batches based on size and processed sequentially.
+        Requests are split into batches based on size and processed in parallel.
 
         https://docs.apify.com/api/v2#/reference/request-queues/batch-request-operations/add-requests
 
         Args:
             requests: List of requests to be added to the queue.
             forefront: Whether to add requests to the front of the queue.
+            max_parallel: Specifies the maximum number of parallel tasks for API calls. This is only applicable
+                to the async client. For the sync client, this value must be set to 1, as parallel execution
+                is not supported.
             max_unprocessed_requests_retries: Number of retry attempts for unprocessed requests.
             min_delay_between_unprocessed_requests_retries: Minimum delay between retry attempts for unprocessed requests.
 
         Returns:
             Result containing lists of processed and unprocessed requests.
         """
+        if max_parallel != 1:
+            raise NotImplementedError('max_parallel is only supported in async client')
+
         request_params = self._params(clientKey=self.client_key, forefront=forefront)
 
         # Compute the payload size limit to ensure it doesn't exceed the maximum allowed size.
@@ -707,7 +714,9 @@ class RequestQueueClientAsync(ResourceClientAsync):
         Args:
             requests: List of requests to be added to the queue.
             forefront: Whether to add requests to the front of the queue.
-            max_parallel: Maximum number of parallel tasks for API calls.
+            max_parallel: Specifies the maximum number of parallel tasks for API calls. This is only applicable
+                to the async client. For the sync client, this value must be set to 1, as parallel execution
+                is not supported.
             max_unprocessed_requests_retries: Number of retry attempts for unprocessed requests.
             min_delay_between_unprocessed_requests_retries: Minimum delay between retry attempts for unprocessed requests.
 

--- a/src/apify_client/clients/resource_clients/request_queue.py
+++ b/src/apify_client/clients/resource_clients/request_queue.py
@@ -30,12 +30,12 @@ class BatchAddRequestsResult(TypedDict):
     """Result of the batch add requests operation.
 
     Args:
-        processed_requests: List of successfully added requests.
-        unprocessed_requests: List of requests that failed to be added.
+        processedRequests: List of successfully added requests.
+        unprocessedRequests: List of requests that failed to be added.
     """
 
-    processed_requests: list[dict]
-    unprocessed_requests: list[dict]
+    processedRequests: list[dict]
+    unprocessedRequests: list[dict]
 
 
 @dataclass
@@ -351,8 +351,8 @@ class RequestQueueClient(ResourceClient):
                 unprocessed_requests.extend(response_parsed.get('unprocessedRequests', []))
 
         return {
-            'processed_requests': processed_requests,
-            'unprocessed_requests': unprocessed_requests,
+            'processedRequests': processed_requests,
+            'unprocessedRequests': unprocessed_requests,
         }
 
     def batch_delete_requests(self: RequestQueueClient, requests: list[dict]) -> dict:
@@ -685,8 +685,8 @@ class RequestQueueClientAsync(ResourceClientAsync):
                 queue.task_done()
 
         return {
-            'processed_requests': processed_requests,
-            'unprocessed_requests': unprocessed_requests,
+            'processedRequests': processed_requests,
+            'unprocessedRequests': unprocessed_requests,
         }
 
     async def batch_add_requests(
@@ -756,12 +756,12 @@ class RequestQueueClientAsync(ResourceClientAsync):
         unprocessed_requests = []
 
         for result in results:
-            processed_requests.extend(result['processed_requests'])
-            unprocessed_requests.extend(result['unprocessed_requests'])
+            processed_requests.extend(result['processedRequests'])
+            unprocessed_requests.extend(result['unprocessedRequests'])
 
         return {
-            'processed_requests': processed_requests,
-            'unprocessed_requests': unprocessed_requests,
+            'processedRequests': processed_requests,
+            'unprocessedRequests': unprocessed_requests,
         }
 
     async def batch_delete_requests(self: RequestQueueClientAsync, requests: list[dict]) -> dict:


### PR DESCRIPTION
### Description

- RQ's batch add requests can handle more than 25 requests.
- It was implemented in the same way as in the TS client.
- Applies for both sync & async versions.
    - I do not use multi-threading for the sync version, since it is out of the scope of this issue. If users want performance, they should go with the client's async version. But if we decide it is worth to implement it, let's open another issue.

### Issues

- Closes: #264

### Testing

It was tested on this code sample (plus the sync alternative):

```python
import asyncio

from apify_client import ApifyClientAsync
from crawlee._utils.crypto import get_random_id

TOKEN = '...'


async def main() -> None:
    apify_client = ApifyClientAsync(token=TOKEN)
    rqs_client = apify_client.request_queues()
    rq = await rqs_client.get_or_create(name='my-rq')
    rq_client = apify_client.request_queue(rq['id'])

    print('Add a single request...')
    result_1 = await rq_client.add_request({'url': 'http://example.com', 'uniqueKey': get_random_id()})
    print(f'result: {result_1}')

    print('Add multiple requests...')
    requests = [
        {
            'url': f'https://example.com/{i}/',
            'uniqueKey': get_random_id(),
        }
        for i in range(110)
    ]
    result_2 = await rq_client.batch_add_requests(requests)
    print(f'result: {result_2}')


if __name__ == '__main__':
    asyncio.run(main())
```

### Checklist

- [x] CI passed