### PR TITLE
chore: include ms in transforming datetime to UTC string

### DIFF
--- a/src/apify_client/_http_client.py
+++ b/src/apify_client/_http_client.py
@@ -80,8 +80,10 @@ class _BaseHTTPClient:
             elif isinstance(value, datetime):
                 utc_aware_dt = value.astimezone(timezone.utc)
 
+                iso_str = utc_aware_dt.isoformat(timespec='milliseconds')
+
                 # Convert to ISO 8601 string in Zulu format
-                zulu_date_str = utc_aware_dt.strftime('%Y-%m-%dT%H:%M:%SZ')
+                zulu_date_str = iso_str.replace('+00:00', 'Z')
 
                 parsed_params[key] = zulu_date_str
             elif value is not None:


### PR DESCRIPTION
While testing client, I noticed that we didn't include ms during transformation of `datetime` to UTC string. 

This PR improves improves conversion to UTC string.