### PR TITLE
chore: Send Booleans as `true` or `false` to API

### DIFF
--- a/src/apify_client/_http_clients/_base.py
+++ b/src/apify_client/_http_clients/_base.py
@@ -145,7 +145,7 @@ class HttpClientBase:
     def _parse_params(params: dict[str, Any] | None) -> dict[str, Any] | None:
         """Convert request parameters to Apify API-compatible formats.
 
-        Converts booleans to 0/1, lists to comma-separated strings, datetimes to ISO 8601 Zulu format.
+        Converts booleans to 'false'/'true', lists to comma-separated strings, datetimes to ISO 8601 Zulu format.
         """
         if params is None:
             return None

--- a/tests/unit/test_http_clients.py
+++ b/tests/unit/test_http_clients.py
@@ -183,9 +183,9 @@ def test_parse_params_none() -> None:
 
 
 def test_parse_params_boolean() -> None:
-    """Test _parse_params converts booleans to integers."""
+    """Test _parse_params converts booleans to `false` or `true`."""
     result = HttpClient._parse_params({'flag': True, 'disabled': False})
-    assert result == {'flag': 1, 'disabled': 0}
+    assert result == {'flag': 'true', 'disabled': 'false'}
 
 
 def test_parse_params_list() -> None:
@@ -224,7 +224,7 @@ def test_parse_params_mixed() -> None:
     assert result == {
         'limit': 10,
         'offset': 0,
-        'flag': 1,
+        'flag': 'true',
         'tags': 'tag1,tag2',
         'created_at': '2024-01-15T10:30:45.123Z',
         'name': 'test',
@@ -377,7 +377,7 @@ def test_prepare_request_call_with_params() -> None:
 
     _headers, params, _data = client._prepare_request_call(params={'limit': 10, 'flag': True})
 
-    assert params == {'limit': 10, 'flag': 1}
+    assert params == {'limit': 10, 'flag': 'true'}
 
 
 def test_build_url_with_params_none() -> None:

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -206,7 +206,7 @@ def mock_api(httpserver: HTTPServer) -> None:
     )
 
     httpserver.expect_request(
-        f'/v2/actor-runs/{_MOCKED_RUN_ID}/log', method='GET', query_string='stream=1&raw=1'
+        f'/v2/actor-runs/{_MOCKED_RUN_ID}/log', method='GET', query_string='stream=true&raw=true'
     ).respond_with_handler(_streaming_log_handler)
 
 
@@ -486,7 +486,7 @@ async def test_streamed_log_async_restart_after_normal_completion(httpserver: HT
     """Test that StreamedLogAsync cannot be restarted after task completes normally."""
     # Set up a quick-completing stream endpoint
     httpserver.expect_request(
-        f'/v2/actor-runs/{_MOCKED_RUN_ID}/log', method='GET', query_string='stream=1&raw=1'
+        f'/v2/actor-runs/{_MOCKED_RUN_ID}/log', method='GET', query_string='stream=true&raw=true'
     ).respond_with_data(b'Quick log\n', content_type='application/octet-stream')
 
     # Set up actor info endpoint (needed for get_streamed_log)


### PR DESCRIPTION
Sending `1` and `0` is working, but the validator is complaining about that.
Lets align with the JS client. [JS client uses `false`, `true`](https://github.com/apify/apify-client-js/blob/v2.22.2/src/utils.ts)
[OpenAPI spec does not define](https://spec.openapis.org/oas/v3.2.0.html#boolean-query-parameter-examples) serialization of Booleans, but tools frequently choose `false/true`

### Issues:

Related to: https://github.com/apify/apify-docs/issues/2286
