### PR TITLE
ci: Trigger doc release on stable release

### DIFF
--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -101,3 +101,16 @@ jobs:
       # Publishes the package to PyPI using PyPA official GitHub action with OIDC authentication.
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  doc_release:
+    name: Doc release
+    needs: [changelog_update, pypi_publish]
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/_release_docs.yaml
+    with:
+      # Use the ref from the changelog update to include the updated changelog.
+      ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- The stable release pipeline was missing a doc release step, so the changelog on the website was not updated after a stable release
- Added a `doc_release` job to `manual_release_stable.yaml` (same pattern as `doc_release_post_publish` in `on_master.yaml`)
- The job runs after `changelog_update` and `pypi_publish`, using the changelog commit ref to include the updated changelog
- Includes explicit permissions (`contents: write`, `pages: write`, `id-token: write`) since the workflow has top-level `permissions: contents: read`

## Test plan
- [ ] Verify the workflow YAML is valid
- [ ] Trigger a stable release and confirm doc release runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)