### PR TITLE
refactor: rename /openapi-specification -> /openapi.json

### DIFF
--- a/src/apify_client/clients/resource_clients/build.py
+++ b/src/apify_client/clients/resource_clients/build.py
@@ -43,16 +43,16 @@ class BuildClient(ActorJobBaseClient):
         """
         return self._abort()
 
-    def get_open_api_specification(self) -> dict | None:
-        """Return OpenAPI specification of the Actor's build.
+    def get_open_api_definition(self) -> dict | None:
+        """Return OpenAPI definition of the Actor's build.
 
-        https://docs.apify.com/api/v2/actor-build-openapi-specification-get
+        https://docs.apify.com/api/v2/actor-build-openapi-json-get
 
         Returns:
-            OpenAPI specification of the Actor's build.
+            OpenAPI definition of the Actor's build.
         """
         response = self.http_client.call(
-            url=self._url('openapi-specification'),
+            url=self._url('openapi.json'),
             method='GET',
         )
 
@@ -120,16 +120,16 @@ class BuildClientAsync(ActorJobBaseClientAsync):
         """
         return await self._delete()
 
-    async def get_open_api_specification(self) -> dict | None:
-        """Return OpenAPI specification of the Actor's build.
+    async def get_open_api_definition(self) -> dict | None:
+        """Return OpenAPI definition of the Actor's build.
 
-        https://docs.apify.com/api/v2/actor-build-openapi-specification-get
+        https://docs.apify.com/api/v2/actor-build-openapi-json-get
 
         Returns:
-            OpenAPI specification of the Actor's build.
+            OpenAPI definition of the Actor's build.
         """
         response = await self.http_client.call(
-            url=self._url('openapi-specification'),
+            url=self._url('openapi.json'),
             method='GET',
         )
 


### PR DESCRIPTION
Recently, we created new endpoints:

`/v2/acts/:actorId/builds/:buildId/openapi-specification`
`/v2/actor-builds/:buildId/openapi-specification`
Than we've received a feedback to rename endpoints to `/openapi.json`.

**This PR renames OpenAPI endpoints from `*/openapi-specification` to `*/openapi.json`*

More context [here](https://apify.slack.com/archives/C01VBUV81UZ/p1737975106009729)