### PR TITLE
feat: Add signature arguments for dataset and kvs methods

### DIFF
--- a/src/apify_client/clients/resource_clients/dataset.py
+++ b/src/apify_client/clients/resource_clients/dataset.py
@@ -85,6 +85,7 @@ class DatasetClient(ResourceClient):
         skip_hidden: bool | None = None,
         flatten: list[str] | None = None,
         view: str | None = None,
+        signature: str | None = None,
     ) -> ListPage:
         """List the items of the dataset.
 
@@ -116,6 +117,7 @@ class DatasetClient(ResourceClient):
                 the # character.
             flatten: A list of fields that should be flattened.
             view: Name of the dataset view to be used.
+            signature: Signature used to access the items.
 
         Returns:
             A page of the list of dataset items according to the specified filters.
@@ -132,6 +134,7 @@ class DatasetClient(ResourceClient):
             skipHidden=skip_hidden,
             flatten=flatten,
             view=view,
+            signature=signature,
         )
 
         response = self.http_client.call(
@@ -169,6 +172,7 @@ class DatasetClient(ResourceClient):
         unwind: list[str] | None = None,
         skip_empty: bool | None = None,
         skip_hidden: bool | None = None,
+        signature: str | None = None,
     ) -> Iterator[dict]:
         """Iterate over the items in the dataset.
 
@@ -198,6 +202,7 @@ class DatasetClient(ResourceClient):
                 contain less items than the limit value.
             skip_hidden: If True, then hidden fields are skipped from the output, i.e. fields starting with
                 the # character.
+            signature: Signature used to access the items.
 
         Yields:
             An item from the dataset.
@@ -227,6 +232,7 @@ class DatasetClient(ResourceClient):
                 unwind=unwind,
                 skip_empty=skip_empty,
                 skip_hidden=skip_hidden,
+                signature=signature,
             )
 
             yield from current_items_page.items
@@ -256,6 +262,7 @@ class DatasetClient(ResourceClient):
         xml_root: str | None = None,
         xml_row: str | None = None,
         flatten: list[str] | None = None,
+        signature: str | None = None,
     ) -> bytes:
         """Get the items in the dataset as raw bytes.
 
@@ -300,6 +307,7 @@ class DatasetClient(ResourceClient):
             xml_row: Overrides default element name that wraps each page or page function result object in xml output.
                 By default the element name is item.
             flatten: A list of fields that should be flattened.
+            signature: Signature used to access the items.
 
         Returns:
             The dataset items as raw bytes.
@@ -327,6 +335,7 @@ class DatasetClient(ResourceClient):
             xml_root=xml_root,
             xml_row=xml_row,
             flatten=flatten,
+            signature=signature,
         )
 
     def get_items_as_bytes(
@@ -348,6 +357,7 @@ class DatasetClient(ResourceClient):
         xml_root: str | None = None,
         xml_row: str | None = None,
         flatten: list[str] | None = None,
+        signature: str | None = None,
     ) -> bytes:
         """Get the items in the dataset as raw bytes.
 
@@ -390,6 +400,7 @@ class DatasetClient(ResourceClient):
             xml_row: Overrides default element name that wraps each page or page function result object in xml output.
                 By default the element name is item.
             flatten: A list of fields that should be flattened.
+            signature: Signature used to access the items.
 
         Returns:
             The dataset items as raw bytes.
@@ -411,6 +422,7 @@ class DatasetClient(ResourceClient):
             xmlRoot=xml_root,
             xmlRow=xml_row,
             flatten=flatten,
+            signature=signature,
         )
 
         response = self.http_client.call(
@@ -440,6 +452,7 @@ class DatasetClient(ResourceClient):
         skip_hidden: bool | None = None,
         xml_root: str | None = None,
         xml_row: str | None = None,
+        signature: str | None = None,
     ) -> Iterator[impit.Response]:
         """Retrieve the items in the dataset as a stream.
 
@@ -481,6 +494,7 @@ class DatasetClient(ResourceClient):
             xml_root: Overrides default root element name of xml output. By default the root element is items.
             xml_row: Overrides default element name that wraps each page or page function result object in xml output.
                 By default the element name is item.
+            signature: Signature used to access the items.
 
         Returns:
             The dataset items as a context-managed streaming `Response`.
@@ -503,6 +517,7 @@ class DatasetClient(ResourceClient):
                 skipHidden=skip_hidden,
                 xmlRoot=xml_root,
                 xmlRow=xml_row,
+                signature=signature,
             )
 
             response = self.http_client.call(
@@ -683,6 +698,7 @@ class DatasetClientAsync(ResourceClientAsync):
         skip_hidden: bool | None = None,
         flatten: list[str] | None = None,
         view: str | None = None,
+        signature: str | None = None,
     ) -> ListPage:
         """List the items of the dataset.
 
@@ -714,6 +730,7 @@ class DatasetClientAsync(ResourceClientAsync):
                 the # character.
             flatten: A list of fields that should be flattened.
             view: Name of the dataset view to be used.
+            signature: Signature used to access the items.
 
         Returns:
             A page of the list of dataset items according to the specified filters.
@@ -730,6 +747,7 @@ class DatasetClientAsync(ResourceClientAsync):
             skipHidden=skip_hidden,
             flatten=flatten,
             view=view,
+            signature=signature,
         )
 
         response = await self.http_client.call(
@@ -767,6 +785,7 @@ class DatasetClientAsync(ResourceClientAsync):
         unwind: list[str] | None = None,
         skip_empty: bool | None = None,
         skip_hidden: bool | None = None,
+        signature: str | None = None,
     ) -> AsyncIterator[dict]:
         """Iterate over the items in the dataset.
 
@@ -796,6 +815,7 @@ class DatasetClientAsync(ResourceClientAsync):
                 contain less items than the limit value.
             skip_hidden: If True, then hidden fields are skipped from the output, i.e. fields starting with
                 the # character.
+            signature: Signature used to access the items.
 
         Yields:
             An item from the dataset.
@@ -825,6 +845,7 @@ class DatasetClientAsync(ResourceClientAsync):
                 unwind=unwind,
                 skip_empty=skip_empty,
                 skip_hidden=skip_hidden,
+                signature=signature,
             )
 
             for item in current_items_page.items:
@@ -855,6 +876,7 @@ class DatasetClientAsync(ResourceClientAsync):
         xml_root: str | None = None,
         xml_row: str | None = None,
         flatten: list[str] | None = None,
+        signature: str | None = None,
     ) -> bytes:
         """Get the items in the dataset as raw bytes.
 
@@ -897,6 +919,7 @@ class DatasetClientAsync(ResourceClientAsync):
             xml_row: Overrides default element name that wraps each page or page function result object in xml output.
                 By default the element name is item.
             flatten: A list of fields that should be flattened.
+            signature: Signature used to access the items.
 
         Returns:
             The dataset items as raw bytes.
@@ -918,6 +941,7 @@ class DatasetClientAsync(ResourceClientAsync):
             xmlRoot=xml_root,
             xmlRow=xml_row,
             flatten=flatten,
+            signature=signature,
         )
 
         response = await self.http_client.call(
@@ -947,6 +971,7 @@ class DatasetClientAsync(ResourceClientAsync):
         skip_hidden: bool | None = None,
         xml_root: str | None = None,
         xml_row: str | None = None,
+        signature: str | None = None,
     ) -> AsyncIterator[impit.Response]:
         """Retrieve the items in the dataset as a stream.
 
@@ -988,6 +1013,7 @@ class DatasetClientAsync(ResourceClientAsync):
             xml_root: Overrides default root element name of xml output. By default the root element is items.
             xml_row: Overrides default element name that wraps each page or page function result object in xml output.
                 By default the element name is item.
+            signature: Signature used to access the items.
 
         Returns:
             The dataset items as a context-managed streaming `Response`.
@@ -1010,6 +1036,7 @@ class DatasetClientAsync(ResourceClientAsync):
                 skipHidden=skip_hidden,
                 xmlRoot=xml_root,
                 xmlRow=xml_row,
+                signature=signature,
             )
 
             response = await self.http_client.call(

--- a/src/apify_client/clients/resource_clients/key_value_store.py
+++ b/src/apify_client/clients/resource_clients/key_value_store.py
@@ -77,6 +77,7 @@ class KeyValueStoreClient(ResourceClient):
         exclusive_start_key: str | None = None,
         collection: str | None = None,
         prefix: str | None = None,
+        signature: str | None = None,
     ) -> dict:
         """List the keys in the key-value store.
 
@@ -87,6 +88,7 @@ class KeyValueStoreClient(ResourceClient):
             exclusive_start_key: All keys up to this one (including) are skipped from the result.
             collection: The name of the collection in store schema to list keys from.
             prefix: The prefix of the keys to be listed.
+            signature: Signature used to access the items.
 
         Returns:
             The list of keys in the key-value store matching the given arguments.
@@ -96,6 +98,7 @@ class KeyValueStoreClient(ResourceClient):
             exclusiveStartKey=exclusive_start_key,
             collection=collection,
             prefix=prefix,
+            signature=signature,
         )
 
         response = self.http_client.call(
@@ -107,13 +110,14 @@ class KeyValueStoreClient(ResourceClient):
 
         return parse_date_fields(pluck_data(response.json()))
 
-    def get_record(self, key: str) -> dict | None:
+    def get_record(self, key: str, signature: str | None = None) -> dict | None:
         """Retrieve the given record from the key-value store.
 
         https://docs.apify.com/api/v2#/reference/key-value-stores/record/get-record
 
         Args:
             key: Key of the record to retrieve.
+            signature: Signature used to access the items.
 
         Returns:
             The requested record, or None, if the record does not exist.
@@ -122,7 +126,7 @@ class KeyValueStoreClient(ResourceClient):
             response = self.http_client.call(
                 url=self._url(f'records/{key}'),
                 method='GET',
-                params=self._params(),
+                params=self._params(signature=signature),
             )
 
             return {
@@ -161,13 +165,14 @@ class KeyValueStoreClient(ResourceClient):
 
         return response.status_code == HTTPStatus.OK
 
-    def get_record_as_bytes(self, key: str) -> dict | None:
+    def get_record_as_bytes(self, key: str, signature: str | None = None) -> dict | None:
         """Retrieve the given record from the key-value store, without parsing it.
 
         https://docs.apify.com/api/v2#/reference/key-value-stores/record/get-record
 
         Args:
             key: Key of the record to retrieve.
+            signature: Signature used to access the items.
 
         Returns:
             The requested record, or None, if the record does not exist.
@@ -176,7 +181,7 @@ class KeyValueStoreClient(ResourceClient):
             response = self.http_client.call(
                 url=self._url(f'records/{key}'),
                 method='GET',
-                params=self._params(),
+                params=self._params(signature=signature),
             )
 
             return {
@@ -191,13 +196,14 @@ class KeyValueStoreClient(ResourceClient):
         return None
 
     @contextmanager
-    def stream_record(self, key: str) -> Iterator[dict | None]:
+    def stream_record(self, key: str, signature: str | None = None) -> Iterator[dict | None]:
         """Retrieve the given record from the key-value store, as a stream.
 
         https://docs.apify.com/api/v2#/reference/key-value-stores/record/get-record
 
         Args:
             key: Key of the record to retrieve.
+            signature: Signature used to access the items.
 
         Returns:
             The requested record as a context-managed streaming Response, or None, if the record does not exist.
@@ -207,7 +213,7 @@ class KeyValueStoreClient(ResourceClient):
             response = self.http_client.call(
                 url=self._url(f'records/{key}'),
                 method='GET',
-                params=self._params(),
+                params=self._params(signature=signature),
                 stream=True,
             )
 
@@ -395,6 +401,7 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
         exclusive_start_key: str | None = None,
         collection: str | None = None,
         prefix: str | None = None,
+        signature: str | None = None,
     ) -> dict:
         """List the keys in the key-value store.
 
@@ -405,6 +412,7 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
             exclusive_start_key: All keys up to this one (including) are skipped from the result.
             collection: The name of the collection in store schema to list keys from.
             prefix: The prefix of the keys to be listed.
+            signature: Signature used to access the items.
 
         Returns:
             The list of keys in the key-value store matching the given arguments.
@@ -414,6 +422,7 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
             exclusiveStartKey=exclusive_start_key,
             collection=collection,
             prefix=prefix,
+            signature=signature,
         )
 
         response = await self.http_client.call(
@@ -425,13 +434,14 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
 
         return parse_date_fields(pluck_data(response.json()))
 
-    async def get_record(self, key: str) -> dict | None:
+    async def get_record(self, key: str, signature: str | None = None) -> dict | None:
         """Retrieve the given record from the key-value store.
 
         https://docs.apify.com/api/v2#/reference/key-value-stores/record/get-record
 
         Args:
             key: Key of the record to retrieve.
+            signature: Signature used to access the items.
 
         Returns:
             The requested record, or None, if the record does not exist.
@@ -440,7 +450,7 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
             response = await self.http_client.call(
                 url=self._url(f'records/{key}'),
                 method='GET',
-                params=self._params(),
+                params=self._params(signature=signature),
             )
 
             return {
@@ -479,13 +489,14 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
 
         return response.status_code == HTTPStatus.OK
 
-    async def get_record_as_bytes(self, key: str) -> dict | None:
+    async def get_record_as_bytes(self, key: str, signature: str | None = None) -> dict | None:
         """Retrieve the given record from the key-value store, without parsing it.
 
         https://docs.apify.com/api/v2#/reference/key-value-stores/record/get-record
 
         Args:
             key: Key of the record to retrieve.
+            signature: Signature used to access the items.
 
         Returns:
             The requested record, or None, if the record does not exist.
@@ -494,7 +505,7 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
             response = await self.http_client.call(
                 url=self._url(f'records/{key}'),
                 method='GET',
-                params=self._params(),
+                params=self._params(signature=signature),
             )
 
             return {
@@ -509,13 +520,14 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
         return None
 
     @asynccontextmanager
-    async def stream_record(self, key: str) -> AsyncIterator[dict | None]:
+    async def stream_record(self, key: str, signature: str | None = None) -> AsyncIterator[dict | None]:
         """Retrieve the given record from the key-value store, as a stream.
 
         https://docs.apify.com/api/v2#/reference/key-value-stores/record/get-record
 
         Args:
             key: Key of the record to retrieve.
+            signature: Signature used to access the items.
 
         Returns:
             The requested record as a context-managed streaming Response, or None, if the record does not exist.
@@ -525,7 +537,7 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
             response = await self.http_client.call(
                 url=self._url(f'records/{key}'),
                 method='GET',
-                params=self._params(),
+                params=self._params(signature=signature),
                 stream=True,
             )
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+from .integration_test_utils import TestDataset, TestKvs
 from apify_client import ApifyClient, ApifyClientAsync
 
 TOKEN_ENV_VAR = 'APIFY_TEST_USER_API_TOKEN'
@@ -31,3 +32,28 @@ def apify_client(api_token: str) -> ApifyClient:
 def apify_client_async(api_token: str) -> ApifyClientAsync:
     api_url = os.getenv(API_URL_ENV_VAR)
     return ApifyClientAsync(api_token, api_url=api_url)
+
+
+@pytest.fixture
+def test_dataset_of_another_user() -> TestDataset:
+    """Pre-existing dataset of another test user with restricted access."""
+    return TestDataset(
+        id='InrsNvJNGwJMFAR2l',
+        signature='MC4wLjFGbVN3UjB5T0xvMU1hU0lFQjZCMQ',
+        expected_content=[{'item1': 1, 'item2': 2, 'item3': 3}, {'item1': 4, 'item2': 5, 'item3': 6}],
+    )
+
+
+@pytest.fixture
+def test_kvs_of_another_user() -> TestKvs:
+    """Pre-existing key value store of another test user with restricted access."""
+    return TestKvs(
+        id='0SWREKM4yzKnpQRGA',
+        signature='MC4wLjVKVmlMSVpDNEhaazg1Z1VXTnBP',
+        expected_content={'key1': 1, 'key2': 2, 'key3': 3},
+        keys_signature={
+            'key1': 'qrQL9pHpiok99v9kWhKx',
+            'key2': '1BhGTfsLvpsF8aPiIgoBt',
+            'key3': 'rPPqxmTNcxvvpvO0Bx5s',
+        },
+    )

--- a/tests/integration/integration_test_utils.py
+++ b/tests/integration/integration_test_utils.py
@@ -1,5 +1,7 @@
+import dataclasses
 import secrets
 import string
+from typing import Any
 
 import pytest
 
@@ -24,3 +26,20 @@ parametrized_api_urls = pytest.mark.parametrize(
         ('http://10.0.88.214:8010', None),
     ],
 )
+
+
+@dataclasses.dataclass
+class TestStorage:
+    id: str
+    signature: str
+
+
+@dataclasses.dataclass
+class TestDataset(TestStorage):
+    expected_content: list
+
+
+@dataclasses.dataclass
+class TestKvs(TestStorage):
+    expected_content: dict[str, Any]
+    keys_signature: dict[str, str]


### PR DESCRIPTION
### Description
Add signature argument to:
- `DatasetClient(Async).list_items`
- `DatasetClient(Async).iterate_items`
- `DatasetClient(Async).get_items_as_bytes`
- `DatasetClient(Async).stream_items`
- `DatasetClient(Async).list_keys`
- `DatasetClient(Async).get_record`
- `DatasetClient(Async).get_record_as_bytes`
- `DatasetClient(Async).stream_record`

Added tests that point to pre-created storage of specific test user.

### Issues
Closes: #517