### PR TITLE
fix: Restrict apify-shared version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ classifiers = [
 ]
 keywords = ["apify", "api", "client", "automation", "crawling", "scraping"]
 dependencies = [
-    "apify-shared>=1.4.1",
-    "colorama~=0.4.0",
+    "apify-shared<2.0.0",
+    "colorama>=0.4.0",
     "httpx>=0.25",
     "more_itertools>=10.0.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -49,8 +49,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "apify-shared", specifier = ">=1.4.1" },
-    { name = "colorama", specifier = "~=0.4.0" },
+    { name = "apify-shared", specifier = "<2.0.0" },
+    { name = "colorama", specifier = ">=0.4.0" },
     { name = "httpx", specifier = ">=0.25" },
     { name = "more-itertools", specifier = ">=10.0.0" },
 ]


### PR DESCRIPTION
This will be backported to https://github.com/apify/apify-client-python/tree/release-v1 branch, and a new patch will be released.