### PR TITLE
chore: Exclude docs from Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
     "extends": ["config:base", ":semanticCommitTypeAll(chore)"],
+    "ignorePaths": ["docs/**"],
     "pinVersions": false,
     "separateMajorMinor": false,
     "dependencyDashboard": false,


### PR DESCRIPTION
To eliminate artifacts update problems like this - https://github.com/apify/apify-client-python/pull/590#issuecomment-3797686854