### PR TITLE
fix: remove erroneous async keyword from sync ActorClient.default_build

### DIFF
--- a/src/apify_client/clients/resource_clients/actor.py
+++ b/src/apify_client/clients/resource_clients/actor.py
@@ -439,7 +439,7 @@ class ActorClient(ResourceClient):
         """Retrieve a client for the runs of this Actor."""
         return RunCollectionClient(**self._sub_resource_init_options(resource_path='runs'))
 
-    async def default_build(
+    def default_build(
         self,
         *,
         wait_for_finish: int | None = None,


### PR DESCRIPTION
## Summary
- `ActorClient.default_build` (the **sync** variant) was incorrectly declared as `async def` — a copy-paste error from the async variant
- Calling it returned a coroutine object instead of a `BuildClient`, making it unusable without `await` (which makes no sense on the sync client)
- Removed the `async` keyword so it behaves as a regular synchronous method

## Test plan
- [ ] Verify existing unit tests pass
- [ ] Verify `ActorClient(...).default_build()` returns a `BuildClient` directly (not a coroutine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)