### PR TITLE
docs: Remove apify-shared from documentation build

### DIFF
--- a/website/build_api_reference.sh
+++ b/website/build_api_reference.sh
@@ -14,24 +14,6 @@ sed_no_backup() {
 pydoc-markdown --quiet --dump > docspec-dump.jsonl
 sed_no_backup "s#${PWD}/..#REPO_ROOT_PLACEHOLDER#g" docspec-dump.jsonl
 
-# Create docpec dump from the right version of the apify-shared package
-apify_shared_version=$(python -c "import apify_shared; print(apify_shared.__version__)")
-apify_shared_tempdir=$(realpath "$(mktemp -d)")
-git clone --quiet https://github.com/apify/apify-shared-python.git "${apify_shared_tempdir}"
-cp ./pydoc-markdown.yml "${apify_shared_tempdir}/pydoc-markdown.yml"
-sed_no_backup "s#search_path: \[../src\]#search_path: \[./src\]#g" "${apify_shared_tempdir}/pydoc-markdown.yml"
-
-(
-    cd "${apify_shared_tempdir}";
-    git checkout --quiet "v${apify_shared_version}";
-    pydoc-markdown --quiet --dump > ./apify-shared-docspec-dump.jsonl
-)
-
-cp "${apify_shared_tempdir}/apify-shared-docspec-dump.jsonl" .
-sed_no_backup "s#${apify_shared_tempdir}#REPO_ROOT_PLACEHOLDER#g" apify-shared-docspec-dump.jsonl
-
-rm -rf "${apify_shared_tempdir}"
-
 # Generate import shortcuts from the modules
 python generate_module_shortcuts.py
 

--- a/website/generate_module_shortcuts.py
+++ b/website/generate_module_shortcuts.py
@@ -45,7 +45,7 @@ def resolve_shortcuts(shortcuts: dict) -> None:
 
 
 shortcuts = {}
-for module_name in ['apify', 'apify_client', 'apify_shared']:
+for module_name in ['apify', 'apify_client']:
     try:
         module = importlib.import_module(module_name)
         module_shortcuts = get_module_shortcuts(module)

--- a/website/transformDocs.js
+++ b/website/transformDocs.js
@@ -9,17 +9,15 @@ const REPO_ROOT_PLACEHOLDER = 'REPO_ROOT_PLACEHOLDER';
 
 const APIFY_CLIENT_REPO_URL = 'https://github.com/apify/apify-client-python';
 const APIFY_SDK_REPO_URL    = 'https://github.com/apify/apify-sdk-python';
-const APIFY_SHARED_REPO_URL = 'https://github.com/apify/apify-shared-python';
 
 const REPO_URL_PER_PACKAGE = {
     'apify': APIFY_SDK_REPO_URL,
     'apify_client': APIFY_CLIENT_REPO_URL,
-    'apify_shared': APIFY_SHARED_REPO_URL,
 };
 
 // For each package, get the installed version, and set the tag to the corresponding version
 const TAG_PER_PACKAGE = {};
-for (const pkg of ['apify', 'apify_client', 'apify_shared']) {
+for (const pkg of ['apify', 'apify_client']) {
     const spawnResult = spawnSync('python', ['-c', `import ${pkg}; print(${pkg}.__version__)`]);
     if (spawnResult.status === 0) {
         TAG_PER_PACKAGE[pkg] = `v${spawnResult.stdout.toString().trim()}`;
@@ -319,15 +317,12 @@ function main() {
         ]
     };
 
-    // Load the docspec dump files of this module and of apify-shared
+    // Load the docspec dump file of this module
     const thisPackageDocspecDump = fs.readFileSync('docspec-dump.jsonl', 'utf8');
     const thisPackageModules = thisPackageDocspecDump.split('\n').filter((line) => line !== '');
 
-    const apifySharedDocspecDump = fs.readFileSync('apify-shared-docspec-dump.jsonl', 'utf8');
-    const apifySharedModules = apifySharedDocspecDump.split('\n').filter((line) => line !== '');
-
     // Convert all the modules, store them in the root object
-    for (const module of [...thisPackageModules, ...apifySharedModules]) {
+    for (const module of thisPackageModules) {
         const parsedModule = JSON.parse(module);
         convertObject(parsedModule, typedocApiReference, parsedModule);
     };


### PR DESCRIPTION
## Summary

- Removes `apify-shared` from the docs build pipeline — it is no longer a dependency of `apify-client-python`
- Removes cloning of `apify-shared-python` repo and its docspec dump generation from `build_api_reference.sh`
- Removes `apify_shared` references from `transformDocs.js` (repo URL, version detection, docspec merging)
- Removes `apify_shared` from the module list in `generate_module_shortcuts.py`

## Test plan

- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)