### PR TITLE
feat: Add `KeyValueStoreClient(Async).get_record_public_url`

### DIFF
--- a/tests/integration/test_key_value_store.py
+++ b/tests/integration/test_key_value_store.py
@@ -1,39 +1,40 @@
 from __future__ import annotations
 
+import json
 from unittest import mock
 from unittest.mock import Mock
 
 import impit
+import pytest
 
 from integration.integration_test_utils import parametrized_api_urls, random_resource_name
 
 from apify_client import ApifyClient, ApifyClientAsync
 from apify_client.client import DEFAULT_API_URL
 
-MOCKED_API_KVS_RESPONSE = """{
-  "data": {
-    "id": "someID",
-    "name": "name",
-    "userId": "userId",
-    "createdAt": "2025-09-11T08:48:51.806Z",
-    "modifiedAt": "2025-09-11T08:48:51.806Z",
-    "accessedAt": "2025-09-11T08:48:51.806Z",
-    "actId": null,
-    "actRunId": null,
-    "schema": null,
-    "stats": {
-      "readCount": 0,
-      "writeCount": 0,
-      "deleteCount": 0,
-      "listCount": 0,
-      "storageBytes": 0
-    },
-    "consoleUrl": "https://console.apify.com/storage/key-value-stores/someID",
-    "keysPublicUrl": "https://api.apify.com/v2/key-value-stores/someID/keys",
-    "generalAccess": "FOLLOW_USER_SETTING",
-    "urlSigningSecretKey": "urlSigningSecretKey"
-  }
-}"""
+
+def _get_mocked_api_kvs_response(signing_key: str | None = None) -> str:
+    response_data = {
+        'data': {
+            'id': 'someID',
+            'name': 'name',
+            'userId': 'userId',
+            'createdAt': '2025-09-11T08:48:51.806Z',
+            'modifiedAt': '2025-09-11T08:48:51.806Z',
+            'accessedAt': '2025-09-11T08:48:51.806Z',
+            'actId': None,
+            'actRunId': None,
+            'schema': None,
+            'stats': {'readCount': 0, 'writeCount': 0, 'deleteCount': 0, 'listCount': 0, 'storageBytes': 0},
+            'consoleUrl': 'https://console.apify.com/storage/key-value-stores/someID',
+            'keysPublicUrl': 'https://api.apify.com/v2/key-value-stores/someID/keys',
+            'generalAccess': 'FOLLOW_USER_SETTING',
+        }
+    }
+    if signing_key:
+        response_data['data']['urlSigningSecretKey'] = signing_key
+
+    return json.dumps(response_data)
 
 
 class TestKeyValueStoreSync:
@@ -73,17 +74,22 @@ class TestKeyValueStoreSync:
         store.delete()
         assert apify_client.key_value_store(created_store['id']).get() is None
 
+    @pytest.mark.parametrize('signature', [None, 'custom-signature'])
     @parametrized_api_urls
-    def test_public_url(self, api_token: str, api_url: str, api_public_url: str) -> None:
+    def test_public_url(self, api_token: str, api_url: str, api_public_url: str, signature: str) -> None:
         apify_client = ApifyClient(token=api_token, api_url=api_url, api_public_url=api_public_url)
         kvs = apify_client.key_value_store('someID')
 
         # Mock the API call to return predefined response
-        with mock.patch.object(apify_client.http_client, 'call', return_value=Mock(text=MOCKED_API_KVS_RESPONSE)):
+        with mock.patch.object(
+            apify_client.http_client,
+            'call',
+            return_value=Mock(text=_get_mocked_api_kvs_response(signing_key=signature)),
+        ):
             public_url = kvs.create_keys_public_url()
+            expected_signature = f'?signature={public_url.split("signature=")[1]}' if signature else ''
             assert public_url == (
-                f'{(api_public_url or DEFAULT_API_URL).strip("/")}/v2/key-value-stores/'
-                f'someID/keys?signature={public_url.split("signature=")[1]}'
+                f'{(api_public_url or DEFAULT_API_URL).strip("/")}/v2/key-value-stores/someID/keys{expected_signature}'
             )
 
 
@@ -130,15 +136,20 @@ class TestKeyValueStoreAsync:
         await store.delete()
         assert await apify_client_async.key_value_store(created_store['id']).get() is None
 
+    @pytest.mark.parametrize('signature', [None, 'custom-signature'])
     @parametrized_api_urls
-    async def test_public_url(self, api_token: str, api_url: str, api_public_url: str) -> None:
+    async def test_public_url(self, api_token: str, api_url: str, api_public_url: str, signature: str) -> None:
         apify_client = ApifyClientAsync(token=api_token, api_url=api_url, api_public_url=api_public_url)
         kvs = apify_client.key_value_store('someID')
 
         # Mock the API call to return predefined response
-        with mock.patch.object(apify_client.http_client, 'call', return_value=Mock(text=MOCKED_API_KVS_RESPONSE)):
+        with mock.patch.object(
+            apify_client.http_client,
+            'call',
+            return_value=Mock(text=_get_mocked_api_kvs_response(signing_key=signature)),
+        ):
             public_url = await kvs.create_keys_public_url()
+            expected_signature = f'?signature={public_url.split("signature=")[1]}' if signature else ''
             assert public_url == (
-                f'{(api_public_url or DEFAULT_API_URL).strip("/")}/v2/key-value-stores/'
-                f'someID/keys?signature={public_url.split("signature=")[1]}'
+                f'{(api_public_url or DEFAULT_API_URL).strip("/")}/v2/key-value-stores/someID/keys{expected_signature}'
             )

--- a/tests/integration/test_key_value_store.py
+++ b/tests/integration/test_key_value_store.py
@@ -90,13 +90,13 @@ class TestKeyValueStoreSync:
             return_value=Mock(text=_get_mocked_api_kvs_response(signing_key=signing_key)),
         ):
             public_url = kvs.create_keys_public_url()
-            expected_signature = (
-                f'?signature={
-                    create_storage_content_signature(resource_id=MOCKED_ID, url_signing_secret_key=signing_key)
-                }'
-                if signing_key
-                else ''
-            )
+            if signing_key:
+                signature_value = create_storage_content_signature(
+                    resource_id=MOCKED_ID, url_signing_secret_key=signing_key
+                )
+                expected_signature = f'?signature={signature_value}'
+            else:
+                expected_signature = ''
             assert public_url == (
                 f'{(api_public_url or DEFAULT_API_URL).strip("/")}/v2/key-value-stores/someID/keys{expected_signature}'
             )
@@ -179,13 +179,13 @@ class TestKeyValueStoreAsync:
             return_value=Mock(text=mocked_response),
         ):
             public_url = await kvs.create_keys_public_url()
-            expected_signature = (
-                f'?signature={
-                    create_storage_content_signature(resource_id=MOCKED_ID, url_signing_secret_key=signing_key)
-                }'
-                if signing_key
-                else ''
-            )
+            if signing_key:
+                signature_value = create_storage_content_signature(
+                    resource_id=MOCKED_ID, url_signing_secret_key=signing_key
+                )
+                expected_signature = f'?signature={signature_value}'
+            else:
+                expected_signature = ''
             assert public_url == (
                 f'{(api_public_url or DEFAULT_API_URL).strip("/")}/v2/key-value-stores/someID/keys{expected_signature}'
             )

--- a/tests/integration/test_key_value_store.py
+++ b/tests/integration/test_key_value_store.py
@@ -107,9 +107,8 @@ class TestKeyValueStoreSync:
             public_url = kvs.get_record_public_url(key='key')
             expected_signature = f'?signature={public_url.split("signature=")[1]}' if signing_key else ''
             assert public_url == (
-                f'{(api_public_url or DEFAULT_API_URL).strip("/")}/v2/key-value-stores/someID/records/key{
-                    expected_signature
-                }'
+                f'{(api_public_url or DEFAULT_API_URL).strip("/")}/v2/key-value-stores/someID/'
+                f'records/key{expected_signature}'
             )
 
 
@@ -189,7 +188,6 @@ class TestKeyValueStoreAsync:
             public_url = await kvs.get_record_public_url(key='key')
             expected_signature = f'?signature={public_url.split("signature=")[1]}' if signing_key else ''
             assert public_url == (
-                f'{(api_public_url or DEFAULT_API_URL).strip("/")}/v2/key-value-stores/someID/records/key{
-                    expected_signature
-                }'
+                f'{(api_public_url or DEFAULT_API_URL).strip("/")}/v2/key-value-stores/someID/'
+                f'records/key{expected_signature}'
             )

--- a/tests/integration/test_key_value_store.py
+++ b/tests/integration/test_key_value_store.py
@@ -74,9 +74,9 @@ class TestKeyValueStoreSync:
         store.delete()
         assert apify_client.key_value_store(created_store['id']).get() is None
 
-    @pytest.mark.parametrize('signature', [None, 'custom-signature'])
+    @pytest.mark.parametrize('signing_key', [None, 'custom-signing-key'])
     @parametrized_api_urls
-    def test_public_url(self, api_token: str, api_url: str, api_public_url: str, signature: str) -> None:
+    def test_public_url(self, api_token: str, api_url: str, api_public_url: str, signing_key: str) -> None:
         apify_client = ApifyClient(token=api_token, api_url=api_url, api_public_url=api_public_url)
         kvs = apify_client.key_value_store('someID')
 
@@ -84,28 +84,33 @@ class TestKeyValueStoreSync:
         with mock.patch.object(
             apify_client.http_client,
             'call',
-            return_value=Mock(text=_get_mocked_api_kvs_response(signing_key=signature)),
+            return_value=Mock(text=_get_mocked_api_kvs_response(signing_key=signing_key)),
         ):
             public_url = kvs.create_keys_public_url()
-            expected_signature = f'?signature={public_url.split("signature=")[1]}' if signature else ''
+            expected_signature = f'?signature={public_url.split("signature=")[1]}' if signing_key else ''
             assert public_url == (
                 f'{(api_public_url or DEFAULT_API_URL).strip("/")}/v2/key-value-stores/someID/keys{expected_signature}'
             )
 
-    @pytest.mark.parametrize('signature', [None, 'custom-signature'])
-    def test_record_public_url(self, api_token: str, signature: str) -> None:
-        apify_client = ApifyClient(token=api_token)
+    @pytest.mark.parametrize('signing_key', [None, 'custom-signing-key'])
+    @parametrized_api_urls
+    def test_record_public_url(self, api_token: str, api_url: str, api_public_url: str, signing_key: str) -> None:
+        apify_client = ApifyClient(token=api_token, api_url=api_url, api_public_url=api_public_url)
         kvs = apify_client.key_value_store('someID')
 
         # Mock the API call to return predefined response
         with mock.patch.object(
             apify_client.http_client,
             'call',
-            return_value=Mock(text=_get_mocked_api_kvs_response(signing_key=signature)),
+            return_value=Mock(text=_get_mocked_api_kvs_response(signing_key=signing_key)),
         ):
             public_url = kvs.get_record_public_url(key='key')
-            expected_signature = f'?signature={public_url.split("signature=")[1]}' if signature else ''
-            assert public_url == (f'{DEFAULT_API_URL}/v2/key-value-stores/someID/records/key{expected_signature}')
+            expected_signature = f'?signature={public_url.split("signature=")[1]}' if signing_key else ''
+            assert public_url == (
+                f'{(api_public_url or DEFAULT_API_URL).strip("/")}/v2/key-value-stores/someID/records/key{
+                    expected_signature
+                }'
+            )
 
 
 class TestKeyValueStoreAsync:
@@ -151,9 +156,9 @@ class TestKeyValueStoreAsync:
         await store.delete()
         assert await apify_client_async.key_value_store(created_store['id']).get() is None
 
-    @pytest.mark.parametrize('signature', [None, 'custom-signature'])
+    @pytest.mark.parametrize('signing_key', [None, 'custom-signing-key'])
     @parametrized_api_urls
-    async def test_record_public_url(self, api_token: str, api_url: str, api_public_url: str, signature: str) -> None:
+    async def test_record_public_url(self, api_token: str, api_url: str, api_public_url: str, signing_key: str) -> None:
         apify_client = ApifyClientAsync(token=api_token, api_url=api_url, api_public_url=api_public_url)
         kvs = apify_client.key_value_store('someID')
 
@@ -161,25 +166,30 @@ class TestKeyValueStoreAsync:
         with mock.patch.object(
             apify_client.http_client,
             'call',
-            return_value=Mock(text=_get_mocked_api_kvs_response(signing_key=signature)),
+            return_value=Mock(text=_get_mocked_api_kvs_response(signing_key=signing_key)),
         ):
             public_url = await kvs.create_keys_public_url()
-            expected_signature = f'?signature={public_url.split("signature=")[1]}' if signature else ''
+            expected_signature = f'?signature={public_url.split("signature=")[1]}' if signing_key else ''
             assert public_url == (
                 f'{(api_public_url or DEFAULT_API_URL).strip("/")}/v2/key-value-stores/someID/keys{expected_signature}'
             )
 
-    @pytest.mark.parametrize('signature', [None, 'custom-signature'])
-    async def test_public_url(self, api_token: str, signature: str) -> None:
-        apify_client = ApifyClientAsync(token=api_token)
+    @pytest.mark.parametrize('signing_key', [None, 'custom-signing-key'])
+    @parametrized_api_urls
+    async def test_public_url(self, api_token: str, api_url: str, api_public_url: str, signing_key: str) -> None:
+        apify_client = ApifyClientAsync(token=api_token, api_url=api_url, api_public_url=api_public_url)
         kvs = apify_client.key_value_store('someID')
 
         # Mock the API call to return predefined response
         with mock.patch.object(
             apify_client.http_client,
             'call',
-            return_value=Mock(text=_get_mocked_api_kvs_response(signing_key=signature)),
+            return_value=Mock(text=_get_mocked_api_kvs_response(signing_key=signing_key)),
         ):
             public_url = await kvs.get_record_public_url(key='key')
-            expected_signature = f'?signature={public_url.split("signature=")[1]}' if signature else ''
-            assert public_url == (f'{DEFAULT_API_URL}/v2/key-value-stores/someID/records/key{expected_signature}')
+            expected_signature = f'?signature={public_url.split("signature=")[1]}' if signing_key else ''
+            assert public_url == (
+                f'{(api_public_url or DEFAULT_API_URL).strip("/")}/v2/key-value-stores/someID/records/key{
+                    expected_signature
+                }'
+            )


### PR DESCRIPTION
### Description
- Add `KeyValueStoreClient.get_record_public_url`.
- Add `KeyValueStoreClientAsync.get_record_public_url`.
- Add tests.
### Issues

Closes: #497 