### PR TITLE
fix: Retry on all impit.HTTPError exceptions, not just specific subclasses

### DIFF
--- a/src/apify_client/_utils.py
+++ b/src/apify_client/_utils.py
@@ -281,13 +281,16 @@ def maybe_parse_response(response: Response) -> Any:
 
 
 def is_retryable_error(exc: Exception) -> bool:
-    """Check if the given error is retryable."""
+    """Check if the given error is retryable.
+
+    All ``impit.HTTPError`` subclasses are considered retryable because they represent transport-level failures
+    (network issues, timeouts, protocol errors, body decoding errors) that are typically transient. HTTP status
+    code errors are handled separately in ``_make_request`` based on the response status code, not here.
+    """
     return isinstance(
         exc,
         (
             InvalidResponseBodyError,
-            impit.NetworkError,
-            impit.TimeoutException,
-            impit.RemoteProtocolError,
+            impit.HTTPError,
         ),
     )

--- a/tests/unit/test_client_timeouts.py
+++ b/tests/unit/test_client_timeouts.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock
 
 import pytest
-from impit import Response, TimeoutException
+from impit import HTTPError, Response, TimeoutException
 
 from apify_client import ApifyClient
 from apify_client._http_client import HTTPClient, HTTPClientAsync
@@ -73,6 +73,32 @@ async def test_dynamic_timeout_async_client(monkeypatch: pytest.MonkeyPatch) -> 
     assert retry_counter_mock.call_count == 4
     assert timeouts == expected_timeouts
     # Check that the response is successful
+    assert response.status_code == 200
+
+
+async def test_retry_on_http_error_async_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tests that bare impit.HTTPError (e.g. body decode errors) are retried.
+
+    This reproduces the scenario where the HTTP response body is truncated mid-stream
+    (e.g. "unexpected EOF during chunk size line"), which impit raises as a generic HTTPError.
+    """
+    should_raise_error = iter((True, True, False))
+    retry_counter_mock = Mock()
+
+    async def mock_request(*_args: Any, **_kwargs: Any) -> Response:
+        retry_counter_mock()
+        should_raise = next(should_raise_error)
+        if should_raise:
+            raise HTTPError('The internal HTTP library has thrown an error: unexpected EOF during chunk size line')
+
+        return Response(status_code=200)
+
+    monkeypatch.setattr('impit.AsyncClient.request', mock_request)
+
+    response = await HTTPClientAsync(timeout_secs=5).call(method='GET', url='http://placeholder.url/http_error')
+
+    # 3 attempts: 2 failures + 1 success
+    assert retry_counter_mock.call_count == 3
     assert response.status_code == 200
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,16 +2,19 @@ import time
 from collections.abc import Callable
 from typing import Any
 
+import impit
 import pytest
 from apify_shared.consts import WebhookEventType
 
 from apify_client._utils import (
     encode_webhook_list_to_base64,
+    is_retryable_error,
     pluck_data,
     retry_with_exp_backoff,
     retry_with_exp_backoff_async,
     to_safe_id,
 )
+from apify_client.errors import InvalidResponseBodyError
 
 
 def test__to_safe_id() -> None:
@@ -154,3 +157,33 @@ def test__encode_webhook_list_to_base64() -> None:
         )
         == 'W3siZXZlbnRUeXBlcyI6IFsiQUNUT1IuUlVOLkNSRUFURUQiXSwgInJlcXVlc3RVcmwiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9ydW4tY3JlYXRlZCJ9LCB7ImV2ZW50VHlwZXMiOiBbIkFDVE9SLlJVTi5TVUNDRUVERUQiXSwgInJlcXVlc3RVcmwiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9ydW4tc3VjY2VlZGVkIiwgInBheWxvYWRUZW1wbGF0ZSI6ICJ7XCJoZWxsb1wiOiBcIndvcmxkXCIsIFwicmVzb3VyY2VcIjp7e3Jlc291cmNlfX19In1d'  # noqa: E501
     )
+
+
+@pytest.mark.parametrize(
+    'exc',
+    [
+        InvalidResponseBodyError(impit.Response(status_code=200)),
+        impit.HTTPError('generic http error'),
+        impit.NetworkError('network error'),
+        impit.TimeoutException('timeout'),
+        impit.RemoteProtocolError('remote protocol error'),
+        impit.ReadError('read error'),
+        impit.ConnectError('connect error'),
+        impit.WriteError('write error'),
+        impit.DecodingError('decoding error'),
+    ],
+)
+def test__is_retryable_error(exc: Exception) -> None:
+    assert is_retryable_error(exc) is True
+
+
+@pytest.mark.parametrize(
+    'exc',
+    [
+        Exception('generic exception'),
+        ValueError('value error'),
+        RuntimeError('runtime error'),
+    ],
+)
+def test__is_not_retryable_error(exc: Exception) -> None:
+    assert is_retryable_error(exc) is False


### PR DESCRIPTION
## Summary

- Broadened `is_retryable_error()` to catch `impit.HTTPError` (base class) instead of only `impit.NetworkError`, `impit.TimeoutException`, and `impit.RemoteProtocolError`
- Some transient errors (e.g. body decode failures like "unexpected EOF during chunk size line") are raised by `impit` as bare `HTTPError` instances that don't match any of the specific subclasses, causing requests to fail without retrying
- HTTP status code errors are already handled separately in `_make_request` based on response status codes, so this change only affects transport-level failures

**Triggered by**: [flaky e2e test failure in apify-sdk-python](https://github.com/apify/apify-sdk-python/actions/runs/22101349916/attempts/1) where `wait_for_finish` failed with:
```
impit.HTTPError: The internal HTTP library has thrown an error:
reqwest::Error {
    kind: Decode,
    source: reqwest::Error {
        kind: Body,
        source: hyper::Error(
            Body,
            Custom {
                kind: UnexpectedEof,
                error: "unexpected EOF during chunk size line",
            },
        ),
    },
}
```

## Test plan

- [x] Added parametrized unit tests for `is_retryable_error` covering all `impit` exception types (retryable) and generic exceptions (non-retryable)
- [x] Added integration-style test `test_retry_on_http_error_async_client` that verifies bare `HTTPError` is actually retried by the HTTP client
- [x] All 115 unit tests pass
- [x] Pre-commit hooks pass (lint, type-check, docstrings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)