### PR TITLE
need to add a way to override the SSL verify context through the clie…

### DIFF
--- a/src/apify_client/_http_client.py
+++ b/src/apify_client/_http_client.py
@@ -10,6 +10,7 @@ from importlib import metadata
 from typing import TYPE_CHECKING, Any, Callable
 
 import httpx
+from ssl import SSLContext
 from apify_shared.utils import ignore_docs, is_content_type_json, is_content_type_text, is_content_type_xml
 
 from apify_client._errors import ApifyApiError, InvalidResponseBodyError, is_retryable_error
@@ -37,6 +38,7 @@ class _BaseHTTPClient:
         min_delay_between_retries_millis: int = 500,
         timeout_secs: int = 360,
         stats: Statistics | None = None,
+        ssl_ctx: SSLContext | str | bool = True,
     ) -> None:
         self.max_retries = max_retries
         self.min_delay_between_retries_millis = min_delay_between_retries_millis
@@ -58,8 +60,8 @@ class _BaseHTTPClient:
         if token is not None:
             headers['Authorization'] = f'Bearer {token}'
 
-        self.httpx_client = httpx.Client(headers=headers, follow_redirects=True, timeout=timeout_secs)
-        self.httpx_async_client = httpx.AsyncClient(headers=headers, follow_redirects=True, timeout=timeout_secs)
+        self.httpx_client = httpx.Client(headers=headers, follow_redirects=True, timeout=timeout_secs, verify=ssl_ctx)
+        self.httpx_async_client = httpx.AsyncClient(headers=headers, follow_redirects=True, timeout=timeout_secs, verify=ssl_ctx)
 
         self.stats = stats or Statistics()
 

--- a/src/apify_client/client.py
+++ b/src/apify_client/client.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from ssl import SSLContext
 
 from apify_shared.utils import ignore_docs
 
@@ -58,6 +59,7 @@ DEFAULT_TIMEOUT = 360
 API_VERSION = 'v2'
 
 
+
 class _BaseApifyClient:
     http_client: HTTPClient | HTTPClientAsync
 
@@ -70,6 +72,7 @@ class _BaseApifyClient:
         max_retries: int | None = 8,
         min_delay_between_retries_millis: int | None = 500,
         timeout_secs: int | None = DEFAULT_TIMEOUT,
+        ssl_ctx: SSLContext | str | bool = True
     ) -> None:
         """Initialize a new instance.
 
@@ -87,6 +90,7 @@ class _BaseApifyClient:
         self.max_retries = max_retries or 8
         self.min_delay_between_retries_millis = min_delay_between_retries_millis or 500
         self.timeout_secs = timeout_secs or DEFAULT_TIMEOUT
+        self.ssl_ctx = ssl_ctx
 
     def _options(self) -> dict:
         return {
@@ -109,6 +113,7 @@ class ApifyClient(_BaseApifyClient):
         max_retries: int | None = 8,
         min_delay_between_retries_millis: int | None = 500,
         timeout_secs: int | None = DEFAULT_TIMEOUT,
+        ssl_ctx: SSLContext | str | bool = True
     ) -> None:
         """Initialize a new instance.
 
@@ -126,6 +131,7 @@ class ApifyClient(_BaseApifyClient):
             max_retries=max_retries,
             min_delay_between_retries_millis=min_delay_between_retries_millis,
             timeout_secs=timeout_secs,
+            ssl_ctx=ssl_ctx,
         )
 
         self.stats = Statistics()
@@ -135,6 +141,7 @@ class ApifyClient(_BaseApifyClient):
             min_delay_between_retries_millis=self.min_delay_between_retries_millis,
             timeout_secs=self.timeout_secs,
             stats=self.stats,
+            ssl_ctx=self.ssl_ctx,
         )
 
     def actor(self, actor_id: str) -> ActorClient:


### PR DESCRIPTION
We need a way to pass in the a context to the `httpx` client library so that we can manage the untreated certs.  

The only way to do this is by following the recommendation here:

https://www.python-httpx.org/advanced/ssl/

All this fixes the issue to work around the error:

`httpx.ConnectError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:997)`


