### PR TITLE
refactor: Remove redundant retries from `batch_add_requests`

### DIFF
--- a/src/apify_client/clients/resource_clients/request_queue.py
+++ b/src/apify_client/clients/resource_clients/request_queue.py
@@ -5,7 +5,7 @@ import logging
 import math
 from collections.abc import Iterable
 from queue import Queue
-from typing import Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from apify_shared.utils import filter_out_none_values_recursively, ignore_docs, parse_date_fields
 from more_itertools import constrained_batches
@@ -13,6 +13,9 @@ from more_itertools import constrained_batches
 from apify_client._errors import ApifyApiError
 from apify_client._utils import catch_not_found_or_throw, pluck_data
 from apify_client.clients.base import ResourceClient, ResourceClientAsync
+
+if TYPE_CHECKING:
+    from datetime import timedelta
 
 logger = logging.getLogger(__name__)
 
@@ -279,6 +282,8 @@ class RequestQueueClient(ResourceClient):
         *,
         forefront: bool = False,
         max_parallel: int = 1,
+        max_unprocessed_requests_retries: int | None = None,
+        min_delay_between_unprocessed_requests_retries: timedelta | None = None,
     ) -> BatchAddRequestsResult:
         """Add requests to the request queue in batches.
 
@@ -292,10 +297,17 @@ class RequestQueueClient(ResourceClient):
             max_parallel: Specifies the maximum number of parallel tasks for API calls. This is only applicable
                 to the async client. For the sync client, this value must be set to 1, as parallel execution
                 is not supported.
+            max_unprocessed_requests_retries: Deprecated argument. Will be removed in next major release.
+            min_delay_between_unprocessed_requests_retries: Deprecated argument. Will be removed in next major release.
 
         Returns:
             Result containing lists of processed and unprocessed requests.
         """
+        if max_unprocessed_requests_retries:
+            logger.warning('`max_unprocessed_requests_retries` is deprecated and not used anymore.')
+        if min_delay_between_unprocessed_requests_retries:
+            logger.warning('`min_delay_between_unprocessed_requests_retries` is deprecated and not used anymore.')
+
         if max_parallel != 1:
             raise NotImplementedError('max_parallel is only supported in async client')
 
@@ -678,6 +690,8 @@ class RequestQueueClientAsync(ResourceClientAsync):
         *,
         forefront: bool = False,
         max_parallel: int = 5,
+        max_unprocessed_requests_retries: int | None = None,
+        min_delay_between_unprocessed_requests_retries: timedelta | None = None,
     ) -> BatchAddRequestsResult:
         """Add requests to the request queue in batches.
 
@@ -691,10 +705,17 @@ class RequestQueueClientAsync(ResourceClientAsync):
             max_parallel: Specifies the maximum number of parallel tasks for API calls. This is only applicable
                 to the async client. For the sync client, this value must be set to 1, as parallel execution
                 is not supported.
+            max_unprocessed_requests_retries: Deprecated argument. Will be removed in next major release.
+            min_delay_between_unprocessed_requests_retries: Deprecated argument. Will be removed in next major release.
 
         Returns:
             Result containing lists of processed and unprocessed requests.
         """
+        if max_unprocessed_requests_retries:
+            logger.warning('`max_unprocessed_requests_retries` is deprecated and not used anymore.')
+        if min_delay_between_unprocessed_requests_retries:
+            logger.warning('`min_delay_between_unprocessed_requests_retries` is deprecated and not used anymore.')
+
         tasks = set[asyncio.Task]()
         queue: asyncio.Queue[Iterable[dict]] = asyncio.Queue()
         request_params = self._params(clientKey=self.client_key, forefront=forefront)

--- a/src/apify_client/clients/resource_clients/request_queue.py
+++ b/src/apify_client/clients/resource_clients/request_queue.py
@@ -332,24 +332,20 @@ class RequestQueueClient(ResourceClient):
             for request in request_batch:
                 unprocessed_requests[request['uniqueKey']] = _get_unprocessed_request_from_request(request)
 
-            try:
-                # Send the batch to the API.
-                response = self.http_client.call(
-                    url=self._url('requests/batch'),
-                    method='POST',
-                    params=request_params,
-                    json=list(request_batch),
-                    timeout_secs=_MEDIUM_TIMEOUT,
-                )
+            # Send the batch to the API.
+            response = self.http_client.call(
+                url=self._url('requests/batch'),
+                method='POST',
+                params=request_params,
+                json=list(request_batch),
+                timeout_secs=_MEDIUM_TIMEOUT,
+            )
 
-                response_parsed = parse_date_fields(pluck_data(response.json()))
-                processed_requests.extend(response_parsed.get('processedRequests', []))
+            response_parsed = parse_date_fields(pluck_data(response.json()))
+            processed_requests.extend(response_parsed.get('processedRequests', []))
 
-                for processed_request in response_parsed.get('processedRequests', []):
-                    unprocessed_requests.pop(processed_request['uniqueKey'], None)
-
-            except Exception as exc:
-                logger.warning(f'Error occurred while processing a batch of requests: {exc}')
+            for processed_request in response_parsed.get('processedRequests', []):
+                unprocessed_requests.pop(processed_request['uniqueKey'], None)
 
         return {
             'processedRequests': processed_requests,
@@ -667,28 +663,22 @@ class RequestQueueClientAsync(ResourceClientAsync):
             except asyncio.CancelledError:
                 break
 
-            try:
-                # Send the batch to the API.
-                response = await self.http_client.call(
-                    url=self._url('requests/batch'),
-                    method='POST',
-                    params=request_params,
-                    json=list(request_batch),
-                    timeout_secs=_MEDIUM_TIMEOUT,
-                )
+            # Send the batch to the API.
+            response = await self.http_client.call(
+                url=self._url('requests/batch'),
+                method='POST',
+                params=request_params,
+                json=list(request_batch),
+                timeout_secs=_MEDIUM_TIMEOUT,
+            )
 
-                response_parsed = parse_date_fields(pluck_data(response.json()))
-                processed_requests.extend(response_parsed.get('processedRequests', []))
+            response_parsed = parse_date_fields(pluck_data(response.json()))
+            processed_requests.extend(response_parsed.get('processedRequests', []))
 
-                for processed_request in response_parsed.get('processedRequests', []):
-                    unprocessed_requests.pop(processed_request['uniqueKey'], None)
+            for processed_request in response_parsed.get('processedRequests', []):
+                unprocessed_requests.pop(processed_request['uniqueKey'], None)
 
-            except Exception as exc:
-                logger.warning(f'Error occurred while processing a batch of requests: {exc}')
-
-            finally:
-                # Mark the batch as done whether it succeeded or failed.
-                queue.task_done()
+            queue.task_done()
 
         return {
             'processedRequests': processed_requests,

--- a/tests/unit/test_client_request_queue.py
+++ b/tests/unit/test_client_request_queue.py
@@ -1,5 +1,7 @@
+import pytest
 import respx
 
+import apify_client
 from apify_client import ApifyClient, ApifyClientAsync
 
 _PARTIALLY_ADDED_BATCH_RESPONSE_CONTENT = """{
@@ -24,8 +26,8 @@ _PARTIALLY_ADDED_BATCH_RESPONSE_CONTENT = """{
 
 
 @respx.mock
-async def test_batch_not_processed_due_to_exception_async() -> None:
-    """Test that all requests are unprocessed unless explicitly stated by the server that they have been processed."""
+async def test_batch_not_processed_raises_exception_async() -> None:
+    """Test that client exceptions are not silently ignored"""
     client = ApifyClientAsync(token='')
 
     respx.route(method='POST', host='api.apify.com').mock(return_value=respx.MockResponse(401))
@@ -35,8 +37,8 @@ async def test_batch_not_processed_due_to_exception_async() -> None:
     ]
     rq_client = client.request_queue(request_queue_id='whatever')
 
-    response = await rq_client.batch_add_requests(requests=requests)
-    assert response['unprocessedRequests'] == requests
+    with pytest.raises(apify_client._errors.ApifyApiError):
+        await rq_client.batch_add_requests(requests=requests)
 
 
 @respx.mock
@@ -58,8 +60,8 @@ async def test_batch_processed_partially_async() -> None:
 
 
 @respx.mock
-def test_batch_not_processed_due_to_exception_sync() -> None:
-    """Test that all requests are unprocessed unless explicitly stated by the server that they have been processed."""
+def test_batch_not_processed_raises_exception_sync() -> None:
+    """Test that client exceptions are not silently ignored"""
     client = ApifyClient(token='')
 
     respx.route(method='POST', host='api.apify.com').mock(return_value=respx.MockResponse(401))
@@ -69,8 +71,8 @@ def test_batch_not_processed_due_to_exception_sync() -> None:
     ]
     rq_client = client.request_queue(request_queue_id='whatever')
 
-    response = rq_client.batch_add_requests(requests=requests)
-    assert response['unprocessedRequests'] == requests
+    with pytest.raises(apify_client._errors.ApifyApiError):
+        rq_client.batch_add_requests(requests=requests)
 
 
 @respx.mock

--- a/tests/unit/test_client_request_queue.py
+++ b/tests/unit/test_client_request_queue.py
@@ -1,0 +1,91 @@
+import respx
+
+from apify_client import ApifyClient, ApifyClientAsync
+
+_PARTIALLY_ADDED_BATCH_RESPONSE_CONTENT = """{
+  "data": {
+    "processedRequests": [
+      {
+        "requestId": "YiKoxjkaS9gjGTqhF",
+        "uniqueKey": "http://example.com/1",
+        "wasAlreadyPresent": true,
+        "wasAlreadyHandled": false
+      }
+    ],
+    "unprocessedRequests": [
+      {
+        "uniqueKey": "http://example.com/2",
+        "url": "http://example.com/2",
+        "method": "GET"
+      }
+    ]
+  }
+}"""
+
+
+@respx.mock
+async def test_batch_not_processed_due_to_exception_async() -> None:
+    """Test that all requests are unprocessed unless explicitly stated by the server that they have been processed."""
+    client = ApifyClientAsync(token='')
+
+    respx.route(method='POST', host='api.apify.com').mock(return_value=respx.MockResponse(401))
+    requests = [
+        {'uniqueKey': 'http://example.com/1', 'url': 'http://example.com/1', 'method': 'GET'},
+        {'uniqueKey': 'http://example.com/2', 'url': 'http://example.com/2', 'method': 'GET'},
+    ]
+    rq_client = client.request_queue(request_queue_id='whatever')
+
+    response = await rq_client.batch_add_requests(requests=requests)
+    assert response['unprocessedRequests'] == requests
+
+
+@respx.mock
+async def test_batch_processed_partially_async() -> None:
+    client = ApifyClientAsync(token='')
+
+    respx.route(method='POST', host='api.apify.com').mock(
+        return_value=respx.MockResponse(200, content=_PARTIALLY_ADDED_BATCH_RESPONSE_CONTENT)
+    )
+    requests = [
+        {'uniqueKey': 'http://example.com/1', 'url': 'http://example.com/1', 'method': 'GET'},
+        {'uniqueKey': 'http://example.com/2', 'url': 'http://example.com/2', 'method': 'GET'},
+    ]
+    rq_client = client.request_queue(request_queue_id='whatever')
+
+    response = await rq_client.batch_add_requests(requests=requests)
+    assert requests[0]['uniqueKey'] in {request['uniqueKey'] for request in response['processedRequests']}
+    assert response['unprocessedRequests'] == [requests[1]]
+
+
+@respx.mock
+def test_batch_not_processed_due_to_exception_sync() -> None:
+    """Test that all requests are unprocessed unless explicitly stated by the server that they have been processed."""
+    client = ApifyClient(token='')
+
+    respx.route(method='POST', host='api.apify.com').mock(return_value=respx.MockResponse(401))
+    requests = [
+        {'uniqueKey': 'http://example.com/1', 'url': 'http://example.com/1', 'method': 'GET'},
+        {'uniqueKey': 'http://example.com/2', 'url': 'http://example.com/2', 'method': 'GET'},
+    ]
+    rq_client = client.request_queue(request_queue_id='whatever')
+
+    response = rq_client.batch_add_requests(requests=requests)
+    assert response['unprocessedRequests'] == requests
+
+
+@respx.mock
+async def test_batch_processed_partially_sync() -> None:
+    client = ApifyClient(token='')
+
+    respx.route(method='POST', host='api.apify.com').mock(
+        return_value=respx.MockResponse(200, content=_PARTIALLY_ADDED_BATCH_RESPONSE_CONTENT)
+    )
+    requests = [
+        {'uniqueKey': 'http://example.com/1', 'url': 'http://example.com/1', 'method': 'GET'},
+        {'uniqueKey': 'http://example.com/2', 'url': 'http://example.com/2', 'method': 'GET'},
+    ]
+    rq_client = client.request_queue(request_queue_id='whatever')
+
+    response = rq_client.batch_add_requests(requests=requests)
+    assert requests[0]['uniqueKey'] in {request['uniqueKey'] for request in response['processedRequests']}
+    assert response['unprocessedRequests'] == [requests[1]]

--- a/tests/unit/test_client_timeouts.py
+++ b/tests/unit/test_client_timeouts.py
@@ -116,7 +116,7 @@ _timeout_params = [
     (RequestQueueClient, 'delete_request', request_queue._SMALL_TIMEOUT, {'request_id': 123}),
     (RequestQueueClient, 'prolong_request_lock', request_queue._MEDIUM_TIMEOUT, {'request_id': 123, 'lock_secs': 1}),
     (RequestQueueClient, 'delete_request_lock', request_queue._SMALL_TIMEOUT, {'request_id': 123}),
-    (RequestQueueClient, 'batch_add_requests', request_queue._MEDIUM_TIMEOUT, {'requests': [{}]}),
+    (RequestQueueClient, 'batch_add_requests', request_queue._MEDIUM_TIMEOUT, {'requests': [{'uniqueKey': '123'}]}),
     (RequestQueueClient, 'batch_delete_requests', request_queue._SMALL_TIMEOUT, {'requests': [{}]}),
     (RequestQueueClient, 'list_requests', request_queue._MEDIUM_TIMEOUT, {}),
 ]

--- a/tests/unit/test_client_timeouts.py
+++ b/tests/unit/test_client_timeouts.py
@@ -116,7 +116,7 @@ _timeout_params = [
     (RequestQueueClient, 'delete_request', request_queue._SMALL_TIMEOUT, {'request_id': 123}),
     (RequestQueueClient, 'prolong_request_lock', request_queue._MEDIUM_TIMEOUT, {'request_id': 123, 'lock_secs': 1}),
     (RequestQueueClient, 'delete_request_lock', request_queue._SMALL_TIMEOUT, {'request_id': 123}),
-    (RequestQueueClient, 'batch_add_requests', request_queue._MEDIUM_TIMEOUT, {'requests': [{'uniqueKey': '123'}]}),
+    (RequestQueueClient, 'batch_add_requests', request_queue._MEDIUM_TIMEOUT, {'requests': [{}]}),
     (RequestQueueClient, 'batch_delete_requests', request_queue._SMALL_TIMEOUT, {'requests': [{}]}),
     (RequestQueueClient, 'list_requests', request_queue._MEDIUM_TIMEOUT, {}),
 ]


### PR DESCRIPTION
### Description

Remove retries from `batch_add_requests` (such retries already exist on the http client level).
Add deprecation warnings when retires related arguments are used.
Align sync and async version to not ignore exceptions from the http client. 
Add tests.

### Issues

- Closes: #390 