### PR TITLE
docs: Set line length to docs related code to 90

### DIFF
--- a/docs/02_concepts/code/06_logging_formatter.py
+++ b/docs/02_concepts/code/06_logging_formatter.py
@@ -7,7 +7,8 @@ apify_client_logger.addHandler(logging.StreamHandler())
 
 # Create a custom logging formatter
 formatter = logging.Formatter(
-    '%(asctime)s - %(name)s - %(levelname)s - %(message)s - %(attempt)s - %(status_code)s - %(url)s'
+    '%(asctime)s - %(name)s - %(levelname)s - %(message)s - '
+    '%(attempt)s - %(status_code)s - %(url)s'
 )
 handler = logging.StreamHandler()
 handler.setFormatter(formatter)

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,0 +1,9 @@
+# Line lenght different from the rest of the code to make sure that the example codes visualised on the generated
+# documentation webpages are shown without vertical slider to make them more readable.
+
+[tool.ruff]
+# Inherit all from project top configuration file.
+extend = "../pyproject.toml"
+
+# Override just line length
+line-length = 90 # Maximum possible fit to the doc webpage. Longer lines need slider.


### PR DESCRIPTION
### Description

Set line length to docs related code to 90 to have each code example fully visible without the need to use slider.
Update existing examples to be compliant.