### PR TITLE
fix: prevent infinite loop in _wait_for_finish on persistent 404s

### DIFF
--- a/src/apify_client/clients/base/actor_job_base_client.py
+++ b/src/apify_client/clients/base/actor_job_base_client.py
@@ -39,7 +39,6 @@ class ActorJobBaseClient(ResourceClient):
                 )
                 job = parse_date_fields(pluck_data(response.json()))
 
-                seconds_elapsed = math.floor((datetime.now(timezone.utc) - started_at).total_seconds())
                 if ActorJobStatus(job['status']).is_terminal or (
                     wait_secs is not None and seconds_elapsed >= wait_secs
                 ):
@@ -56,6 +55,9 @@ class ActorJobBaseClient(ResourceClient):
                 # and return None. In such case, the requested record probably really doesn't exist.
                 if seconds_elapsed > DEFAULT_WAIT_WHEN_JOB_NOT_EXIST_SEC:
                     return None
+
+            finally:
+                seconds_elapsed = math.floor((datetime.now(timezone.utc) - started_at).total_seconds())
 
             # It might take some time for database replicas to get up-to-date so sleep a bit before retrying
             time.sleep(0.25)
@@ -93,7 +95,6 @@ class ActorJobBaseClientAsync(ResourceClientAsync):
                 )
                 job = parse_date_fields(pluck_data(response.json()))
 
-                seconds_elapsed = math.floor((datetime.now(timezone.utc) - started_at).total_seconds())
                 if ActorJobStatus(job['status']).is_terminal or (
                     wait_secs is not None and seconds_elapsed >= wait_secs
                 ):
@@ -110,6 +111,9 @@ class ActorJobBaseClientAsync(ResourceClientAsync):
                 # and return None. In such case, the requested record probably really doesn't exist.
                 if seconds_elapsed > DEFAULT_WAIT_WHEN_JOB_NOT_EXIST_SEC:
                     return None
+
+            finally:
+                seconds_elapsed = math.floor((datetime.now(timezone.utc) - started_at).total_seconds())
 
             # It might take some time for database replicas to get up-to-date so sleep a bit before retrying
             await asyncio.sleep(0.25)


### PR DESCRIPTION
## Summary
- `_wait_for_finish` could spin indefinitely when polling a non-existent job
- `seconds_elapsed` was only updated inside the `try` block (on success), so on persistent 404 errors the timeout check `seconds_elapsed > 3` always evaluated as `0 > 3 = False`
- Moved the `seconds_elapsed` update into a `finally` block so it is always updated regardless of success or failure (both sync and async variants)

## Test plan
- [ ] Verify existing unit tests pass
- [ ] Verify the fix by testing `wait_for_finish` on a non-existent run/build ID — should return `None` after ~3 seconds instead of looping forever

🤖 Generated with [Claude Code](https://claude.com/claude-code)