### PR TITLE
chore: configure codecov checks as informational

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -4,3 +4,8 @@ coverage:
       default:
         target: auto
         threshold: 0.10%   # tolerate up to 0.10% decrease
+        informational: true # CI check reports status but never fails
+    patch:
+      default:
+        target: 50%         # error only if patch coverage drops below 50%
+        informational: true  # CI check reports status but never fails


### PR DESCRIPTION
## Summary
- Add patch coverage target at 50%
- Set both project and patch status checks to informational mode so they report coverage but never block CI

## Test plan
- [x] Verify codecov.yaml syntax is valid
- [ ] Merge and verify Codecov status checks appear as informational on next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)