### PR TITLE
feat: Add `unqiue_key` based methods to `RequestQueueClient`

### DIFF
--- a/src/apify_client/clients/resource_clients/request_queue.py
+++ b/src/apify_client/clients/resource_clients/request_queue.py
@@ -226,7 +226,7 @@ class RequestQueueClient(ResourceClient):
         https://docs.apify.com/api/v2#/reference/request-queues/request/get-request
 
         Args:
-            request_unique_key: unique key of the request to retrieve.
+            request_unique_key: Unique key of the request to retrieve.
 
         Returns:
             The retrieved request, or None, if it did not exist.
@@ -327,7 +327,7 @@ class RequestQueueClient(ResourceClient):
         https://docs.apify.com/api/v2#/reference/request-queues/request-lock/prolong-request-lock
 
         Args:
-            request_unique_key: ID of the request to prolong the lock.
+            request_unique_key: Unique key of the request to prolong the lock.
             forefront: Whether to put the request in the beginning or the end of the queue after lock expires.
             lock_secs: By how much to prolong the lock, in seconds.
         """
@@ -359,7 +359,7 @@ class RequestQueueClient(ResourceClient):
         https://docs.apify.com/api/v2#/reference/request-queues/request-lock/delete-request-lock
 
         Args:
-            request_unique_key: ID of the request to delete the lock.
+            request_unique_key: Unique key of the request to delete the lock.
             forefront: Whether to put the request in the beginning or the end of the queue after the lock is deleted.
         """
         return self.delete_request_lock(unique_key_to_request_id(request_unique_key), forefront=forefront)
@@ -660,7 +660,7 @@ class RequestQueueClientAsync(ResourceClientAsync):
         https://docs.apify.com/api/v2#/reference/request-queues/request/get-request
 
         Args:
-            request_unique_key: unique key of the request to retrieve.
+            request_unique_key: Unique key of the request to retrieve.
 
         Returns:
             The retrieved request, or None, if it did not exist.
@@ -759,7 +759,7 @@ class RequestQueueClientAsync(ResourceClientAsync):
         https://docs.apify.com/api/v2#/reference/request-queues/request-lock/prolong-request-lock
 
         Args:
-            request_unique_key: ID of the request to prolong the lock.
+            request_unique_key: Unique key of the request to prolong the lock.
             forefront: Whether to put the request in the beginning or the end of the queue after lock expires.
             lock_secs: By how much to prolong the lock, in seconds.
         """
@@ -798,7 +798,7 @@ class RequestQueueClientAsync(ResourceClientAsync):
         https://docs.apify.com/api/v2#/reference/request-queues/request-lock/delete-request-lock
 
         Args:
-            request_unique_key: ID of the request to delete the lock.
+            request_unique_key: Unique key of the request to delete the lock.
             forefront: Whether to put the request in the beginning or the end of the queue after the lock is deleted.
         """
         return await self.delete_request_lock(unique_key_to_request_id(request_unique_key), forefront=forefront)

--- a/src/apify_client/clients/resource_clients/request_queue.py
+++ b/src/apify_client/clients/resource_clients/request_queue.py
@@ -220,18 +220,18 @@ class RequestQueueClient(ResourceClient):
 
         return None
 
-    def get_request_by_unique_key(self, request_unique_key: str) -> dict | None:
+    def get_request_by_unique_key(self, unique_key: str) -> dict | None:
         """Retrieve a request from the queue.
 
         https://docs.apify.com/api/v2#/reference/request-queues/request/get-request
 
         Args:
-            request_unique_key: Unique key of the request to retrieve.
+            unique_key: Unique key of the request to retrieve.
 
         Returns:
             The retrieved request, or None, if it did not exist.
         """
-        return self.get_request(unique_key_to_request_id(request_unique_key))
+        return self.get_request(unique_key_to_request_id(unique_key))
 
     def update_request(self, request: dict, *, forefront: bool | None = None) -> dict:
         """Update a request in the queue.
@@ -278,15 +278,15 @@ class RequestQueueClient(ResourceClient):
             timeout_secs=_SMALL_TIMEOUT,
         )
 
-    def delete_request_by_unique_key(self, request_unique_key: str) -> None:
+    def delete_request_by_unique_key(self, unique_key: str) -> None:
         """Delete a request from the queue.
 
         https://docs.apify.com/api/v2#/reference/request-queues/request/delete-request
 
         Args:
-            request_unique_key: Unique key of the request to delete.
+            unique_key: Unique key of the request to delete.
         """
-        return self.delete_request(unique_key_to_request_id(request_unique_key))
+        return self.delete_request(unique_key_to_request_id(unique_key))
 
     def prolong_request_lock(
         self,
@@ -317,7 +317,7 @@ class RequestQueueClient(ResourceClient):
 
     def prolong_request_lock_by_unique_key(
         self,
-        request_unique_key: str,
+        unique_key: str,
         *,
         forefront: bool | None = None,
         lock_secs: int,
@@ -327,13 +327,11 @@ class RequestQueueClient(ResourceClient):
         https://docs.apify.com/api/v2#/reference/request-queues/request-lock/prolong-request-lock
 
         Args:
-            request_unique_key: Unique key of the request to prolong the lock.
+            unique_key: Unique key of the request to prolong the lock.
             forefront: Whether to put the request in the beginning or the end of the queue after lock expires.
             lock_secs: By how much to prolong the lock, in seconds.
         """
-        return self.prolong_request_lock(
-            unique_key_to_request_id(request_unique_key), forefront=forefront, lock_secs=lock_secs
-        )
+        return self.prolong_request_lock(unique_key_to_request_id(unique_key), forefront=forefront, lock_secs=lock_secs)
 
     def delete_request_lock(self, request_id: str, *, forefront: bool | None = None) -> None:
         """Delete the lock on a request.
@@ -353,16 +351,16 @@ class RequestQueueClient(ResourceClient):
             timeout_secs=_SMALL_TIMEOUT,
         )
 
-    def delete_request_lock_by_unique_key(self, request_unique_key: str, *, forefront: bool | None = None) -> None:
+    def delete_request_lock_by_unique_key(self, unique_key: str, *, forefront: bool | None = None) -> None:
         """Delete the lock on a request.
 
         https://docs.apify.com/api/v2#/reference/request-queues/request-lock/delete-request-lock
 
         Args:
-            request_unique_key: Unique key of the request to delete the lock.
+            unique_key: Unique key of the request to delete the lock.
             forefront: Whether to put the request in the beginning or the end of the queue after the lock is deleted.
         """
-        return self.delete_request_lock(unique_key_to_request_id(request_unique_key), forefront=forefront)
+        return self.delete_request_lock(unique_key_to_request_id(unique_key), forefront=forefront)
 
     def batch_add_requests(
         self,
@@ -654,18 +652,18 @@ class RequestQueueClientAsync(ResourceClientAsync):
 
         return None
 
-    async def get_request_by_unique_key(self, request_unique_key: str) -> dict | None:
+    async def get_request_by_unique_key(self, unique_key: str) -> dict | None:
         """Retrieve a request from the queue.
 
         https://docs.apify.com/api/v2#/reference/request-queues/request/get-request
 
         Args:
-            request_unique_key: Unique key of the request to retrieve.
+            unique_key: Unique key of the request to retrieve.
 
         Returns:
             The retrieved request, or None, if it did not exist.
         """
-        return await self.get_request(unique_key_to_request_id(request_unique_key))
+        return await self.get_request(unique_key_to_request_id(unique_key))
 
     async def update_request(self, request: dict, *, forefront: bool | None = None) -> dict:
         """Update a request in the queue.
@@ -710,15 +708,15 @@ class RequestQueueClientAsync(ResourceClientAsync):
             timeout_secs=_SMALL_TIMEOUT,
         )
 
-    async def delete_request_by_unique_key(self, request_unique_key: str) -> None:
+    async def delete_request_by_unique_key(self, unique_key: str) -> None:
         """Delete a request from the queue.
 
         https://docs.apify.com/api/v2#/reference/request-queues/request/delete-request
 
         Args:
-            request_unique_key: Unique key of the request to delete.
+            unique_key: Unique key of the request to delete.
         """
-        return await self.delete_request(unique_key_to_request_id(request_unique_key))
+        return await self.delete_request(unique_key_to_request_id(unique_key))
 
     async def prolong_request_lock(
         self,
@@ -749,7 +747,7 @@ class RequestQueueClientAsync(ResourceClientAsync):
 
     async def prolong_request_lock_by_unique_key(
         self,
-        request_unique_key: str,
+        unique_key: str,
         *,
         forefront: bool | None = None,
         lock_secs: int,
@@ -759,12 +757,12 @@ class RequestQueueClientAsync(ResourceClientAsync):
         https://docs.apify.com/api/v2#/reference/request-queues/request-lock/prolong-request-lock
 
         Args:
-            request_unique_key: Unique key of the request to prolong the lock.
+            unique_key: Unique key of the request to prolong the lock.
             forefront: Whether to put the request in the beginning or the end of the queue after lock expires.
             lock_secs: By how much to prolong the lock, in seconds.
         """
         return await self.prolong_request_lock(
-            unique_key_to_request_id(request_unique_key), forefront=forefront, lock_secs=lock_secs
+            unique_key_to_request_id(unique_key), forefront=forefront, lock_secs=lock_secs
         )
 
     async def delete_request_lock(
@@ -790,18 +788,16 @@ class RequestQueueClientAsync(ResourceClientAsync):
             timeout_secs=_SMALL_TIMEOUT,
         )
 
-    async def delete_request_lock_by_unique_key(
-        self, request_unique_key: str, *, forefront: bool | None = None
-    ) -> None:
+    async def delete_request_lock_by_unique_key(self, unique_key: str, *, forefront: bool | None = None) -> None:
         """Delete the lock on a request.
 
         https://docs.apify.com/api/v2#/reference/request-queues/request-lock/delete-request-lock
 
         Args:
-            request_unique_key: Unique key of the request to delete the lock.
+            unique_key: Unique key of the request to delete the lock.
             forefront: Whether to put the request in the beginning or the end of the queue after the lock is deleted.
         """
-        return await self.delete_request_lock(unique_key_to_request_id(request_unique_key), forefront=forefront)
+        return await self.delete_request_lock(unique_key_to_request_id(unique_key), forefront=forefront)
 
     async def _batch_add_requests_worker(
         self,

--- a/src/apify_client/clients/resource_clients/request_queue.py
+++ b/src/apify_client/clients/resource_clients/request_queue.py
@@ -248,7 +248,7 @@ class RequestQueueClient(ResourceClient):
         Returns:
             The updated request.
         """
-        request_id = request.get('id', unique_key_to_request_id(request.get('unique_key', '')))
+        request_id = request.get('id', unique_key_to_request_id(request.get('uniqueKey', '')))
 
         request_params = self._params(forefront=forefront, clientKey=self.client_key)
 
@@ -682,7 +682,7 @@ class RequestQueueClientAsync(ResourceClientAsync):
         Returns:
             The updated request.
         """
-        request_id = request.get('id', unique_key_to_request_id(request.get('unique_key', '')))
+        request_id = request.get('id', unique_key_to_request_id(request.get('uniqueKey', '')))
 
         request_params = self._params(forefront=forefront, clientKey=self.client_key)
 

--- a/src/apify_client/clients/resource_clients/request_queue.py
+++ b/src/apify_client/clients/resource_clients/request_queue.py
@@ -59,9 +59,6 @@ def unique_key_to_request_id(unique_key: str, *, request_id_length: int = 15) ->
     Returns:
         A URL-safe, truncated request ID based on the unique key.
     """
-    if not unique_key:
-        raise ValueError('unique_key must not be empty')
-
     # Encode the unique key and compute its SHA-256 hash
     hashed_key = sha256(unique_key.encode('utf-8')).digest()
 

--- a/tests/integration/test_request_queue.py
+++ b/tests/integration/test_request_queue.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 from integration.integration_test_utils import random_resource_name, random_string
+
+from apify_client.clients.resource_clients.request_queue import unique_key_to_request_id
 
 if TYPE_CHECKING:
     from apify_client import ApifyClient, ApifyClientAsync
@@ -113,3 +117,38 @@ class TestRequestQueueAsync:
         assert len(requests_in_queue2['items']) == 25 - len(delete_response['processedRequests'])
 
         await queue.delete()
+
+
+def test_unique_key_to_request_id_length() -> None:
+    unique_key = 'exampleKey123'
+    request_id = unique_key_to_request_id(unique_key, request_id_length=15)
+    assert len(request_id) == 15, 'Request ID should have the correct length.'
+
+
+def test_unique_key_to_request_id_consistency() -> None:
+    unique_key = 'consistentKey'
+    request_id_1 = unique_key_to_request_id(unique_key)
+    request_id_2 = unique_key_to_request_id(unique_key)
+    assert request_id_1 == request_id_2, 'The same unique key should generate consistent request IDs.'
+
+
+@pytest.mark.parametrize(
+    ('unique_key', 'expected_request_id'),
+    [
+        ('abc', 'ungWv48BzpBQUDe'),
+        ('uniqueKey', 'xiWPs083cree7mH'),
+        ('', '47DEQpj8HBSaTIm'),
+        ('测试中文', 'lKPdJkdvw8MXEUp'),
+        ('test+/=', 'XZRQjhoG0yjfnYD'),
+    ],
+    ids=[
+        'basic_abc',
+        'keyword_uniqueKey',
+        'empty_string',
+        'non_ascii_characters',
+        'url_unsafe_characters',
+    ],
+)
+def test_unique_key_to_request_id_matches_known_values(unique_key: str, expected_request_id: str) -> None:
+    request_id = unique_key_to_request_id(unique_key)
+    assert request_id == expected_request_id, f'Unique key "{unique_key}" should produce the expected request ID.'

--- a/uv.lock
+++ b/uv.lock
@@ -1,10 +1,10 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [[package]]
 name = "apify-client"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "apify-shared" },


### PR DESCRIPTION
### Description

- Add `unqiue_key` based methods to `RequestQueueClient` as an alternative to `id` based methods
- Add function to transform  `unqiue_key` to `id`

### Issues

- Part of: https://github.com/apify/crawlee-python/issues/1358
