### PR TITLE
chore: Remove dead duplicate `urlparse` in async `create_keys_public_url`

### DIFF
--- a/src/apify_client/_resource_clients/key_value_store.py
+++ b/src/apify_client/_resource_clients/key_value_store.py
@@ -906,8 +906,6 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
         """
         metadata = await self.get(timeout=timeout)
 
-        keys_public_url = urlparse(self._build_url('keys'))
-
         request_params = self._build_params(
             limit=limit,
             exclusiveStartKey=exclusive_start_key,
@@ -924,6 +922,7 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
             request_params['signature'] = signature
 
         keys_public_url = urlparse(self._build_url('keys', public=True))
+
         filtered_params = {k: v for k, v in request_params.items() if v is not None}
         if filtered_params:
             keys_public_url = keys_public_url._replace(query=urlencode(filtered_params))


### PR DESCRIPTION
## Summary

The async `KeyValueStoreClientAsync.create_keys_public_url` assigned `keys_public_url = urlparse(self._build_url('keys'))` early in the method, but this value was unconditionally overwritten later by `urlparse(self._build_url('keys', public=True))`. The sync counterpart only has the single correct call — this was an asymmetric refactor artifact.

No behavior change: the second assignment always won. Removing the dead call eliminates a small wasted `_build_url`/`urlparse` on every call and removes a latent foot-gun where code inserted between the two assignments would silently see the non-public URL.