### PR TITLE
test: correct isinstance check in webhook integration test

### DIFF
--- a/tests/integration/test_webhook.py
+++ b/tests/integration/test_webhook.py
@@ -14,6 +14,7 @@ from apify_client._models import (
     ListOfRuns,
     ListOfWebhookDispatches,
     ListOfWebhooks,
+    Run,
     Webhook,
     WebhookDispatch,
     WebhookEventType,
@@ -39,7 +40,7 @@ async def _get_finished_run_id(client: ApifyClient | ApifyClientAsync) -> str:
     # No completed runs found - start one and wait for it to finish
     run = await maybe_await(client.actor(HELLO_WORLD_ACTOR).call())
 
-    assert isinstance(run, ListOfRuns)
+    assert isinstance(run, Run)
 
     return run.id
 


### PR DESCRIPTION
## Summary
- Fix flaky `test_webhook_create_and_get` integration test
- The `_get_finished_run_id` helper incorrectly asserted `isinstance(run, ListOfRuns)` after calling `.call()`, which returns a `Run` object — causing failures when no prior successful runs existed for the hello-world actor

## Test plan
- [x] Verify the fix by inspecting the corrected assertion (`isinstance(run, Run)`)
- [x] Re-run integration tests to confirm the flaky test passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)