### PR TITLE
fix: Preserve count=0 in RunClient's charge

### DIFF
--- a/src/apify_client/_resource_clients/run.py
+++ b/src/apify_client/_resource_clients/run.py
@@ -385,7 +385,8 @@ class RunClient(ResourceClient):
 
         Args:
             event_name: The name of the event to charge for.
-            count: The number of events to charge. Defaults to 1 if not provided.
+            count: The number of events to charge. Defaults to 1 when `None`; other values,
+                including 0, are sent to the server as-is.
             idempotency_key: A unique key to ensure idempotent charging. If not provided,
                 one will be auto-generated.
             timeout: Timeout for the API HTTP request.
@@ -411,7 +412,7 @@ class RunClient(ResourceClient):
             data=json.dumps(
                 {
                     'eventName': event_name,
-                    'count': count or 1,
+                    'count': count if count is not None else 1,
                 }
             ),
             timeout=timeout,
@@ -811,7 +812,8 @@ class RunClientAsync(ResourceClientAsync):
 
         Args:
             event_name: The name of the event to charge for.
-            count: The number of events to charge. Defaults to 1 if not provided.
+            count: The number of events to charge. Defaults to 1 when `None`; other values,
+                including 0, are sent to the server as-is.
             idempotency_key: A unique key to ensure idempotent charging. If not provided,
                 one will be auto-generated.
             timeout: Timeout for the API HTTP request.
@@ -837,7 +839,7 @@ class RunClientAsync(ResourceClientAsync):
             data=json.dumps(
                 {
                     'eventName': event_name,
-                    'count': count or 1,
+                    'count': count if count is not None else 1,
                 }
             ),
             timeout=timeout,

--- a/src/apify_client/_resource_clients/run.py
+++ b/src/apify_client/_resource_clients/run.py
@@ -375,7 +375,7 @@ class RunClient(ResourceClient):
     def charge(
         self,
         event_name: str,
-        count: int | None = None,
+        count: int = 1,
         idempotency_key: str | None = None,
         timeout: Timeout = 'short',
     ) -> None:
@@ -385,8 +385,7 @@ class RunClient(ResourceClient):
 
         Args:
             event_name: The name of the event to charge for.
-            count: The number of events to charge. Defaults to 1 when `None`; other values,
-                including 0, are sent to the server as-is.
+            count: The number of events to charge. Sent to the server as-is, including 0.
             idempotency_key: A unique key to ensure idempotent charging. If not provided,
                 one will be auto-generated.
             timeout: Timeout for the API HTTP request.
@@ -412,7 +411,7 @@ class RunClient(ResourceClient):
             data=json.dumps(
                 {
                     'eventName': event_name,
-                    'count': count if count is not None else 1,
+                    'count': count,
                 }
             ),
             timeout=timeout,
@@ -802,7 +801,7 @@ class RunClientAsync(ResourceClientAsync):
     async def charge(
         self,
         event_name: str,
-        count: int | None = None,
+        count: int = 1,
         idempotency_key: str | None = None,
         timeout: Timeout = 'short',
     ) -> None:
@@ -812,8 +811,7 @@ class RunClientAsync(ResourceClientAsync):
 
         Args:
             event_name: The name of the event to charge for.
-            count: The number of events to charge. Defaults to 1 when `None`; other values,
-                including 0, are sent to the server as-is.
+            count: The number of events to charge. Sent to the server as-is, including 0.
             idempotency_key: A unique key to ensure idempotent charging. If not provided,
                 one will be auto-generated.
             timeout: Timeout for the API HTTP request.
@@ -839,7 +837,7 @@ class RunClientAsync(ResourceClientAsync):
             data=json.dumps(
                 {
                     'eventName': event_name,
-                    'count': count if count is not None else 1,
+                    'count': count,
                 }
             ),
             timeout=timeout,

--- a/src/apify_client/_resource_clients/run.py
+++ b/src/apify_client/_resource_clients/run.py
@@ -385,7 +385,7 @@ class RunClient(ResourceClient):
 
         Args:
             event_name: The name of the event to charge for.
-            count: The number of events to charge. Sent to the server as-is, including 0.
+            count: The number of events to charge.
             idempotency_key: A unique key to ensure idempotent charging. If not provided,
                 one will be auto-generated.
             timeout: Timeout for the API HTTP request.
@@ -811,7 +811,7 @@ class RunClientAsync(ResourceClientAsync):
 
         Args:
             event_name: The name of the event to charge for.
-            count: The number of events to charge. Sent to the server as-is, including 0.
+            count: The number of events to charge.
             idempotency_key: A unique key to ensure idempotent charging. If not provided,
                 one will be auto-generated.
             timeout: Timeout for the API HTTP request.

--- a/tests/unit/test_run_charge.py
+++ b/tests/unit/test_run_charge.py
@@ -24,20 +24,14 @@ def _decode_body(request: Request) -> dict:
 
 
 @pytest.mark.parametrize(
-    ('count', 'expected'),
-    [
-        (None, 1),
-        (0, 0),
-        (1, 1),
-        (5, 5),
-    ],
+    'count',
+    [0, 1, 5],
 )
 def test_run_charge_preserves_count_sync(
     httpserver: HTTPServer,
-    count: int | None,
-    expected: int,
+    count: int,
 ) -> None:
-    """Ensure `count` is sent as-is; only `None` falls back to 1 (in particular, `0` is preserved)."""
+    """Ensure `count` is sent as-is (in particular, `0` is preserved)."""
     captured_requests: list[Request] = []
 
     def capture_request(request: Request) -> Response:
@@ -53,22 +47,16 @@ def test_run_charge_preserves_count_sync(
 
     assert len(captured_requests) == 1
     body = _decode_body(captured_requests[0])
-    assert body['count'] == expected
+    assert body['count'] == count
 
 
 @pytest.mark.parametrize(
-    ('count', 'expected'),
-    [
-        (None, 1),
-        (0, 0),
-        (1, 1),
-        (5, 5),
-    ],
+    'count',
+    [0, 1, 5],
 )
 async def test_run_charge_preserves_count_async(
     httpserver: HTTPServer,
-    count: int | None,
-    expected: int,
+    count: int,
 ) -> None:
     """Async variant of `test_run_charge_preserves_count_sync`."""
     captured_requests: list[Request] = []
@@ -86,4 +74,4 @@ async def test_run_charge_preserves_count_async(
 
     assert len(captured_requests) == 1
     body = _decode_body(captured_requests[0])
-    assert body['count'] == expected
+    assert body['count'] == count

--- a/tests/unit/test_run_charge.py
+++ b/tests/unit/test_run_charge.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import gzip
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from werkzeug import Request, Response
+
+from apify_client import ApifyClient, ApifyClientAsync
+
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
+
+_MOCKED_RUN_ID = 'test_run_id'
+_CHARGE_PATH = f'/v2/actor-runs/{_MOCKED_RUN_ID}/charge'
+
+
+def _decode_body(request: Request) -> dict:
+    raw = request.get_data()
+    if request.headers.get('Content-Encoding') == 'gzip':
+        raw = gzip.decompress(raw)
+    return json.loads(raw)
+
+
+@pytest.mark.parametrize(
+    ('count', 'expected'),
+    [
+        (None, 1),
+        (0, 0),
+        (1, 1),
+        (5, 5),
+    ],
+)
+def test_run_charge_preserves_count_sync(
+    httpserver: HTTPServer,
+    count: int | None,
+    expected: int,
+) -> None:
+    """Ensure `count` is sent as-is; only `None` falls back to 1 (in particular, `0` is preserved)."""
+    captured_requests: list[Request] = []
+
+    def capture_request(request: Request) -> Response:
+        captured_requests.append(request)
+        return Response(status=200, mimetype='application/json')
+
+    httpserver.expect_request(_CHARGE_PATH, method='POST').respond_with_handler(capture_request)
+
+    api_url = httpserver.url_for('/').removesuffix('/')
+    client = ApifyClient(token='test_token', api_url=api_url)
+
+    client.run(_MOCKED_RUN_ID).charge(event_name='test-event', count=count)
+
+    assert len(captured_requests) == 1
+    body = _decode_body(captured_requests[0])
+    assert body['count'] == expected
+
+
+@pytest.mark.parametrize(
+    ('count', 'expected'),
+    [
+        (None, 1),
+        (0, 0),
+        (1, 1),
+        (5, 5),
+    ],
+)
+async def test_run_charge_preserves_count_async(
+    httpserver: HTTPServer,
+    count: int | None,
+    expected: int,
+) -> None:
+    """Async variant of `test_run_charge_preserves_count_sync`."""
+    captured_requests: list[Request] = []
+
+    def capture_request(request: Request) -> Response:
+        captured_requests.append(request)
+        return Response(status=200, mimetype='application/json')
+
+    httpserver.expect_request(_CHARGE_PATH, method='POST').respond_with_handler(capture_request)
+
+    api_url = httpserver.url_for('/').removesuffix('/')
+    client = ApifyClientAsync(token='test_token', api_url=api_url)
+
+    await client.run(_MOCKED_RUN_ID).charge(event_name='test-event', count=count)
+
+    assert len(captured_requests) == 1
+    body = _decode_body(captured_requests[0])
+    assert body['count'] == expected


### PR DESCRIPTION
## Summary

`RunClient.charge` (sync + async) built the request body with `'count': count or 1`. Because `or` treats `0` as falsy, a caller passing `count=0` — e.g. `count=len(batch)` for an empty batch, or a defensive no-op — was silently sent as `count=1`. On a pay-per-event billing endpoint that's a real overcharge, not a cosmetic bug.

## Fix

Changed the signature from `count: int | None = None` to `count: int = 1` and pass `count` through to the request body unchanged. `0` now reaches the server as `0`; the default `1` is expressed in the signature instead of via a fallback.

Docstring updated to reflect the new contract.

## Tests

`tests/unit/test_run_charge.py` parametrizes the sync and async clients over `count` values `0`, `1`, `5` and asserts the value lands in the request body verbatim. The `0` case fails on `master` and passes here.