### PR TITLE
ci: upgrade download-artifact from v4 to v8

### DIFF
--- a/.github/workflows/manual_regenerate_models.yaml
+++ b/.github/workflows/manual_regenerate_models.yaml
@@ -78,7 +78,7 @@ jobs:
       # Skipped for manual runs — datamodel-codegen will fetch from the published spec URL instead.
       - name: Download OpenAPI spec artifact
         if: inputs.docs_workflow_run_id
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: openapi-bundles
           path: openapi-spec


### PR DESCRIPTION
## Summary

Upgrade `actions/download-artifact` from v4 to v8 in the `manual_regenerate_models` workflow.

The old v4 version relies on Node.js 20, which is approaching end-of-life and produces deprecation warnings in CI runs. Upgrading to v8 resolves these warnings and keeps the workflow on a supported runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)