### PR TITLE
fix: use explicit None checks for client config to respect zero values

### DIFF
--- a/src/apify_client/client.py
+++ b/src/apify_client/client.py
@@ -89,9 +89,11 @@ class _BaseApifyClient:
         self.base_url = f'{api_url}/{API_VERSION}'
         api_public_url = (api_public_url or DEFAULT_API_URL).rstrip('/')
         self.public_base_url = f'{api_public_url}/{API_VERSION}'
-        self.max_retries = max_retries or 8
-        self.min_delay_between_retries_millis = min_delay_between_retries_millis or 500
-        self.timeout_secs = timeout_secs or DEFAULT_TIMEOUT
+        self.max_retries = max_retries if max_retries is not None else 8
+        self.min_delay_between_retries_millis = (
+            min_delay_between_retries_millis if min_delay_between_retries_millis is not None else 500
+        )
+        self.timeout_secs = timeout_secs if timeout_secs is not None else DEFAULT_TIMEOUT
 
     def _options(self) -> dict:
         return {


### PR DESCRIPTION
## Summary
- `max_retries`, `min_delay_between_retries_millis`, and `timeout_secs` used `or` for defaults
- The `or` operator treats `0` as falsy, so `max_retries=0` silently became `8`, `timeout_secs=0` became `360`, etc.
- Changed to `if x is not None else default` pattern to correctly respect explicit zero values

## Test plan
- [ ] Verify existing unit tests pass
- [ ] Verify `ApifyClient(token='x', max_retries=0)` results in `client.max_retries == 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)