### PR TITLE
refactor: Replace kwargs.pop with explicit resource_path keyword arguments

### DIFF
--- a/src/apify_client/_resource_clients/actor_collection.py
+++ b/src/apify_client/_resource_clients/actor_collection.py
@@ -20,9 +20,16 @@ class ActorCollectionClient(ResourceClient):
     method on the `ApifyClient` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'acts')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'acts',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     def list(
         self,
@@ -152,9 +159,16 @@ class ActorCollectionClientAsync(ResourceClientAsync):
     method on the `ApifyClientAsync` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'acts')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'acts',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     async def list(
         self,

--- a/src/apify_client/_resource_clients/actor_env_var.py
+++ b/src/apify_client/_resource_clients/actor_env_var.py
@@ -30,9 +30,18 @@ class ActorEnvVarClient(ResourceClient):
     via an appropriate method on the `ActorVersionClient` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'env-vars')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_id: str,
+        resource_path: str = 'env-vars',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_id=resource_id,
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     def get(self) -> EnvVar | None:
         """Return information about the Actor environment variable.
@@ -91,9 +100,18 @@ class ActorEnvVarClientAsync(ResourceClientAsync):
     via an appropriate method on the `ActorVersionClientAsync` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'env-vars')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_id: str,
+        resource_path: str = 'env-vars',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_id=resource_id,
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     async def get(self) -> EnvVar | None:
         """Return information about the Actor environment variable.

--- a/src/apify_client/_resource_clients/actor_env_var_collection.py
+++ b/src/apify_client/_resource_clients/actor_env_var_collection.py
@@ -17,9 +17,16 @@ class ActorEnvVarCollectionClient(ResourceClient):
     appropriate method on the `ActorVersionClient` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'env-vars')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'env-vars',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     def list(self) -> ListOfEnvVars:
         """List the available Actor environment variables.
@@ -69,9 +76,16 @@ class ActorEnvVarCollectionClientAsync(ResourceClientAsync):
     appropriate method on the `ActorVersionClientAsync` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'env-vars')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'env-vars',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     async def list(self) -> ListOfEnvVars:
         """List the available Actor environment variables.

--- a/src/apify_client/_resource_clients/actor_version_collection.py
+++ b/src/apify_client/_resource_clients/actor_version_collection.py
@@ -23,9 +23,16 @@ class ActorVersionCollectionClient(ResourceClient):
     on the `ActorClient` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'versions')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'versions',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     def list(self) -> ListOfVersions:
         """List the available Actor versions.
@@ -99,9 +106,16 @@ class ActorVersionCollectionClientAsync(ResourceClientAsync):
     on the `ActorClientAsync` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'versions')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'versions',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     async def list(self) -> ListOfVersions:
         """List the available Actor versions.

--- a/src/apify_client/_resource_clients/build_collection.py
+++ b/src/apify_client/_resource_clients/build_collection.py
@@ -15,9 +15,16 @@ class BuildCollectionClient(ResourceClient):
     `ApifyClient` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'actor-builds')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'actor-builds',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     def list(
         self,
@@ -54,9 +61,16 @@ class BuildCollectionClientAsync(ResourceClientAsync):
     `ApifyClientAsync` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'actor-builds')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'actor-builds',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     async def list(
         self,

--- a/src/apify_client/_resource_clients/dataset.py
+++ b/src/apify_client/_resource_clients/dataset.py
@@ -65,9 +65,18 @@ class DatasetClient(ResourceClient):
     via an appropriate method on the `ApifyClient` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'datasets')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_id: str | None = None,
+        resource_path: str = 'datasets',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_id=resource_id,
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     def get(self) -> Dataset | None:
         """Retrieve the dataset.
@@ -686,9 +695,18 @@ class DatasetClientAsync(ResourceClientAsync):
     via an appropriate method on the `ApifyClientAsync` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'datasets')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_id: str | None = None,
+        resource_path: str = 'datasets',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_id=resource_id,
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     async def get(self) -> Dataset | None:
         """Retrieve the dataset.

--- a/src/apify_client/_resource_clients/dataset_collection.py
+++ b/src/apify_client/_resource_clients/dataset_collection.py
@@ -16,9 +16,16 @@ class DatasetCollectionClient(ResourceClient):
     appropriate method on the `ApifyClient` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'datasets')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'datasets',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     def list(
         self,
@@ -68,9 +75,16 @@ class DatasetCollectionClientAsync(ResourceClientAsync):
     appropriate method on the `ApifyClientAsync` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'datasets')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'datasets',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     async def list(
         self,

--- a/src/apify_client/_resource_clients/key_value_store.py
+++ b/src/apify_client/_resource_clients/key_value_store.py
@@ -76,9 +76,18 @@ class KeyValueStoreClient(ResourceClient):
     instance via an appropriate method on the `ApifyClient` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'key-value-stores')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_id: str | None = None,
+        resource_path: str = 'key-value-stores',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_id=resource_id,
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     def get(self) -> KeyValueStore | None:
         """Retrieve the key-value store.
@@ -460,9 +469,18 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
     instance via an appropriate method on the `ApifyClientAsync` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'key-value-stores')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_id: str | None = None,
+        resource_path: str = 'key-value-stores',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_id=resource_id,
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     async def get(self) -> KeyValueStore | None:
         """Retrieve the key-value store.

--- a/src/apify_client/_resource_clients/key_value_store_collection.py
+++ b/src/apify_client/_resource_clients/key_value_store_collection.py
@@ -21,9 +21,16 @@ class KeyValueStoreCollectionClient(ResourceClient):
     via an appropriate method on the `ApifyClient` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'key-value-stores')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'key-value-stores',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     def list(
         self,
@@ -78,9 +85,16 @@ class KeyValueStoreCollectionClientAsync(ResourceClientAsync):
     via an appropriate method on the `ApifyClientAsync` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'key-value-stores')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'key-value-stores',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     async def list(
         self,

--- a/src/apify_client/_resource_clients/log.py
+++ b/src/apify_client/_resource_clients/log.py
@@ -22,9 +22,16 @@ class LogClient(ResourceClient):
     `ApifyClient` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'logs')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'logs',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     def get(self, *, raw: bool = False) -> str | None:
         """Retrieve the log as text.
@@ -114,9 +121,16 @@ class LogClientAsync(ResourceClientAsync):
     `ApifyClientAsync` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'logs')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'logs',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     async def get(self, *, raw: bool = False) -> str | None:
         """Retrieve the log as text.

--- a/src/apify_client/_resource_clients/request_queue.py
+++ b/src/apify_client/_resource_clients/request_queue.py
@@ -62,7 +62,9 @@ class RequestQueueClient(ResourceClient):
 
     def __init__(  # noqa: D417
         self,
-        *args: Any,
+        *,
+        resource_id: str | None = None,
+        resource_path: str = 'request-queues',
         client_key: str | None = None,
         **kwargs: Any,
     ) -> None:
@@ -71,8 +73,11 @@ class RequestQueueClient(ResourceClient):
         Args:
             client_key: A unique identifier of the client accessing the request queue.
         """
-        resource_path = kwargs.pop('resource_path', 'request-queues')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+        super().__init__(
+            resource_id=resource_id,
+            resource_path=resource_path,
+            **kwargs,
+        )
         self.client_key = client_key
 
     def get(self) -> RequestQueue | None:
@@ -472,7 +477,9 @@ class RequestQueueClientAsync(ResourceClientAsync):
 
     def __init__(  # noqa: D417
         self,
-        *args: Any,
+        *,
+        resource_id: str | None = None,
+        resource_path: str = 'request-queues',
         client_key: str | None = None,
         **kwargs: Any,
     ) -> None:
@@ -481,8 +488,11 @@ class RequestQueueClientAsync(ResourceClientAsync):
         Args:
             client_key: A unique identifier of the client accessing the request queue.
         """
-        resource_path = kwargs.pop('resource_path', 'request-queues')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+        super().__init__(
+            resource_id=resource_id,
+            resource_path=resource_path,
+            **kwargs,
+        )
         self.client_key = client_key
 
     async def get(self) -> RequestQueue | None:

--- a/src/apify_client/_resource_clients/request_queue_collection.py
+++ b/src/apify_client/_resource_clients/request_queue_collection.py
@@ -20,9 +20,16 @@ class RequestQueueCollectionClient(ResourceClient):
     via an appropriate method on the `ApifyClient` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'request-queues')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'request-queues',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     def list(
         self,
@@ -71,9 +78,16 @@ class RequestQueueCollectionClientAsync(ResourceClientAsync):
     via an appropriate method on the `ApifyClientAsync` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'request-queues')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'request-queues',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     async def list(
         self,

--- a/src/apify_client/_resource_clients/run_collection.py
+++ b/src/apify_client/_resource_clients/run_collection.py
@@ -21,9 +21,16 @@ class RunCollectionClient(ResourceClient):
     `ApifyClient` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'actor-runs')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'actor-runs',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     def list(
         self,
@@ -75,9 +82,16 @@ class RunCollectionClientAsync(ResourceClientAsync):
     `ApifyClientAsync` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'actor-runs')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'actor-runs',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     async def list(
         self,

--- a/src/apify_client/_resource_clients/schedule.py
+++ b/src/apify_client/_resource_clients/schedule.py
@@ -18,9 +18,18 @@ class ScheduleClient(ResourceClient):
     appropriate method on the `ApifyClient` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'schedules')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_id: str,
+        resource_path: str = 'schedules',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_id=resource_id,
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     def get(self) -> Schedule | None:
         """Return information about the schedule.
@@ -118,9 +127,18 @@ class ScheduleClientAsync(ResourceClientAsync):
     appropriate method on the `ApifyClientAsync` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'schedules')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_id: str,
+        resource_path: str = 'schedules',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_id=resource_id,
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     async def get(self) -> Schedule | None:
         """Return information about the schedule.

--- a/src/apify_client/_resource_clients/schedule_collection.py
+++ b/src/apify_client/_resource_clients/schedule_collection.py
@@ -17,9 +17,16 @@ class ScheduleCollectionClient(ResourceClient):
     appropriate method on the `ApifyClient` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'schedules')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'schedules',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     def list(
         self,
@@ -100,9 +107,16 @@ class ScheduleCollectionClientAsync(ResourceClientAsync):
     appropriate method on the `ApifyClientAsync` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'schedules')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'schedules',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     async def list(
         self,

--- a/src/apify_client/_resource_clients/store_collection.py
+++ b/src/apify_client/_resource_clients/store_collection.py
@@ -15,9 +15,16 @@ class StoreCollectionClient(ResourceClient):
     method on the `ApifyClient` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'store')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'store',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     def list(
         self,
@@ -67,9 +74,16 @@ class StoreCollectionClientAsync(ResourceClientAsync):
     method on the `ApifyClientAsync` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'store')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'store',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     async def list(
         self,

--- a/src/apify_client/_resource_clients/task_collection.py
+++ b/src/apify_client/_resource_clients/task_collection.py
@@ -20,9 +20,16 @@ class TaskCollectionClient(ResourceClient):
     method on the `ApifyClient` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'actor-tasks')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'actor-tasks',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     def list(
         self,
@@ -124,9 +131,16 @@ class TaskCollectionClientAsync(ResourceClientAsync):
     method on the `ApifyClientAsync` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'actor-tasks')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'actor-tasks',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     async def list(
         self,

--- a/src/apify_client/_resource_clients/user.py
+++ b/src/apify_client/_resource_clients/user.py
@@ -28,12 +28,18 @@ class UserClient(ResourceClient):
     an appropriate method on the `ApifyClient` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_id = kwargs.pop('resource_id', None)
-        if resource_id is None:
-            resource_id = 'me'
-        resource_path = kwargs.pop('resource_path', 'users')
-        super().__init__(*args, resource_id=resource_id, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_id: str | None = None,
+        resource_path: str = 'users',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_id=resource_id or 'me',
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     def get(self) -> UserPublicInfo | UserPrivateInfo | None:
         """Return information about user account.
@@ -132,12 +138,18 @@ class UserClientAsync(ResourceClientAsync):
     an appropriate method on the `ApifyClientAsync` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_id = kwargs.pop('resource_id', None)
-        if resource_id is None:
-            resource_id = 'me'
-        resource_path = kwargs.pop('resource_path', 'users')
-        super().__init__(*args, resource_id=resource_id, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_id: str | None = None,
+        resource_path: str = 'users',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_id=resource_id or 'me',
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     async def get(self) -> UserPublicInfo | UserPrivateInfo | None:
         """Return information about user account.

--- a/src/apify_client/_resource_clients/webhook.py
+++ b/src/apify_client/_resource_clients/webhook.py
@@ -27,9 +27,18 @@ class WebhookClient(ResourceClient):
     appropriate method on the `ApifyClient` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'webhooks')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_id: str,
+        resource_path: str = 'webhooks',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_id=resource_id,
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     def get(self) -> Webhook | None:
         """Retrieve the webhook.
@@ -149,9 +158,18 @@ class WebhookClientAsync(ResourceClientAsync):
     appropriate method on the `ApifyClientAsync` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'webhooks')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_id: str,
+        resource_path: str = 'webhooks',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_id=resource_id,
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     async def get(self) -> Webhook | None:
         """Retrieve the webhook.

--- a/src/apify_client/_resource_clients/webhook_collection.py
+++ b/src/apify_client/_resource_clients/webhook_collection.py
@@ -20,9 +20,16 @@ class WebhookCollectionClient(ResourceClient):
     appropriate method on the `ApifyClient` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'webhooks')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'webhooks',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     def list(
         self,
@@ -111,9 +118,16 @@ class WebhookCollectionClientAsync(ResourceClientAsync):
     appropriate method on the `ApifyClientAsync` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'webhooks')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'webhooks',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     async def list(
         self,

--- a/src/apify_client/_resource_clients/webhook_dispatch.py
+++ b/src/apify_client/_resource_clients/webhook_dispatch.py
@@ -15,9 +15,18 @@ class WebhookDispatchClient(ResourceClient):
     method on the `ApifyClient` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'webhook-dispatches')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_id: str,
+        resource_path: str = 'webhook-dispatches',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_id=resource_id,
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     def get(self) -> WebhookDispatch | None:
         """Retrieve the webhook dispatch.
@@ -41,9 +50,18 @@ class WebhookDispatchClientAsync(ResourceClientAsync):
     method on the `ApifyClientAsync` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'webhook-dispatches')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_id: str,
+        resource_path: str = 'webhook-dispatches',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_id=resource_id,
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     async def get(self) -> WebhookDispatch | None:
         """Retrieve the webhook dispatch.

--- a/src/apify_client/_resource_clients/webhook_dispatch_collection.py
+++ b/src/apify_client/_resource_clients/webhook_dispatch_collection.py
@@ -15,9 +15,16 @@ class WebhookDispatchCollectionClient(ResourceClient):
     `ApifyClient` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'webhook-dispatches')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'webhook-dispatches',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     def list(
         self,
@@ -50,9 +57,16 @@ class WebhookDispatchCollectionClientAsync(ResourceClientAsync):
     `ApifyClientAsync` class.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        resource_path = kwargs.pop('resource_path', 'webhook-dispatches')
-        super().__init__(*args, resource_path=resource_path, **kwargs)
+    def __init__(
+        self,
+        *,
+        resource_path: str = 'webhook-dispatches',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            resource_path=resource_path,
+            **kwargs,
+        )
 
     async def list(
         self,


### PR DESCRIPTION
## Summary

- Replace the `kwargs.pop('resource_path', ...)` anti-pattern with proper keyword arguments in all resource client `__init__` methods.
- Improves type safety, readability, and IDE support across 22 files (44 sync/async class pairs).
- Special handling for `UserClient` (`resource_id: str | None = None`, resolved to `'me'`) and `RequestQueueClient` (retains extra `client_key` param).

## Test plan

- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)