### PR TITLE
chore: Update dev deps specifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,22 +42,22 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "dycw-pytest-only~=2.1.0",
+    "dycw-pytest-only<3.0.0",
     "griffe",
-    "mypy~=1.18.1",
-    "pre-commit~=4.3.0",
-    "pydoc-markdown~=4.8.0",
-    "pytest-asyncio~=1.2.0",
-    "pytest-cov~=7.0.0",
-    "pytest-timeout~=2.4.0",
-    "pytest-xdist~=3.8.0",
-    "pytest~=8.4.0",
-    "pytest-httpserver~=1.1.0",
-    "redbaron~=0.9.0",
+    "mypy~=1.18.0",
+    "pre-commit<5.0.0",
+    "pydoc-markdown<5.0.0",
+    "pytest-asyncio<2.0.0",
+    "pytest-cov<8.0.0",
+    "pytest-timeout<3.0.0",
+    "pytest-xdist<4.0.0",
+    "pytest<9.0.0",
+    "pytest-httpserver<2.0.0",
+    "redbaron<1.0.0",
     "ruff~=0.14.0",
     "setuptools", # setuptools are used by pytest but not explicitly required
-    "types-colorama~=0.4.15.20240106",
-    "werkzeug~=3.1.0", # Werkzeug is used by pytest-httpserver
+    "types-colorama<0.5.0",
+    "werkzeug<4.0.0", # Werkzeug is used by pytest-httpserver
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/uv.lock
+++ b/uv.lock
@@ -43,22 +43,22 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "dycw-pytest-only", specifier = "~=2.1.0" },
+    { name = "dycw-pytest-only", specifier = "<3.0.0" },
     { name = "griffe" },
-    { name = "mypy", specifier = "~=1.18.1" },
-    { name = "pre-commit", specifier = "~=4.3.0" },
-    { name = "pydoc-markdown", specifier = "~=4.8.0" },
-    { name = "pytest", specifier = "~=8.4.0" },
-    { name = "pytest-asyncio", specifier = "~=1.2.0" },
-    { name = "pytest-cov", specifier = "~=7.0.0" },
-    { name = "pytest-httpserver", specifier = "~=1.1.0" },
-    { name = "pytest-timeout", specifier = "~=2.4.0" },
-    { name = "pytest-xdist", specifier = "~=3.8.0" },
-    { name = "redbaron", specifier = "~=0.9.0" },
+    { name = "mypy", specifier = "~=1.18.0" },
+    { name = "pre-commit", specifier = "<5.0.0" },
+    { name = "pydoc-markdown", specifier = "<5.0.0" },
+    { name = "pytest", specifier = "<9.0.0" },
+    { name = "pytest-asyncio", specifier = "<2.0.0" },
+    { name = "pytest-cov", specifier = "<8.0.0" },
+    { name = "pytest-httpserver", specifier = "<2.0.0" },
+    { name = "pytest-timeout", specifier = "<3.0.0" },
+    { name = "pytest-xdist", specifier = "<4.0.0" },
+    { name = "redbaron", specifier = "<1.0.0" },
     { name = "ruff", specifier = "~=0.14.0" },
     { name = "setuptools" },
-    { name = "types-colorama", specifier = "~=0.4.15.20240106" },
-    { name = "werkzeug", specifier = "~=3.1.0" },
+    { name = "types-colorama", specifier = "<0.5.0" },
+    { name = "werkzeug", specifier = "<4.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Switch from tilde version constraints to using only an upper major version bound. Since the lockfile already pins exact versions, the tilde constraint is unnecessary and causes frequent (and unnecessary) Renovate PRs.
- Use major-only upper-bound version specifiers for most development dependencies.
- Keep the tilde specifier for Ruff and Mypy, since even minor updates can—and often do—break CI.
