### PR TITLE
fix: use 'is not None' checks for json parameter to preserve falsy values

### DIFF
--- a/src/apify_client/_http_client.py
+++ b/src/apify_client/_http_client.py
@@ -101,14 +101,14 @@ class _BaseHTTPClient:
         data: Any = None,
         json: JSONSerializable | None = None,
     ) -> tuple[dict, dict | None, Any]:
-        if json and data:
+        if json is not None and data is not None:
             raise ValueError('Cannot pass both "json" and "data" parameters at the same time!')
 
         if not headers:
             headers = {}
 
         # dump JSON data to string, so they can be gzipped
-        if json:
+        if json is not None:
             data = jsonlib.dumps(json, ensure_ascii=False, allow_nan=False, default=str).encode('utf-8')
             headers['Content-Type'] = 'application/json'
 


### PR DESCRIPTION
## Summary
- `_prepare_request_call` used truthiness checks (`if json`) to detect JSON payloads
- This silently dropped valid falsy JSON values: `0`, `""`, `[]`, `{}`, `False`
- For example, `json=[]` (empty list) would not be serialized or sent to the API
- Changed both the conflict check and the serialization gate to use `is not None`

## Test plan
- [ ] Verify existing unit tests pass
- [ ] Verify that `http_client.call(..., json=[])` correctly sends an empty JSON array

🤖 Generated with [Claude Code](https://claude.com/claude-code)