### PR TITLE
ci: add workflow to regenerate models from OpenAPI spec

### DIFF
--- a/.github/workflows/manual_regenerate_models.yaml
+++ b/.github/workflows/manual_regenerate_models.yaml
@@ -168,11 +168,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
         run: |
-          if [[ -z "$DOCS_PR_NUMBER" ]]; then
-            echo "DOCS_PR_NUMBER is not set; skipping failure comment on apify/apify-docs PR."
-            exit 0
-          fi
-
           gh pr comment "$DOCS_PR_NUMBER" \
             --repo apify/apify-docs \
             --body "Python client model regeneration failed. [See workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})." \


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` workflow that regenerates Pydantic models from an `apify-docs` PR's OpenAPI spec
- Builds the spec locally, runs `datamodel-codegen`, and opens a PR if models changed
- Comments back on the source `apify-docs` PR with a link

## Issues

- Closes: https://github.com/apify/apify-client-python/issues/618

## Context

- https://github.com/apify/apify-docs/pull/2381
- https://github.com/apify/apify-client-python/pull/694