### PR TITLE
docs: bump `@apify/docusaurus-plugin-typedoc-api`

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -82,6 +82,7 @@ module.exports = {
                 pathToCurrentVersionTypedocJSON: `${__dirname}/api-typedoc-generated.json`,
                 sortSidebar: groupSort,
                 routeBasePath: 'reference',
+                python: true,
             },
         ],
         ...config.plugins,

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -7,7 +7,7 @@
             "name": "apify-client-python",
             "dependencies": {
                 "@apify/docs-theme": "^1.0.132",
-                "@apify/docusaurus-plugin-typedoc-api": "^4.2.5",
+                "@apify/docusaurus-plugin-typedoc-api": "^4.2.6",
                 "@docusaurus/core": "^3.5.2",
                 "@docusaurus/plugin-client-redirects": "^3.5.2",
                 "@docusaurus/preset-classic": "^3.5.2",
@@ -307,14 +307,15 @@
             }
         },
         "node_modules/@apify/docusaurus-plugin-typedoc-api": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@apify/docusaurus-plugin-typedoc-api/-/docusaurus-plugin-typedoc-api-4.2.5.tgz",
-            "integrity": "sha512-JfyTI+GQjsBeeB/iw5lj9JcZ76bsczcdlXlodjtRyIkjCRjm7d3a3UM+YgCZn5G7B0UMPcPuB4x07MXSlRGZ4w==",
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@apify/docusaurus-plugin-typedoc-api/-/docusaurus-plugin-typedoc-api-4.2.6.tgz",
+            "integrity": "sha512-M/rpRqbHZjL49xXtvdxdh/M7jSSR5lb3mjKERzKKnX6i92B5BRetL7Eb4qHre9QPQVijgzILhlhTi8otvr0LAw==",
             "license": "MIT",
             "dependencies": {
                 "@docusaurus/plugin-content-docs": "^3.5.2",
                 "@docusaurus/types": "^3.5.2",
                 "@docusaurus/utils": "^3.5.2",
+                "@types/react": "^18.3.11",
                 "@vscode/codicons": "^0.0.35",
                 "marked": "^9.1.6",
                 "marked-smartypants": "^1.1.5",
@@ -329,6 +330,16 @@
                 "@docusaurus/mdx-loader": "^3.5.2",
                 "react": ">=18.0.0",
                 "typescript": "^5.0.0"
+            }
+        },
+        "node_modules/@apify/docusaurus-plugin-typedoc-api/node_modules/@types/react": {
+            "version": "18.3.11",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
+            "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/prop-types": "*",
+                "csstype": "^3.0.2"
             }
         },
         "node_modules/@apify/eslint-config": {

--- a/website/package.json
+++ b/website/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@apify/docs-theme": "^1.0.132",
-        "@apify/docusaurus-plugin-typedoc-api": "^4.2.5",
+        "@apify/docusaurus-plugin-typedoc-api": "^4.2.6",
         "@docusaurus/core": "^3.5.2",
         "@docusaurus/plugin-client-redirects": "^3.5.2",
         "@docusaurus/preset-classic": "^3.5.2",


### PR DESCRIPTION
Fixes type-wise links between documentation pages (see https://github.com/apify/apify-client-js/issues/591 for more context ). 