### PR TITLE
fix: Only include actor_standby when at least one field is provided

### DIFF
--- a/src/apify_client/clients/resource_clients/actor.py
+++ b/src/apify_client/clients/resource_clients/actor.py
@@ -62,7 +62,7 @@ def get_actor_representation(
     actor_permission_level: ActorPermissionLevel | None = None,
 ) -> dict:
     """Get dictionary representation of the Actor."""
-    return {
+    actor_dict = {
         'name': name,
         'title': title,
         'description': description,
@@ -85,17 +85,31 @@ def get_actor_representation(
             'body': example_run_input_body,
             'contentType': example_run_input_content_type,
         },
-        'actorStandby': {
+        'pricingInfos': pricing_infos,
+        'actorPermissionLevel': actor_permission_level,
+    }
+
+    # Only include actorStandby if at least one field is provided
+    if any(
+        [
+            actor_standby_is_enabled is not None,
+            actor_standby_desired_requests_per_actor_run is not None,
+            actor_standby_max_requests_per_actor_run is not None,
+            actor_standby_idle_timeout_secs is not None,
+            actor_standby_build is not None,
+            actor_standby_memory_mbytes is not None,
+        ]
+    ):
+        actor_dict['actorStandby'] = {
             'isEnabled': actor_standby_is_enabled,
             'desiredRequestsPerActorRun': actor_standby_desired_requests_per_actor_run,
             'maxRequestsPerActorRun': actor_standby_max_requests_per_actor_run,
             'idleTimeoutSecs': actor_standby_idle_timeout_secs,
             'build': actor_standby_build,
             'memoryMbytes': actor_standby_memory_mbytes,
-        },
-        'pricingInfos': pricing_infos,
-        'actorPermissionLevel': actor_permission_level,
-    }
+        }
+
+    return actor_dict
 
 
 class ActorClient(ResourceClient):


### PR DESCRIPTION
Update the `get_actor_representation` function to conditionally include the `actor_standby` object only when at least one of its fields is not None. This prevents sending empty or null-only actor_standby objects to the API.

**Background:**
According to the API changes, `actor_standby` is optional and should only be included when needed. When present, `is_enabled` is the only required field within the object.

**Changes:**
- Modified `get_actor_representation()` to conditionally add `actor_standby` to the Actor dictionary
- The object is only included if at least one of the following fields is not None:
  - `actor_standby_is_enabled`
  - `actor_standby_desired_requests_per_actor_run`
  - `actor_standby_max_requests_per_actor_run`
  - `actor_standby_idle_timeout_secs`
  - `actor_standby_build`
  - `actor_standby_memory_mbytes`

**Related:**
- Related JS client issue: https://github.com/apify/apify-client-js/issues/832

Closes #595