### PR TITLE
fix: Prevent `_prepare_request_call` from mutating caller's headers dict

### DIFF
--- a/src/apify_client/_http_clients/_base.py
+++ b/src/apify_client/_http_clients/_base.py
@@ -204,8 +204,7 @@ class HttpClientBase:
         if json is not None and data is not None:
             raise ValueError('Cannot pass both "json" and "data" parameters at the same time!')
 
-        if not headers:
-            headers = {}
+        headers = dict(headers) if headers else {}
 
         # Dump JSON data to string so it can be gzipped.
         if json is not None:

--- a/tests/unit/test_http_clients.py
+++ b/tests/unit/test_http_clients.py
@@ -380,6 +380,24 @@ def test_prepare_request_call_with_params() -> None:
     assert params == {'limit': 10, 'flag': 'true'}
 
 
+def test_prepare_request_call_does_not_mutate_caller_headers() -> None:
+    """Test _prepare_request_call does not mutate the caller's headers dict.
+
+    A caller that reuses a shared headers dict across calls must not see stale
+    `Content-Type`/`Content-Encoding` headers leak in from a prior JSON/body call.
+    """
+    client = _ConcreteHttpClient()
+
+    caller_headers = {'x-trace-id': 'abc-123'}
+    original = dict(caller_headers)
+
+    client._prepare_request_call(headers=caller_headers, json={'x': 1})
+    assert caller_headers == original
+
+    client._prepare_request_call(headers=caller_headers, data='payload')
+    assert caller_headers == original
+
+
 def test_build_url_with_params_none() -> None:
     """Test _build_url_with_params with None params."""
     client = _ConcreteHttpClient()


### PR DESCRIPTION
## Summary

`_prepare_request_call` in `HttpClientBase` was mutating the caller's `headers` dict in place — the `if not headers: headers = {}` guard only allocated a new dict when the caller passed `None`/empty, so a non-empty caller-owned dict was mutated directly. Users of the documented custom `HttpClient` / `HttpClientAsync` extension points that reuse a shared headers dict across `call()` invocations would see stale `Content-Type` / `Content-Encoding` headers leak into subsequent requests (e.g. a bodyless `GET` carrying `Content-Encoding: gzip` from a prior `POST`).

Fix: copy up-front with `headers = dict(headers) if headers else {}`. Added a regression test covering the aliased-dict case.