### PR TITLE
fix: correct deadline logic in _wait_for_finish

### DIFF
--- a/src/apify_client/_resource_clients/_resource_client.py
+++ b/src/apify_client/_resource_clients/_resource_client.py
@@ -294,9 +294,8 @@ class ResourceClient(ResourceClientBase):
         Raises:
             ApifyApiError: If API returns errors other than 404.
         """
-        now = datetime.now(UTC)
-        deadline = (now + wait_duration) if wait_duration is not None else None
-        not_found_deadline = now + DEFAULT_WAIT_WHEN_JOB_NOT_EXIST
+        deadline = (datetime.now(UTC) + wait_duration) if wait_duration is not None else None
+        not_found_deadline: datetime | None = None
         actor_job: dict = {}
 
         while True:
@@ -317,6 +316,9 @@ class ResourceClient(ResourceClientBase):
                 actor_job_response = ActorJobResponse.model_validate(result)
                 actor_job = actor_job_response.data.model_dump()
 
+                # Reset the not-found streak so a later transient 404 gets its own grace window.
+                not_found_deadline = None
+
                 is_terminal = actor_job_response.data.status in TERMINAL_STATUSES
                 is_timed_out = deadline is not None and datetime.now(UTC) >= deadline
 
@@ -326,9 +328,12 @@ class ResourceClient(ResourceClientBase):
             except ApifyApiError as exc:
                 catch_not_found_or_throw(exc)
 
-                # If there are still not found errors after DEFAULT_WAIT_WHEN_JOB_NOT_EXIST, we give up
-                # and return None. In such case, the requested record probably really doesn't exist.
-                if datetime.now(UTC) > not_found_deadline:
+                now = datetime.now(UTC)
+                if deadline is not None and now >= deadline:
+                    return None
+                if not_found_deadline is None:
+                    not_found_deadline = now + DEFAULT_WAIT_WHEN_JOB_NOT_EXIST
+                elif now > not_found_deadline:
                     return None
 
             # It might take some time for database replicas to get up-to-date so sleep a bit before retrying
@@ -474,9 +479,8 @@ class ResourceClientAsync(ResourceClientBase):
         Raises:
             ApifyApiError: If API returns errors other than 404.
         """
-        now = datetime.now(UTC)
-        deadline = (now + wait_duration) if wait_duration is not None else None
-        not_found_deadline = now + DEFAULT_WAIT_WHEN_JOB_NOT_EXIST
+        deadline = (datetime.now(UTC) + wait_duration) if wait_duration is not None else None
+        not_found_deadline: datetime | None = None
         actor_job: dict = {}
 
         while True:
@@ -497,6 +501,9 @@ class ResourceClientAsync(ResourceClientBase):
                 actor_job_response = ActorJobResponse.model_validate(result)
                 actor_job = actor_job_response.data.model_dump()
 
+                # Reset the not-found streak so a later transient 404 gets its own grace window.
+                not_found_deadline = None
+
                 is_terminal = actor_job_response.data.status in TERMINAL_STATUSES
                 is_timed_out = deadline is not None and datetime.now(UTC) >= deadline
 
@@ -506,9 +513,12 @@ class ResourceClientAsync(ResourceClientBase):
             except ApifyApiError as exc:
                 catch_not_found_or_throw(exc)
 
-                # If there are still not found errors after DEFAULT_WAIT_WHEN_JOB_NOT_EXIST, we give up
-                # and return None. In such case, the requested record probably really doesn't exist.
-                if datetime.now(UTC) > not_found_deadline:
+                now = datetime.now(UTC)
+                if deadline is not None and now >= deadline:
+                    return None
+                if not_found_deadline is None:
+                    not_found_deadline = now + DEFAULT_WAIT_WHEN_JOB_NOT_EXIST
+                elif now > not_found_deadline:
                     return None
 
             # It might take some time for database replicas to get up-to-date so sleep a bit before retrying


### PR DESCRIPTION
## Summary

Fixes two bugs in `ResourceClient._wait_for_finish` / `ResourceClientAsync._wait_for_finish`:

1. **`not_found_deadline` anchored at function entry.** The 3-second "job not found" grace window was computed once at entry and never reset. A single transient 404 (e.g. replica lag) during a long poll could terminate the wait and return `None` even though the job was live. The deadline is now lazy — it starts on the first observed 404 and resets after any successful response, so each run of 404s gets its own fresh window.

2. **User `wait_duration` not checked on 404.** When `wait_duration` was shorter than `DEFAULT_WAIT_WHEN_JOB_NOT_EXIST` (3s) and the API returned persistent 404s, the loop could overrun the documented contract by up to ~3s. The 404 branch now checks the user deadline first.

Applied symmetrically to the sync and async mirrors.