### PR TITLE
refactor: Reduce API calls required to watch status during `ActorClient.call`

### DIFF
--- a/src/apify_client/clients/resource_clients/log.py
+++ b/src/apify_client/clients/resource_clients/log.py
@@ -404,25 +404,25 @@ class StatusMessageWatcher:
         self._check_period = check_period.total_seconds()
         self._last_status_message = ''
 
-    def _log_run_data(self, run_data: dict[str, Any] | None) -> bool:
+    def log_run_data(self, response: dict[str, Any] | None) -> bool:
         """Get relevant run data, log them if changed and return `True` if more data is expected.
 
         Args:
-            run_data: The dictionary that contains the run data.
+            response: The dictionary that contains the parsed run data.
 
         Returns:
               `True` if more data is expected, `False` otherwise.
         """
-        if run_data is not None:
-            status = run_data.get('status', 'Unknown status')
-            status_message = run_data.get('statusMessage', '')
+        if response is not None:
+            status = response.get('status', 'Unknown status')
+            status_message = response.get('statusMessage', '')
             new_status_message = f'Status: {status}, Message: {status_message}'
 
             if new_status_message != self._last_status_message:
                 self._last_status_message = new_status_message
                 self._to_logger.info(new_status_message)
 
-            return not (run_data.get('isStatusMessageTerminal', False))
+            return not (response.get('isStatusMessageTerminal', False))
         return True
 
 
@@ -476,7 +476,7 @@ class StatusMessageWatcherAsync(StatusMessageWatcher):
     async def _log_changed_status_message(self) -> None:
         while True:
             run_data = await self._run_client.get()
-            if not self._log_run_data(run_data):
+            if not self.log_run_data(run_data):
                 break
             await asyncio.sleep(self._check_period)
 
@@ -531,7 +531,7 @@ class StatusMessageWatcherSync(StatusMessageWatcher):
 
     def _log_changed_status_message(self) -> None:
         while True:
-            if not self._log_run_data(self._run_client.get()):
+            if not self.log_run_data(self._run_client.get()):
                 break
             if self._stop_logging:
                 break

--- a/src/apify_client/clients/resource_clients/run.py
+++ b/src/apify_client/clients/resource_clients/run.py
@@ -35,6 +35,8 @@ if TYPE_CHECKING:
 
     from apify_shared.consts import RunGeneralAccess
 
+    from apify_client.clients.base.actor_job_base_client import ResponseWatcher
+
 
 class RunClient(ActorJobBaseClient):
     """Sub-client for manipulating a single Actor run."""
@@ -102,17 +104,20 @@ class RunClient(ActorJobBaseClient):
         """
         return self._abort(gracefully=gracefully)
 
-    def wait_for_finish(self, *, wait_secs: int | None = None) -> dict | None:
+    def wait_for_finish(
+        self, *, wait_secs: int | None = None, response_watcher: ResponseWatcher | None = None
+    ) -> dict | None:
         """Wait synchronously until the run finishes or the server times out.
 
         Args:
             wait_secs: How long does the client wait for run to finish. None for indefinite.
+            response_watcher: A callback function that will be called with parsed Actor run data.
 
         Returns:
             The Actor run data. If the status on the object is not one of the terminal statuses (SUCEEDED, FAILED,
                 TIMED_OUT, ABORTED), then the run has not yet finished.
         """
-        return self._wait_for_finish(wait_secs=wait_secs)
+        return self._wait_for_finish(wait_secs=wait_secs, response_watcher=response_watcher)
 
     def metamorph(
         self,
@@ -417,17 +422,20 @@ class RunClientAsync(ActorJobBaseClientAsync):
         """
         return await self._abort(gracefully=gracefully)
 
-    async def wait_for_finish(self, *, wait_secs: int | None = None) -> dict | None:
+    async def wait_for_finish(
+        self, *, wait_secs: int | None = None, response_watcher: ResponseWatcher | None = None
+    ) -> dict | None:
         """Wait synchronously until the run finishes or the server times out.
 
         Args:
             wait_secs: How long does the client wait for run to finish. None for indefinite.
+            response_watcher: A callback function that will be called with parsed Actor run data.
 
         Returns:
             The Actor run data. If the status on the object is not one of the terminal statuses (SUCEEDED, FAILED,
                 TIMED_OUT, ABORTED), then the run has not yet finished.
         """
-        return await self._wait_for_finish(wait_secs=wait_secs)
+        return await self._wait_for_finish(wait_secs=wait_secs, response_watcher=response_watcher)
 
     async def delete(self) -> None:
         """Delete the run.


### PR DESCRIPTION
### Description

- Add `ResponseWatcher` protocol.
- Add `response_watcher` arguments to `wait_for_finish` methods.
- `wait_for_finish` uses an optional `response_watcher` callable each time it processes the API response.

Previously, `StatusWatcher` was periodically calling `RunClient.get` to get the status and status message of another Actor run. Since `ActorClient.call` is already periodically calling `RunClient.get` through `RunClient.wait_for_finish`, there is no need for `StatusWatcher` to do the API calls again; it just needs to re-use the responses of already available in `RunClient.wait_for_finish`. It can do so, by passing the `response_watcher` argument to `wait_for_finish`.

