### PR TITLE
refactor!: Remove the `parse_response` parameter for the `call` method

### DIFF
--- a/src/apify_client/clients/resource_clients/dataset.py
+++ b/src/apify_client/clients/resource_clients/dataset.py
@@ -420,7 +420,6 @@ class DatasetClient(ResourceClient):
             url=self._url('items'),
             method='GET',
             params=request_params,
-            parse_response=False,
         )
 
         return response.content
@@ -516,7 +515,6 @@ class DatasetClient(ResourceClient):
                 method='GET',
                 params=request_params,
                 stream=True,
-                parse_response=False,
             )
             yield response
         finally:
@@ -877,7 +875,6 @@ class DatasetClientAsync(ResourceClientAsync):
             url=self._url('items'),
             method='GET',
             params=request_params,
-            parse_response=False,
         )
 
         return response.content
@@ -973,7 +970,6 @@ class DatasetClientAsync(ResourceClientAsync):
                 method='GET',
                 params=request_params,
                 stream=True,
-                parse_response=False,
             )
             yield response
         finally:

--- a/src/apify_client/clients/resource_clients/key_value_store.py
+++ b/src/apify_client/clients/resource_clients/key_value_store.py
@@ -8,7 +8,12 @@ from typing import TYPE_CHECKING, Any
 from apify_shared.utils import filter_out_none_values_recursively, ignore_docs, parse_date_fields
 
 from apify_client._errors import ApifyApiError
-from apify_client._utils import catch_not_found_or_throw, encode_key_value_store_record_value, pluck_data
+from apify_client._utils import (
+    catch_not_found_or_throw,
+    encode_key_value_store_record_value,
+    maybe_parse_response,
+    pluck_data,
+)
 from apify_client.clients.base import ResourceClient, ResourceClientAsync
 
 if TYPE_CHECKING:
@@ -146,7 +151,7 @@ class KeyValueStoreClient(ResourceClient):
 
             return {
                 'key': key,
-                'value': response._maybe_parsed_body,  # type: ignore[attr-defined]  # noqa: SLF001
+                'value': maybe_parse_response(response),
                 'content_type': response.headers['content-type'],
             }
 
@@ -196,7 +201,6 @@ class KeyValueStoreClient(ResourceClient):
                 url=self._url(f'records/{key}'),
                 method='GET',
                 params=self._params(),
-                parse_response=False,
             )
 
             return {
@@ -228,7 +232,6 @@ class KeyValueStoreClient(ResourceClient):
                 url=self._url(f'records/{key}'),
                 method='GET',
                 params=self._params(),
-                parse_response=False,
                 stream=True,
             )
 
@@ -393,7 +396,7 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
 
             return {
                 'key': key,
-                'value': response._maybe_parsed_body,  # type: ignore[attr-defined]  # noqa: SLF001
+                'value': maybe_parse_response(response),
                 'content_type': response.headers['content-type'],
             }
 
@@ -443,7 +446,6 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
                 url=self._url(f'records/{key}'),
                 method='GET',
                 params=self._params(),
-                parse_response=False,
             )
 
             return {
@@ -475,7 +477,6 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
                 url=self._url(f'records/{key}'),
                 method='GET',
                 params=self._params(),
-                parse_response=False,
                 stream=True,
             )
 

--- a/src/apify_client/clients/resource_clients/log.py
+++ b/src/apify_client/clients/resource_clients/log.py
@@ -76,7 +76,6 @@ class LogClient(ResourceClient):
                 url=self.url,
                 method='GET',
                 params=self._params(raw=raw),
-                parse_response=False,
             )
 
             return response.content  # noqa: TRY300
@@ -105,7 +104,6 @@ class LogClient(ResourceClient):
                 method='GET',
                 params=self._params(stream=True, raw=raw),
                 stream=True,
-                parse_response=False,
             )
 
             yield response
@@ -166,7 +164,6 @@ class LogClientAsync(ResourceClientAsync):
                 url=self.url,
                 method='GET',
                 params=self._params(raw=raw),
-                parse_response=False,
             )
 
             return response.content  # noqa: TRY300
@@ -195,7 +192,6 @@ class LogClientAsync(ResourceClientAsync):
                 method='GET',
                 params=self._params(stream=True, raw=raw),
                 stream=True,
-                parse_response=False,
             )
 
             yield response

--- a/tests/unit/test_client_errors.py
+++ b/tests/unit/test_client_errors.py
@@ -92,7 +92,7 @@ def test_client_apify_api_error_streamed(httpserver: HTTPServer) -> None:
     httpserver.expect_request('/stream_error').respond_with_handler(streaming_handler)
 
     with pytest.raises(ApifyApiError) as e:
-        client.call(method='GET', url=httpserver.url_for('/stream_error'), stream=True, parse_response=False)
+        client.call(method='GET', url=httpserver.url_for('/stream_error'), stream=True)
 
     assert e.value.message == error['error']['message']
     assert e.value.type == error['error']['type']
@@ -108,7 +108,7 @@ async def test_async_client_apify_api_error_streamed(httpserver: HTTPServer) -> 
     httpserver.expect_request('/stream_error').respond_with_handler(streaming_handler)
 
     with pytest.raises(ApifyApiError) as e:
-        await client.call(method='GET', url=httpserver.url_for('/stream_error'), stream=True, parse_response=False)
+        await client.call(method='GET', url=httpserver.url_for('/stream_error'), stream=True)
 
     assert e.value.message == error['error']['message']
     assert e.value.type == error['error']['type']

--- a/uv.lock
+++ b/uv.lock
@@ -23,7 +23,7 @@ wheels = [
 
 [[package]]
 name = "apify-client"
-version = "1.12.2"
+version = "1.12.3"
 source = { editable = "." }
 dependencies = [
     { name = "apify-shared" },


### PR DESCRIPTION
- Remove the `parse_response` parameter for the `call` method. It was only used to create the private attribute `_maybe_parsed_body` in `Response`.
- The `_maybe_parsed_body` attribute has been removed; now the utility is called directly in Key-Value storage client, where it was used.

### Issues

- Closes: #166 