### PR TITLE
ci: Update on_master workflow conditions

### DIFF
--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -20,8 +20,8 @@ jobs:
     uses: ./.github/workflows/_check_docs.yaml
 
   doc_release:
-    # Skip this for non-docs commits and forks.
-    if: "startsWith(github.event.head_commit.message, 'docs') && startsWith(github.repository, 'apify/')"
+    # Skip this for non-"docs" commits.
+    if: startsWith(github.event.head_commit.message, 'docs')
     name: Doc release
     needs: [doc_checks]
     permissions:
@@ -43,15 +43,20 @@ jobs:
     uses: ./.github/workflows/_check_docstrings.yaml
 
   tests:
-    # Skip this for "ci" and "docs" commits.
-    if: "!startsWith(github.event.head_commit.message, 'ci') && !startsWith(github.event.head_commit.message, 'docs')"
+    # Skip this for "docs" commits.
+    if: "!startsWith(github.event.head_commit.message, 'docs')"
     name: Tests
     uses: ./.github/workflows/_tests.yaml
     secrets: inherit
 
   release_prepare:
-    # Skip this for "ci", "docs" and "test" commits and for forks.
-    if: "!startsWith(github.event.head_commit.message, 'ci') && !startsWith(github.event.head_commit.message, 'docs') && !startsWith(github.event.head_commit.message, 'test') && startsWith(github.repository, 'apify/')"
+    # Run this only for "feat", "fix", "perf", "refactor" and "style" commits.
+    if: >-
+      startsWith(github.event.head_commit.message, 'feat') ||
+      startsWith(github.event.head_commit.message, 'fix') ||
+      startsWith(github.event.head_commit.message, 'perf') ||
+      startsWith(github.event.head_commit.message, 'refactor') ||
+      startsWith(github.event.head_commit.message, 'style')
     name: Release prepare
     needs: [code_checks, docstrings_checks, tests]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Pre-release runs only for `feat`, `fix`, `perf`, `refactor`, `style` conventional commits (skip all others)
- Doc release runs only for `docs` conventional commits (skip all others)
- Tests skip only for `docs` conventional commits
- `startsWith(github.repository, 'apify/')` is not necessary since it is only the `on_master` trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)