### PR TITLE
fix: treat naive datetime query params as UTC

### DIFF
--- a/src/apify_client/_http_clients/_base.py
+++ b/src/apify_client/_http_clients/_base.py
@@ -157,7 +157,9 @@ class HttpClientBase:
             elif isinstance(value, list):
                 parsed_params[key] = ','.join(value)
             elif isinstance(value, datetime):
-                utc_aware_dt = value.astimezone(UTC)
+                # Treat a naive datetime as UTC; `.astimezone()` would otherwise assume the host's local tz.
+                aware = value.replace(tzinfo=UTC) if value.tzinfo is None else value
+                utc_aware_dt = aware.astimezone(UTC)
                 iso_str = utc_aware_dt.isoformat(timespec='milliseconds')
                 parsed_params[key] = iso_str.replace('+00:00', 'Z')
             elif value is not None:

--- a/tests/unit/test_http_clients.py
+++ b/tests/unit/test_http_clients.py
@@ -201,6 +201,21 @@ def test_parse_params_datetime() -> None:
     assert result == {'created_at': '2024-01-15T10:30:45.123Z'}
 
 
+@pytest.mark.skipif(not hasattr(time, 'tzset'), reason='time.tzset is Unix-only')
+def test_parse_params_naive_datetime_treated_as_utc(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Naive datetimes must be treated as UTC, not the host's local timezone."""
+    monkeypatch.setenv('TZ', 'Asia/Karachi')
+    time.tzset()
+    try:
+        dt = datetime(2024, 1, 15, 10, 30, 45, 123000)  # noqa: DTZ001 -- intentionally naive
+        result = HttpClient._parse_params({'created_at': dt})
+        assert result == {'created_at': '2024-01-15T10:30:45.123Z'}
+    finally:
+        # Restore TZ before re-applying tzset so the test doesn't leak Karachi time to later tests.
+        monkeypatch.undo()
+        time.tzset()
+
+
 def test_parse_params_none_values_filtered() -> None:
     """Test _parse_params filters out None values."""
     result = HttpClient._parse_params({'a': 1, 'b': None, 'c': 'value'})


### PR DESCRIPTION
## Summary

`HttpClientBase._parse_params` called `.astimezone(UTC)` directly on incoming `datetime` values. Per Python's stdlib, a naive datetime is presumed to represent time in the system's local timezone, so on a non-UTC host the value was shifted by the host's offset and then serialized with a `Z` suffix — a wire format that *looks* like UTC but isn't. This silently corrupted timestamp filters such as `started_before`/`started_after` on `runs().list()` whenever a caller passed a naive datetime.

The fix attaches `UTC` to the value when `tzinfo` is missing, so naive datetimes round-trip as UTC instead of being relocalized.

Added a unit test that pins `TZ=Asia/Karachi` with `time.tzset()` to reproduce the bug deterministically on Unix CI (skipped on Windows, where `time.tzset` is unavailable).