### PR TITLE
feat: add forcePermissionLevel run option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 keywords = ["apify", "api", "client", "automation", "crawling", "scraping"]
 dependencies = [
-    "apify-shared>=2.0.0,<3.0.0",
+    "apify-shared>=2.1.0,<3.0.0",
     "colorama>=0.4.0",
     "impit>=0.5.3",
     "more_itertools>=10.0.0",

--- a/src/apify_client/clients/resource_clients/actor.py
+++ b/src/apify_client/clients/resource_clients/actor.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from decimal import Decimal
     from logging import Logger
 
-    from apify_shared.consts import ActorJobStatus, MetaOrigin
+    from apify_shared.consts import ActorJobStatus, ActorPermissionLevel, MetaOrigin
 
 
 def get_actor_representation(
@@ -50,6 +50,7 @@ def get_actor_representation(
     default_run_max_items: int | None = None,
     default_run_memory_mbytes: int | None = None,
     default_run_timeout_secs: int | None = None,
+    default_run_force_permission_level: ActorPermissionLevel | None = None,
     example_run_input_body: Any = None,
     example_run_input_content_type: str | None = None,
     actor_standby_is_enabled: bool | None = None,
@@ -78,6 +79,7 @@ def get_actor_representation(
             'maxItems': default_run_max_items,
             'memoryMbytes': default_run_memory_mbytes,
             'timeoutSecs': default_run_timeout_secs,
+            'forcePermissionLevel': default_run_force_permission_level,
         },
         'exampleRunInput': {
             'body': example_run_input_body,
@@ -224,6 +226,7 @@ class ActorClient(ResourceClient):
         max_total_charge_usd: Decimal | None = None,
         memory_mbytes: int | None = None,
         timeout_secs: int | None = None,
+        force_permission_level: ActorPermissionLevel | None = None,
         wait_for_finish: int | None = None,
         webhooks: list[dict] | None = None,
     ) -> dict:
@@ -243,6 +246,8 @@ class ActorClient(ResourceClient):
                 specified in the default run configuration for the Actor.
             timeout_secs: Optional timeout for the run, in seconds. By default, the run uses timeout specified
                 in the default run configuration for the Actor.
+            force_permission_level: Override the Actor's permissions for this run. If not set, the Actor will run
+                with permissions configured in the Actor settings.
             wait_for_finish: The maximum number of seconds the server waits for the run to finish. By default,
                 it is 0, the maximum value is 60.
             webhooks: Optional ad-hoc webhooks (https://docs.apify.com/webhooks/ad-hoc-webhooks) associated with
@@ -265,6 +270,7 @@ class ActorClient(ResourceClient):
             memory=memory_mbytes,
             timeout=timeout_secs,
             waitForFinish=wait_for_finish,
+            forcePermissionLevel=force_permission_level.value if force_permission_level is not None else None,
             webhooks=encode_webhook_list_to_base64(webhooks) if webhooks is not None else None,
         )
 
@@ -289,6 +295,7 @@ class ActorClient(ResourceClient):
         memory_mbytes: int | None = None,
         timeout_secs: int | None = None,
         webhooks: list[dict] | None = None,
+        force_permission_level: ActorPermissionLevel | None = None,
         wait_secs: int | None = None,
         logger: Logger | None | Literal['default'] = 'default',
     ) -> dict | None:
@@ -310,6 +317,8 @@ class ActorClient(ResourceClient):
                 specified in the default run configuration for the Actor.
             timeout_secs: Optional timeout for the run, in seconds. By default, the run uses timeout specified
                 in the default run configuration for the Actor.
+            force_permission_level: Override the Actor's permissions for this run. If not set, the Actor will run
+                with permissions configured in the Actor settings.
             webhooks: Optional webhooks (https://docs.apify.com/webhooks) associated with the Actor run, which can
                 be used to receive a notification, e.g. when the Actor finished or failed. If you already have
                 a webhook set up for the Actor, you do not have to add it again here.
@@ -332,6 +341,7 @@ class ActorClient(ResourceClient):
             memory_mbytes=memory_mbytes,
             timeout_secs=timeout_secs,
             webhooks=webhooks,
+            force_permission_level=force_permission_level,
         )
         if not logger:
             return self.root_client.run(started_run['id']).wait_for_finish(wait_secs=wait_secs)
@@ -628,6 +638,7 @@ class ActorClientAsync(ResourceClientAsync):
         max_total_charge_usd: Decimal | None = None,
         memory_mbytes: int | None = None,
         timeout_secs: int | None = None,
+        force_permission_level: ActorPermissionLevel | None = None,
         wait_for_finish: int | None = None,
         webhooks: list[dict] | None = None,
     ) -> dict:
@@ -647,6 +658,8 @@ class ActorClientAsync(ResourceClientAsync):
                 specified in the default run configuration for the Actor.
             timeout_secs: Optional timeout for the run, in seconds. By default, the run uses timeout specified
                 in the default run configuration for the Actor.
+            force_permission_level: Override the Actor's permissions for this run. If not set, the Actor will run
+                with permissions configured in the Actor settings.
             wait_for_finish: The maximum number of seconds the server waits for the run to finish. By default,
                 it is 0, the maximum value is 60.
             webhooks: Optional ad-hoc webhooks (https://docs.apify.com/webhooks/ad-hoc-webhooks) associated with
@@ -669,6 +682,7 @@ class ActorClientAsync(ResourceClientAsync):
             memory=memory_mbytes,
             timeout=timeout_secs,
             waitForFinish=wait_for_finish,
+            forcePermissionLevel=force_permission_level,
             webhooks=encode_webhook_list_to_base64(webhooks) if webhooks is not None else None,
         )
 
@@ -693,6 +707,7 @@ class ActorClientAsync(ResourceClientAsync):
         memory_mbytes: int | None = None,
         timeout_secs: int | None = None,
         webhooks: list[dict] | None = None,
+        force_permission_level: ActorPermissionLevel | None = None,
         wait_secs: int | None = None,
         logger: Logger | None | Literal['default'] = 'default',
     ) -> dict | None:
@@ -714,6 +729,8 @@ class ActorClientAsync(ResourceClientAsync):
                 specified in the default run configuration for the Actor.
             timeout_secs: Optional timeout for the run, in seconds. By default, the run uses timeout specified
                 in the default run configuration for the Actor.
+            force_permission_level: Override the Actor's permissions for this run. If not set, the Actor will run
+                with permissions configured in the Actor settings.
             webhooks: Optional webhooks (https://docs.apify.com/webhooks) associated with the Actor run, which can
                 be used to receive a notification, e.g. when the Actor finished or failed. If you already have
                 a webhook set up for the Actor, you do not have to add it again here.
@@ -736,6 +753,7 @@ class ActorClientAsync(ResourceClientAsync):
             memory_mbytes=memory_mbytes,
             timeout_secs=timeout_secs,
             webhooks=webhooks,
+            force_permission_level=force_permission_level,
         )
 
         if not logger:

--- a/uv.lock
+++ b/uv.lock
@@ -35,7 +35,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "apify-shared", specifier = ">=2.0.0,<3.0.0" },
+    { name = "apify-shared", specifier = ">=2.1.0,<3.0.0" },
     { name = "colorama", specifier = ">=0.4.0" },
     { name = "impit", specifier = ">=0.5.3" },
     { name = "more-itertools", specifier = ">=10.0.0" },
@@ -63,11 +63,11 @@ dev = [
 
 [[package]]
 name = "apify-shared"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e6/f4/710d95d6d5e1afde0b35359b0eb2ad7363ec81eeab348b5a109959d19513/apify_shared-2.0.0.tar.gz", hash = "sha256:c3ee4f7556f6fd61b9e2d39288d6c4d272b7c3ee0ebf0bb6b8acf46e5605b688", size = 46601, upload-time = "2025-08-13T13:32:22.7Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/88/5283f9ffad85751b7501ae56aa500db26b149dc51ed8cc6025304ecfc5fc/apify_shared-2.1.0.tar.gz", hash = "sha256:95b603454788189e9c6fa98af0e311d78033178db1434a4f0690fac40467aae0", size = 46982, upload-time = "2025-09-05T13:38:16.22Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/51/37e94ec858360c85b6b690c5694894c5b051416dcb829c324a507fea8d42/apify_shared-2.0.0-py3-none-any.whl", hash = "sha256:e4c74aba7277190efa52958fa7d1696fd361a828b604cc88858e9a29396c2f27", size = 16191, upload-time = "2025-08-13T13:32:21.286Z" },
+    { url = "https://files.pythonhosted.org/packages/76/50/3ae064870ae0e302909e215ba30a681d1ddc3c067c2242cae596c921817d/apify_shared-2.1.0-py3-none-any.whl", hash = "sha256:f6dacf375ae07fd72c1fa1daa64e5265b6cab1b05a98df077b7de0ec2077f7c3", size = 16489, upload-time = "2025-09-05T13:38:15.069Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
We want Actor developers to be able to easily test their full permission Actors with limited permissions without changing the Actor configuration for everybody or redeploying the Actor under a different name. For that reason, we have introduced a new forcePermissionLevel run option. This PR adds the option to the client.

Full context here: https://github.com/apify/apify-core/pull/22681

This has been already done in Apify JS client: https://github.com/apify/apify-client-js/pull/743