### PR TITLE
chore: update generated models from apify-docs PR #2441

### DIFF
--- a/src/apify_client/_models.py
+++ b/src/apify_client/_models.py
@@ -394,7 +394,13 @@ class Build(BaseModel):
     options: BuildOptions | None = None
     usage: BuildUsage | None = None
     usage_total_usd: Annotated[float | None, Field(alias='usageTotalUsd', examples=[0.02])] = None
+    """
+    Total cost in USD for this build. Requires authentication token to access.
+    """
     usage_usd: Annotated[BuildUsage | None, Field(alias='usageUsd')] = None
+    """
+    Platform usage costs breakdown in USD for this build. Requires authentication token to access.
+    """
     input_schema: Annotated[
         str | None, Field(alias='inputSchema', deprecated=True, examples=['{\\n  "title": "Schema for ... }'])
     ] = None
@@ -2877,11 +2883,11 @@ class Run(BaseModel):
     """
     usage_total_usd: Annotated[float | None, Field(alias='usageTotalUsd', examples=[0.2654])] = None
     """
-    Total cost in USD for this run. Represents what you actually pay. For run owners: includes platform usage (compute units) and/or event costs depending on the Actor's pricing model. For run non-owners: only available for Pay-Per-Event Actors (event costs only). Not available for Pay-Per-Result Actors when you're not the Actor owner.
+    Total cost in USD for this run. Represents what you actually pay. For run owners: includes platform usage (compute units) and/or event costs depending on the Actor's pricing model. For run non-owners: only available for Pay-Per-Event Actors (event costs only). Requires authentication token to access.
     """
     usage_usd: Annotated[RunUsageUsd | None, Field(alias='usageUsd')] = None
     """
-    Platform usage costs breakdown in USD. Only present if you own the run AND are paying for platform usage (Pay-Per-Usage, Rental, or Pay-Per-Event with usage costs like standby Actors). Not available for standard Pay-Per-Event Actors or Pay-Per-Result Actors owned by others.
+    Platform usage costs breakdown in USD. Only present if you own the run AND are paying for platform usage (Pay-Per-Usage, Rental, or Pay-Per-Event with usage costs like standby Actors). Not available for standard Pay-Per-Event Actors. Requires authentication token to access.
     """
     metamorphs: list[Metamorph] | None = None
     """


### PR DESCRIPTION
This PR updates the auto-generated Pydantic models based on OpenAPI specification changes in [apify-docs PR #2441](https://github.com/apify/apify-docs/pull/2441).