### PR TITLE
chore: ignore versioned docs in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
     "extends": ["config:base", ":semanticCommitTypeAll(chore)"],
-    "ignorePaths": ["docs/**"],
+    "ignorePaths": ["docs/**", "website/versioned_docs/**"],
     "pinVersions": false,
     "separateMajorMinor": false,
     "dependencyDashboard": false,


### PR DESCRIPTION
## Summary
- Add `website/versioned_docs/**` to Renovate `ignorePaths` to prevent potential artifact update failures caused by `pyproject.toml` files in versioned docs directories.

See https://github.com/apify/crawlee-python/pull/1820#issuecomment-4153186847

🤖 Generated with [Claude Code](https://claude.com/claude-code)