### PR TITLE
refactor: consolidate StorageOwnership to the generated StrEnum

### DIFF
--- a/src/apify_client/_resource_clients/dataset_collection.py
+++ b/src/apify_client/_resource_clients/dataset_collection.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from apify_client._docs import docs_group
-from apify_client._models import Dataset, DatasetResponse, ListOfDatasets, ListOfDatasetsResponse
+from apify_client._models import Dataset, DatasetResponse, ListOfDatasets, ListOfDatasetsResponse, StorageOwnership
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 
 if TYPE_CHECKING:
-    from apify_client._types import StorageOwnership, Timeout
+    from apify_client._types import Timeout
 
 
 @docs_group('Resource clients')

--- a/src/apify_client/_resource_clients/key_value_store_collection.py
+++ b/src/apify_client/_resource_clients/key_value_store_collection.py
@@ -8,11 +8,12 @@ from apify_client._models import (
     KeyValueStoreResponse,
     ListOfKeyValueStores,
     ListOfKeyValueStoresResponse,
+    StorageOwnership,
 )
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 
 if TYPE_CHECKING:
-    from apify_client._types import StorageOwnership, Timeout
+    from apify_client._types import Timeout
 
 
 @docs_group('Resource clients')

--- a/src/apify_client/_resource_clients/request_queue_collection.py
+++ b/src/apify_client/_resource_clients/request_queue_collection.py
@@ -8,11 +8,12 @@ from apify_client._models import (
     ListOfRequestQueuesResponse,
     RequestQueue,
     RequestQueueResponse,
+    StorageOwnership,
 )
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 
 if TYPE_CHECKING:
-    from apify_client._types import StorageOwnership, Timeout
+    from apify_client._types import Timeout
 
 
 @docs_group('Resource clients')

--- a/src/apify_client/_types.py
+++ b/src/apify_client/_types.py
@@ -9,9 +9,6 @@ from pydantic import AnyUrl, BaseModel, ConfigDict, Field, RootModel, model_vali
 
 from apify_client._models import ActorJobStatus, WebhookCreate  # noqa: TC001
 
-StorageOwnership = Literal['ownedByMe', 'sharedWithMe']
-"""Filter for storage listing methods to return only storages owned by the user or shared with the user."""
-
 Timeout = timedelta | Literal['no_timeout', 'short', 'medium', 'long']
 """Type for the `timeout` parameter on resource client methods.
 

--- a/tests/unit/test_storage_collection_listing.py
+++ b/tests/unit/test_storage_collection_listing.py
@@ -7,6 +7,7 @@ import pytest
 from werkzeug.wrappers import Response
 
 from apify_client import ApifyClient, ApifyClientAsync
+from apify_client._models import StorageOwnership
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -47,7 +48,7 @@ def test_dataset_collection_list_ownership_sync(httpserver: HTTPServer, client_u
     httpserver.expect_oneshot_request('/v2/datasets', method='GET').respond_with_handler(_make_handler(captured))
 
     client = ApifyClient(token='placeholder_token', **client_urls)
-    result = client.datasets().list(ownership='ownedByMe')
+    result = client.datasets().list(ownership=StorageOwnership.OWNED_BY_ME)
 
     assert result.total == 0
     assert captured['args']['ownership'] == 'ownedByMe'
@@ -58,7 +59,7 @@ async def test_dataset_collection_list_ownership_async(httpserver: HTTPServer, c
     httpserver.expect_oneshot_request('/v2/datasets', method='GET').respond_with_handler(_make_handler(captured))
 
     client = ApifyClientAsync(token='placeholder_token', **client_urls)
-    result = await client.datasets().list(ownership='sharedWithMe')
+    result = await client.datasets().list(ownership=StorageOwnership.SHARED_WITH_ME)
 
     assert result.total == 0
     assert captured['args']['ownership'] == 'sharedWithMe'
@@ -71,7 +72,7 @@ def test_key_value_store_collection_list_ownership_sync(httpserver: HTTPServer, 
     )
 
     client = ApifyClient(token='placeholder_token', **client_urls)
-    result = client.key_value_stores().list(ownership='ownedByMe')
+    result = client.key_value_stores().list(ownership=StorageOwnership.OWNED_BY_ME)
 
     assert result.total == 0
     assert captured['args']['ownership'] == 'ownedByMe'
@@ -84,7 +85,7 @@ async def test_key_value_store_collection_list_ownership_async(httpserver: HTTPS
     )
 
     client = ApifyClientAsync(token='placeholder_token', **client_urls)
-    result = await client.key_value_stores().list(ownership='sharedWithMe')
+    result = await client.key_value_stores().list(ownership=StorageOwnership.SHARED_WITH_ME)
 
     assert result.total == 0
     assert captured['args']['ownership'] == 'sharedWithMe'
@@ -95,7 +96,7 @@ def test_request_queue_collection_list_ownership_sync(httpserver: HTTPServer, cl
     httpserver.expect_oneshot_request('/v2/request-queues', method='GET').respond_with_handler(_make_handler(captured))
 
     client = ApifyClient(token='placeholder_token', **client_urls)
-    result = client.request_queues().list(ownership='ownedByMe')
+    result = client.request_queues().list(ownership=StorageOwnership.OWNED_BY_ME)
 
     assert result.total == 0
     assert captured['args']['ownership'] == 'ownedByMe'
@@ -106,7 +107,7 @@ async def test_request_queue_collection_list_ownership_async(httpserver: HTTPSer
     httpserver.expect_oneshot_request('/v2/request-queues', method='GET').respond_with_handler(_make_handler(captured))
 
     client = ApifyClientAsync(token='placeholder_token', **client_urls)
-    result = await client.request_queues().list(ownership='sharedWithMe')
+    result = await client.request_queues().list(ownership=StorageOwnership.SHARED_WITH_ME)
 
     assert result.total == 0
     assert captured['args']['ownership'] == 'sharedWithMe'


### PR DESCRIPTION
## Summary

- Removes the duplicate `StorageOwnership` `Literal` from `_types.py`.
- Reuses the auto-generated `StorageOwnership` `StrEnum` from `_models.py` in the dataset, key-value store, and request queue collection clients.
- Updates the unit tests to pass enum members (`StorageOwnership.OWNED_BY_ME` / `SHARED_WITH_ME`) instead of raw strings.

Closes #700.