### PR TITLE
ci: Make regenerated-models comment on docs PRs more visible

### DIFF
--- a/.github/workflows/manual_regenerate_models.yaml
+++ b/.github/workflows/manual_regenerate_models.yaml
@@ -1,7 +1,7 @@
 # This workflow regenerates Pydantic models (src/apify_client/_models.py) from the OpenAPI spec.
 #
 # It can be triggered in two ways:
-#   1. Automatically via workflow_dispatch from the apify-docs CI pipeline (with docs_pr_number and docs_workflow_run_id).
+#   1. Automatically via workflow_dispatch from the apify-docs CI pipeline.
 #   2. Manually from the GitHub UI (without any inputs) to regenerate from the live published spec.
 
 name: Regenerate models
@@ -63,8 +63,8 @@ jobs:
         with:
           token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
-      # If the branch already exists on the remote (e.g. from a previous run, possibly with
-      # reviewer commits), check it out to build on top of it instead of starting fresh.
+      # If the branch already exists on the remote (e.g. from a previous run, possibly with reviewer commits),
+      # check it out to build on top of it instead of starting fresh.
       - name: Switch to existing branch or create a new one
         run: |
           if git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null 2>&1; then
@@ -155,14 +155,29 @@ jobs:
           GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
           PR_CREATED: ${{ steps.pr.outputs.created }}
           PR_URL: ${{ steps.pr.outputs.pr_url }}
+          DOCS_PR_AUTHOR: ${{ inputs.docs_pr_author }}
         run: |
-          if [[ "$PR_CREATED" = "true" ]]; then
-            COMMENT="A PR to update the Python client models has been created: ${PR_URL}
-
-          This was automatically triggered by OpenAPI specification changes in this PR."
-          else
-            COMMENT="The Python client model PR has been updated with the latest OpenAPI spec changes: ${PR_URL}"
+          MENTION=""
+          if [[ -n "$DOCS_PR_AUTHOR" ]]; then
+            MENTION="@${DOCS_PR_AUTHOR} "
           fi
+
+          if [[ "$PR_CREATED" = "true" ]]; then
+            HEADLINE="A companion PR has been opened in \`apify-client-python\` with the regenerated models: ${PR_URL}"
+          else
+            HEADLINE="The companion \`apify-client-python\` PR has been updated with the latest spec changes: ${PR_URL}"
+          fi
+
+          COMMENT=$(printf '%s\n' \
+            "> [!IMPORTANT]" \
+            "> **Action required** — ${MENTION}please coordinate this docs PR with the Python API client PR linked below." \
+            ">" \
+            "> Because this PR modifies the OpenAPI specification, the generated models in \`apify-client-python\` must be regenerated to stay in sync. This has already been done automatically:" \
+            ">" \
+            "> ${HEADLINE}" \
+            ">" \
+            "> - Please make sure to review and merge both PRs together to keep the OpenAPI spec and API clients in sync." \
+            "> - You can ask for review and help from the Tooling team if needed.")
 
           gh pr comment "$DOCS_PR_NUMBER" \
             --repo apify/apify-docs \


### PR DESCRIPTION
## Summary

The `manual_regenerate_models` workflow posts a cross-repo comment on the source `apify-docs` PR whenever a companion `apify-client-python` PR is opened or updated. Some authors have been ignoring it, which leaves the Python client out of sync with the OpenAPI spec.

This PR makes the comment harder to miss:

- Uses a GitHub `[!IMPORTANT]` alert block so it renders as a highlighted callout.
- Adds an `@mention` of the docs PR author (passed in via the new `docs_pr_author` workflow input) so they get a direct notification.
- Rewrites the body with an explicit "Action required" headline and a short action checklist (review & merge both PRs together, ping the Tooling team if needed).
- Minor cleanup: comment/docstring wording in the workflow file.