### PR TITLE
fix: fetch key-value store records as attachments

### DIFF
--- a/src/apify_client/clients/resource_clients/key_value_store.py
+++ b/src/apify_client/clients/resource_clients/key_value_store.py
@@ -126,7 +126,7 @@ class KeyValueStoreClient(ResourceClient):
             response = self.http_client.call(
                 url=self._url(f'records/{key}'),
                 method='GET',
-                params=self._params(signature=signature),
+                params=self._params(signature=signature, attachment=True),
             )
 
             return {
@@ -181,7 +181,7 @@ class KeyValueStoreClient(ResourceClient):
             response = self.http_client.call(
                 url=self._url(f'records/{key}'),
                 method='GET',
-                params=self._params(signature=signature),
+                params=self._params(signature=signature, attachment=True),
             )
 
             return {
@@ -213,7 +213,7 @@ class KeyValueStoreClient(ResourceClient):
             response = self.http_client.call(
                 url=self._url(f'records/{key}'),
                 method='GET',
-                params=self._params(signature=signature),
+                params=self._params(signature=signature, attachment=True),
                 stream=True,
             )
 
@@ -450,7 +450,7 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
             response = await self.http_client.call(
                 url=self._url(f'records/{key}'),
                 method='GET',
-                params=self._params(signature=signature),
+                params=self._params(signature=signature, attachment=True),
             )
 
             return {
@@ -505,7 +505,7 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
             response = await self.http_client.call(
                 url=self._url(f'records/{key}'),
                 method='GET',
-                params=self._params(signature=signature),
+                params=self._params(signature=signature, attachment=True),
             )
 
             return {
@@ -537,7 +537,7 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
             response = await self.http_client.call(
                 url=self._url(f'records/{key}'),
                 method='GET',
-                params=self._params(signature=signature),
+                params=self._params(signature=signature, attachment=True),
                 stream=True,
             )
 


### PR DESCRIPTION
See apify/apify-core#25006 - fetching with `attachment=true` now allows getting unmodified HTML, without the script snippet for disabling cookies. There are no other side effects (except that the response will have `Content-Disposition: attachment`, but that is irrelevant to clients other than web browsers)