### PR TITLE
chore: Use only packages older than 24 hours

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,6 +228,10 @@ allow_population_by_field_name = true
 aliases = "datamodel_codegen_aliases.json"
 formatters = ["ruff-check", "ruff-format"]
 
+[tool.uv]
+# Minimal defense against supply-chain atatcks.
+exclude-newer = "24 hours"
+
 # Run tasks with: uv run poe <task>
 [tool.poe.tasks]
 clean = "rm -rf .coverage .pytest_cache .ruff_cache .ty_cache build dist htmlcov"

--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,7 @@
             "automergeType": "branch"
         }
     ],
+    "minimumReleaseAge": "1 day",
     "schedule": ["before 7am every weekday"],
     "ignoreDeps": ["apify_client", "docusaurus-plugin-typedoc-api"]
 }

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.14'",
 ]
 
+[options]
+exclude-newer = "2026-03-23T08:38:56.883370546Z"
+exclude-newer-span = "PT24H"
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"


### PR DESCRIPTION
- Update Renovate and project settings to use only package versions older than 24 hours
- Motivation is to add minimal defence to supply chain attacks.

