### PR TITLE
fix: Renamed sortBy parameters option

### DIFF
--- a/src/apify_client/clients/resource_clients/actor_collection.py
+++ b/src/apify_client/clients/resource_clients/actor_collection.py
@@ -26,7 +26,7 @@ class ActorCollectionClient(ResourceCollectionClient):
         limit: int | None = None,
         offset: int | None = None,
         desc: bool | None = None,
-        sort_by: Literal['createdAt', 'lastRunStartedAt'] | None = 'createdAt',
+        sort_by: Literal['createdAt', 'stats.lastRunStartedAt'] | None = 'createdAt',
     ) -> ListPage[dict]:
         """List the Actors the user has created or used.
 
@@ -152,7 +152,7 @@ class ActorCollectionClientAsync(ResourceCollectionClientAsync):
         limit: int | None = None,
         offset: int | None = None,
         desc: bool | None = None,
-        sort_by: Literal['createdAt', 'lastRunStartedAt'] | None = 'createdAt',
+        sort_by: Literal['createdAt', 'stats.lastRunStartedAt'] | None = 'createdAt',
     ) -> ListPage[dict]:
         """List the Actors the user has created or used.
 


### PR DESCRIPTION
Renamed option for sortBy parameter from "lastRunStartedAt" to "stats.lastRunStartedAt" to fit the [TICKET](https://app.zenhub.com/workspaces/platform-team-5f6454160d9f82000fa6733f/issues/gh/apify/apify-core/20997) specifications. Will merge when the [apify-core PR](https://github.com/apify/apify-core/pull/21731) is deployed