### PR TITLE
fix: Add missing tagged_builds parameter to Actor update method

### DIFF
--- a/src/apify_client/clients/resource_clients/actor.py
+++ b/src/apify_client/clients/resource_clients/actor.py
@@ -88,6 +88,7 @@ def get_actor_representation(
         },
         'pricingInfos': pricing_infos,
         'actorPermissionLevel': actor_permission_level,
+        'taggedBuilds': tagged_builds,
     }
 
     # Only include actorStandby if at least one field is provided
@@ -109,10 +110,6 @@ def get_actor_representation(
             'build': actor_standby_build,
             'memoryMbytes': actor_standby_memory_mbytes,
         }
-
-    # Add taggedBuilds if provided
-    if tagged_builds is not None:
-        actor_dict['taggedBuilds'] = tagged_builds
 
     return actor_dict
 


### PR DESCRIPTION
Add support for the missing `tagged_builds` parameter in the Actor update method, allowing users to create, update, or remove build tags.

The parameter accepts a dictionary mapping tag names to either:
- A dict with 'build_id' key to assign/reassign a tag
- None to remove a tag

**Example usage:**
```python
client.actor('my-actor').update(
    tagged_builds={
        'latest': {'build_id': 'abc123'},
        'beta': None  # removes beta tag
    }
)
```

**Changes:**
- Added `tagged_builds` parameter to `get_actor_representation()` helper function
- Added `tagged_builds` parameter to `ActorClient.update()` (sync version)
- Added `tagged_builds` parameter to `ActorClientAsync.update()` (async version)

**Related:**
- Related JS client issue: https://github.com/apify/apify-client-js/issues/829

Closes #585