### PR TITLE
feat: Add `unlock_requests` method to RequestQueue clients

### DIFF
--- a/src/apify_client/clients/resource_clients/request_queue.py
+++ b/src/apify_client/clients/resource_clients/request_queue.py
@@ -404,6 +404,24 @@ class RequestQueueClient(ResourceClient):
 
         return parse_date_fields(pluck_data(response.json()))
 
+    def unlock_requests(self: RequestQueueClient) -> dict:
+        """Unlock all requests in the queue, which were locked by the same clientKey or from the same Actor run.
+
+        https://docs.apify.com/api/v2#/reference/request-queues/request-collection/unlock-requests
+
+        Returns:
+            dict: Result of the unlock operation
+        """
+        request_params = self._params(clientKey=self.client_key)
+
+        response = self.http_client.call(
+            url=self._url('requests/unlock'),
+            method='POST',
+            params=request_params,
+        )
+
+        return parse_date_fields(pluck_data(response.json()))
+
 
 class RequestQueueClientAsync(ResourceClientAsync):
     """Async sub-client for manipulating a single request queue."""
@@ -809,6 +827,24 @@ class RequestQueueClientAsync(ResourceClientAsync):
         response = await self.http_client.call(
             url=self._url('requests'),
             method='GET',
+            params=request_params,
+        )
+
+        return parse_date_fields(pluck_data(response.json()))
+
+    async def unlock_requests(self: RequestQueueClientAsync) -> dict:
+        """Unlock all requests in the queue, which were locked by the same clientKey or from the same Actor run.
+
+        https://docs.apify.com/api/v2#/reference/request-queues/request-collection/unlock-requests
+
+        Returns:
+            dict: Result of the unlock operation
+        """
+        request_params = self._params(clientKey=self.client_key)
+
+        response = await self.http_client.call(
+            url=self._url('requests/unlock'),
+            method='POST',
             params=request_params,
         )
 


### PR DESCRIPTION
Introduce the `unlock_requests` method to both sync and async RequestQueue clients, allowing users to unlock all requests locked by the same clientKey or Actor run.