### PR TITLE
feat: add rate limit statistics

### DIFF
--- a/src/apify_client/_http_client.py
+++ b/src/apify_client/_http_client.py
@@ -229,6 +229,8 @@ class HTTPClientAsync(_BaseHTTPClient):
         log_context.method.set(method)
         log_context.url.set(url)
 
+        self.stats.calls += 1
+
         if stream and parse_response:
             raise ValueError('Cannot stream response and parse it at the same time!')
 

--- a/src/apify_client/_http_client.py
+++ b/src/apify_client/_http_client.py
@@ -14,6 +14,7 @@ from apify_shared.utils import ignore_docs, is_content_type_json, is_content_typ
 
 from apify_client._errors import ApifyApiError, InvalidResponseBodyError, is_retryable_error
 from apify_client._logging import log_context, logger_name
+from apify_client._statistics import Statistics
 from apify_client._utils import retry_with_exp_backoff, retry_with_exp_backoff_async
 
 if TYPE_CHECKING:
@@ -35,6 +36,7 @@ class _BaseHTTPClient:
         max_retries: int = 8,
         min_delay_between_retries_millis: int = 500,
         timeout_secs: int = 360,
+        stats: Statistics | None = None,
     ) -> None:
         self.max_retries = max_retries
         self.min_delay_between_retries_millis = min_delay_between_retries_millis
@@ -58,6 +60,8 @@ class _BaseHTTPClient:
 
         self.httpx_client = httpx.Client(headers=headers, follow_redirects=True, timeout=timeout_secs)
         self.httpx_async_client = httpx.AsyncClient(headers=headers, follow_redirects=True, timeout=timeout_secs)
+
+        self.stats = stats or Statistics()
 
     @staticmethod
     def _maybe_parse_response(response: httpx.Response) -> Any:
@@ -143,6 +147,8 @@ class HTTPClient(_BaseHTTPClient):
         log_context.method.set(method)
         log_context.url.set(url)
 
+        self.stats.calls += 1
+
         if stream and parse_response:
             raise ValueError('Cannot stream response and parse it at the same time!')
 
@@ -153,6 +159,9 @@ class HTTPClient(_BaseHTTPClient):
         def _make_request(stop_retrying: Callable, attempt: int) -> httpx.Response:
             log_context.attempt.set(attempt)
             logger.debug('Sending request')
+
+            self.stats.requests += 1
+
             try:
                 request = httpx_client.build_request(
                     method=method,
@@ -176,6 +185,9 @@ class HTTPClient(_BaseHTTPClient):
                         setattr(response, '_maybe_parsed_body', _maybe_parsed_body)  # noqa: B010
 
                     return response
+
+                if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
+                    self.stats.add_rate_limit_error(attempt)
 
             except Exception as e:
                 logger.debug('Request threw exception', exc_info=e)
@@ -250,6 +262,9 @@ class HTTPClientAsync(_BaseHTTPClient):
                         setattr(response, '_maybe_parsed_body', _maybe_parsed_body)  # noqa: B010
 
                     return response
+
+                if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
+                    self.stats.add_rate_limit_error(attempt)
 
             except Exception as e:
                 logger.debug('Request threw exception', exc_info=e)

--- a/src/apify_client/_statistics.py
+++ b/src/apify_client/_statistics.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from dataclasses import dataclass, field
 
 
@@ -11,7 +12,7 @@ class Statistics:
     requests: int = 0
     """Total number of HTTP requests sent, including retries."""
 
-    rate_limit_errors: list[int] = field(default_factory=list)
+    rate_limit_errors: defaultdict[int, int] = field(default_factory=lambda: defaultdict(int))
     """List tracking which retry attempts encountered rate limit (429) errors."""
 
     def add_rate_limit_error(self, attempt: int) -> None:
@@ -23,15 +24,4 @@ class Statistics:
         if attempt < 1:
             raise ValueError('Attempt must be greater than 0')
 
-        index = attempt - 1
-        self._ensure_list_capacity(index)
-        self.rate_limit_errors[index] += 1
-
-    def _ensure_list_capacity(self, index: int) -> None:
-        """Ensure rate_limit_errors list has enough capacity.
-
-        Args:
-            index: Required index to access
-        """
-        if len(self.rate_limit_errors) <= index:
-            self.rate_limit_errors.extend([0] * (index - len(self.rate_limit_errors) + 1))
+        self.rate_limit_errors[attempt - 1] += 1

--- a/src/apify_client/_statistics.py
+++ b/src/apify_client/_statistics.py
@@ -13,7 +13,7 @@ class Statistics:
         """Add rate limit error for specific attempt.
 
         Args:
-            attempt: The attempt number (1-based indexing)
+            attempt: The attempt number (1-based indexing).
         """
         if attempt < 1:
             raise ValueError('Attempt must be greater than 0')

--- a/src/apify_client/_statistics.py
+++ b/src/apify_client/_statistics.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Statistics:
+    """Statistics about API client usage and rate limit errors."""
+
+    calls: int = 0
+    requests: int = 0
+    rate_limit_errors: list[int] = field(default_factory=list)
+
+    def add_rate_limit_error(self, attempt: int) -> None:
+        """Add rate limit error for specific attempt.
+
+        Args:
+            attempt: The attempt number (1-based indexing)
+        """
+        if attempt < 1:
+            raise ValueError('Attempt must be greater than 0')
+
+        index = attempt - 1
+        self._ensure_list_capacity(index)
+        self.rate_limit_errors[index] += 1
+
+    def _ensure_list_capacity(self, index: int) -> None:
+        """Ensure rate_limit_errors list has enough capacity.
+
+        Args:
+            index: Required index to access
+        """
+        if len(self.rate_limit_errors) <= index:
+            self.rate_limit_errors.extend([0] * (index - len(self.rate_limit_errors) + 1))

--- a/src/apify_client/_statistics.py
+++ b/src/apify_client/_statistics.py
@@ -6,8 +6,13 @@ class Statistics:
     """Statistics about API client usage and rate limit errors."""
 
     calls: int = 0
+    """Total number of API method calls made by the client."""
+
     requests: int = 0
+    """Total number of HTTP requests sent, including retries."""
+
     rate_limit_errors: list[int] = field(default_factory=list)
+    """List tracking which retry attempts encountered rate limit (429) errors."""
 
     def add_rate_limit_error(self, attempt: int) -> None:
         """Add rate limit error for specific attempt.

--- a/src/apify_client/client.py
+++ b/src/apify_client/client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from apify_shared.utils import ignore_docs
 
 from apify_client._http_client import HTTPClient, HTTPClientAsync
+from apify_client._statistics import Statistics
 from apify_client.clients import (
     ActorClient,
     ActorClientAsync,
@@ -126,11 +127,13 @@ class ApifyClient(_BaseApifyClient):
             timeout_secs=timeout_secs,
         )
 
+        self.stats = Statistics()
         self.http_client = HTTPClient(
             token=token,
             max_retries=self.max_retries,
             min_delay_between_retries_millis=self.min_delay_between_retries_millis,
             timeout_secs=self.timeout_secs,
+            stats=self.stats,
         )
 
     def actor(self, actor_id: str) -> ActorClient:

--- a/tests/unit/test_statistics.py
+++ b/tests/unit/test_statistics.py
@@ -13,6 +13,14 @@ from apify_client._statistics import Statistics
         ([1, 5, 3], [1, 0, 1, 0, 1]),
         ([2, 1, 2, 1, 5, 2, 1], [3, 3, 0, 0, 1]),
     ],
+    ids=[
+        'single_error',
+        'two_single_errors',
+        'two_single_errors_reversed',
+        'three_single_errors',
+        'three_single_errors_reordered',
+        'multiple_errors_per_attempt',
+    ],
 )
 def test_add_rate_limit_error(attempts: list[int], expected_errors: list[int]) -> None:
     """Test that add_rate_limit_error correctly tracks errors for different attempt sequences."""

--- a/tests/unit/test_statistics.py
+++ b/tests/unit/test_statistics.py
@@ -6,12 +6,12 @@ from apify_client._statistics import Statistics
 @pytest.mark.parametrize(
     ('attempts', 'expected_errors'),
     [
-        ([1], [1]),
-        ([1, 5], [1, 0, 0, 0, 1]),
-        ([5, 1], [1, 0, 0, 0, 1]),
-        ([3, 5, 1], [1, 0, 1, 0, 1]),
-        ([1, 5, 3], [1, 0, 1, 0, 1]),
-        ([2, 1, 2, 1, 5, 2, 1], [3, 3, 0, 0, 1]),
+        ([1], {0: 1}),
+        ([1, 5], {0: 1, 4: 1}),
+        ([5, 1], {0: 1, 4: 1}),
+        ([3, 5, 1], {0: 1, 2: 1, 4: 1}),
+        ([1, 5, 3], {0: 1, 2: 1, 4: 1}),
+        ([2, 1, 2, 1, 5, 2, 1], {0: 3, 1: 3, 4: 1}),
     ],
     ids=[
         'single_error',
@@ -42,7 +42,7 @@ def test_statistics_initial_state() -> None:
     stats = Statistics()
     assert stats.calls == 0
     assert stats.requests == 0
-    assert stats.rate_limit_errors == []
+    assert stats.rate_limit_errors == {}
 
 
 def test_add_rate_limit_error_type_validation() -> None:

--- a/tests/unit/test_statistics.py
+++ b/tests/unit/test_statistics.py
@@ -1,0 +1,44 @@
+import pytest
+
+from apify_client._statistics import Statistics
+
+
+@pytest.mark.parametrize(
+    ('attempts', 'expected_errors'),
+    [
+        ([1], [1]),
+        ([1, 5], [1, 0, 0, 0, 1]),
+        ([5, 1], [1, 0, 0, 0, 1]),
+        ([3, 5, 1], [1, 0, 1, 0, 1]),
+        ([1, 5, 3], [1, 0, 1, 0, 1]),
+        ([2, 1, 2, 1, 5, 2, 1], [3, 3, 0, 0, 1]),
+    ],
+)
+def test_add_rate_limit_error(attempts: list[int], expected_errors: list[int]) -> None:
+    """Test that add_rate_limit_error correctly tracks errors for different attempt sequences."""
+    stats = Statistics()
+    for attempt in attempts:
+        stats.add_rate_limit_error(attempt)
+    assert stats.rate_limit_errors == expected_errors
+
+
+def test_add_rate_limit_error_invalid_attempt() -> None:
+    """Test that add_rate_limit_error raises ValueError for invalid attempt."""
+    stats = Statistics()
+    with pytest.raises(ValueError, match='Attempt must be greater than 0'):
+        stats.add_rate_limit_error(0)
+
+
+def test_statistics_initial_state() -> None:
+    """Test initial state of Statistics instance."""
+    stats = Statistics()
+    assert stats.calls == 0
+    assert stats.requests == 0
+    assert stats.rate_limit_errors == []
+
+
+def test_add_rate_limit_error_type_validation() -> None:
+    """Test type validation in add_rate_limit_error."""
+    stats = Statistics()
+    with pytest.raises(TypeError):
+        stats.add_rate_limit_error('1')  # type: ignore[arg-type]

--- a/tests/unit/test_statistics.py
+++ b/tests/unit/test_statistics.py
@@ -6,20 +6,12 @@ from apify_client._statistics import Statistics
 @pytest.mark.parametrize(
     ('attempts', 'expected_errors'),
     [
-        ([1], {0: 1}),
-        ([1, 5], {0: 1, 4: 1}),
-        ([5, 1], {0: 1, 4: 1}),
-        ([3, 5, 1], {0: 1, 2: 1, 4: 1}),
-        ([1, 5, 3], {0: 1, 2: 1, 4: 1}),
-        ([2, 1, 2, 1, 5, 2, 1], {0: 3, 1: 3, 4: 1}),
-    ],
-    ids=[
-        'single_error',
-        'two_single_errors',
-        'two_single_errors_reversed',
-        'three_single_errors',
-        'three_single_errors_reordered',
-        'multiple_errors_per_attempt',
+        pytest.param([1], {0: 1}, id='single error'),
+        pytest.param([1, 5], {0: 1, 4: 1}, id='two single errors'),
+        pytest.param([5, 1], {0: 1, 4: 1}, id='two single errors reversed'),
+        pytest.param([3, 5, 1], {0: 1, 2: 1, 4: 1}, id='three single errors'),
+        pytest.param([1, 5, 3], {0: 1, 2: 1, 4: 1}, id='three single errors reordered'),
+        pytest.param([2, 1, 2, 1, 5, 2, 1], {0: 3, 1: 3, 4: 1}, id='multiple errors per attempt'),
     ],
 )
 def test_add_rate_limit_error(attempts: list[int], expected_errors: list[int]) -> None:


### PR DESCRIPTION
### Description

- Add `Statistics` for gather HTTP rate limit errors
- Linked Issues is in the sdk, but the implementation should be in the client

### Issues

- https://github.com/apify/apify-sdk-python/issues/318

### Testing

- Add tests for `Statistics`