### PR TITLE
fix: raise NotFoundError on ambiguous 404 responses

### DIFF
--- a/docs/04_upgrading/upgrading_to_v3.mdx
+++ b/docs/04_upgrading/upgrading_to_v3.mdx
@@ -218,11 +218,26 @@ except RateLimitError:
     ...
 ```
 
-### Behavior change: `.get()` now returns `None` on any 404
+### Behavior change: `.get()` on chained clients now raises on 404
 
-As a consequence of the dispatch above, `.get()`-style convenience methods — which use `catch_not_found_or_throw` internally to swallow 404 responses and return `None` — now swallow **every** 404, regardless of the `error.type` string in the response body. Previously only 404 responses carrying the types `record-not-found` or `record-or-token-not-found` were swallowed; any other 404 was re-raised as `ApifyApiError`.
+`.get()` continues to swallow 404 into `None` for direct, ID-identified fetches like `client.dataset(id).get()` or `client.run(id).get()` — a 404 there unambiguously means the named resource does not exist.
 
-In practice this matters only if you relied on a `.get()` call raising for a 404 with an unusual error type — such cases now return `None` instead. If your code needs to distinguish between "resource missing" and "404 with an unexpected type", inspect `.type` on the returned response or catch <ApiLink to="class/NotFoundError">`NotFoundError`</ApiLink> from non-`.get()` calls that do not use `catch_not_found_or_throw`.
+For chained calls that target a default sub-resource without an ID — `run.dataset()`, `run.key_value_store()`, `run.request_queue()`, `run.log()` — a 404 is ambiguous (it could mean the parent run is missing OR the default sub-resource is missing, and the API body does not disambiguate). These now raise <ApiLink to="class/NotFoundError">`NotFoundError`</ApiLink> instead of silently returning `None`:
+
+```python
+from apify_client import ApifyClient
+from apify_client.errors import NotFoundError
+
+client = ApifyClient(token='MY-APIFY-TOKEN')
+
+try:
+    dataset = client.run('some-run-id').dataset().get()
+except NotFoundError:
+    # Previously this returned `None`; now you must handle it explicitly.
+    dataset = None
+```
+
+Direct `.get()` also now swallows every 404 regardless of the `error.type` string in the response body (previously only `record-not-found` and `record-or-token-not-found` types were swallowed). If your code needs to distinguish between "resource missing" and "404 with an unexpected type", inspect `.type` on a caught <ApiLink to="class/NotFoundError">`NotFoundError`</ApiLink> from a non-`.get()` call path.
 
 ## Snake_case `sort_by` values on `actors().list()`
 

--- a/docs/04_upgrading/upgrading_to_v3.mdx
+++ b/docs/04_upgrading/upgrading_to_v3.mdx
@@ -218,11 +218,15 @@ except RateLimitError:
     ...
 ```
 
-### Behavior change: `.get()` on chained clients now raises on 404
+### Behavior change: 404 on ambiguous endpoints now raises `NotFoundError`
 
-`.get()` continues to swallow 404 into `None` for direct, ID-identified fetches like `client.dataset(id).get()` or `client.run(id).get()` — a 404 there unambiguously means the named resource does not exist.
+Direct, ID-identified fetches like `client.dataset(id).get()` or `client.run(id).get()` continue to swallow 404 into `None` — a 404 there unambiguously means the named resource does not exist. Similarly, `.delete()` on an ID-identified client keeps its idempotent behavior (404 is silently swallowed).
 
-For chained calls that target a default sub-resource without an ID — `run.dataset()`, `run.key_value_store()`, `run.request_queue()`, `run.log()` — a 404 is ambiguous (it could mean the parent run is missing OR the default sub-resource is missing, and the API body does not disambiguate). These now raise <ApiLink to="class/NotFoundError">`NotFoundError`</ApiLink> instead of silently returning `None`:
+For calls where a 404 is *ambiguous*, the client now propagates <ApiLink to="class/NotFoundError">`NotFoundError`</ApiLink> instead of returning `None` / silently succeeding. Three categories of endpoints are affected:
+
+1. **Chained calls that target a default sub-resource without an ID** — `run.dataset()`, `run.key_value_store()`, `run.request_queue()`, `run.log()`. A 404 here could mean the parent run is missing OR the default sub-resource is missing, and the API body does not disambiguate. Applies to both `.get()` and `.delete()`.
+2. **`.get()` / `.get_as_bytes()` / `.stream()` on a chained `LogClient`** — e.g. `run.log().get()`. Direct `client.log(build_or_run_id).get()` still returns `None` on 404.
+3. **Singleton sub-resource endpoints fetched via a fixed path** — <ApiLink to="class/ScheduleClient#get_log">`ScheduleClient.get_log()`</ApiLink>, <ApiLink to="class/TaskClient#get_input">`TaskClient.get_input()`</ApiLink>, <ApiLink to="class/DatasetClient#get_statistics">`DatasetClient.get_statistics()`</ApiLink>, <ApiLink to="class/UserClient#monthly_usage">`UserClient.monthly_usage()`</ApiLink>, <ApiLink to="class/UserClient#limits">`UserClient.limits()`</ApiLink>, <ApiLink to="class/WebhookClient#test">`WebhookClient.test()`</ApiLink>. These hit paths like `/schedules/{id}/log` or `/actor-tasks/{id}/input`, so a 404 effectively means the parent is missing. Return types moved from `T | None` to `T`.
 
 ```python
 from apify_client import ApifyClient
@@ -235,6 +239,12 @@ try:
 except NotFoundError:
     # Previously this returned `None`; now you must handle it explicitly.
     dataset = None
+
+try:
+    schedule_log = client.schedule('some-schedule-id').get_log()
+except NotFoundError:
+    # `get_log()` previously returned `None` when the schedule was missing; now it raises.
+    schedule_log = None
 ```
 
 Direct `.get()` also now swallows every 404 regardless of the `error.type` string in the response body (previously only `record-not-found` and `record-or-token-not-found` types were swallowed). If your code needs to distinguish between "resource missing" and "404 with an unexpected type", inspect `.type` on a caught <ApiLink to="class/NotFoundError">`NotFoundError`</ApiLink> from a non-`.get()` call path.

--- a/src/apify_client/_resource_clients/_resource_client.py
+++ b/src/apify_client/_resource_clients/_resource_client.py
@@ -194,7 +194,12 @@ class ResourceClient(ResourceClientBase):
         )
 
     def _get(self, *, timeout: Timeout) -> dict | None:
-        """Perform a GET request for this resource, returning the parsed response or None if not found."""
+        """Perform a GET request for this resource, returning the parsed response or None if not found.
+
+        404s collapse to `None` only when this client targets a specific resource by ID. For chained clients
+        without a `resource_id` (e.g. `run.dataset()`), a 404 could mean either the parent or the default
+        sub-resource is missing and the API body cannot disambiguate, so `NotFoundError` propagates to the caller.
+        """
         try:
             response = self._http_client.call(
                 url=self._build_url(),
@@ -204,6 +209,8 @@ class ResourceClient(ResourceClientBase):
             )
             return response_to_dict(response)
         except ApifyApiError as exc:
+            if self._resource_id is None:
+                raise
             catch_not_found_or_throw(exc)
             return None
 
@@ -374,7 +381,12 @@ class ResourceClientAsync(ResourceClientBase):
         )
 
     async def _get(self, *, timeout: Timeout) -> dict | None:
-        """Perform a GET request for this resource, returning the parsed response or None if not found."""
+        """Perform a GET request for this resource, returning the parsed response or None if not found.
+
+        404s collapse to `None` only when this client targets a specific resource by ID. For chained clients
+        without a `resource_id` (e.g. `run.dataset()`), a 404 could mean either the parent or the default
+        sub-resource is missing and the API body cannot disambiguate, so `NotFoundError` propagates to the caller.
+        """
         try:
             response = await self._http_client.call(
                 url=self._build_url(),
@@ -384,6 +396,8 @@ class ResourceClientAsync(ResourceClientBase):
             )
             return response_to_dict(response)
         except ApifyApiError as exc:
+            if self._resource_id is None:
+                raise
             catch_not_found_or_throw(exc)
             return None
 

--- a/src/apify_client/_resource_clients/_resource_client.py
+++ b/src/apify_client/_resource_clients/_resource_client.py
@@ -10,7 +10,13 @@ from apify_client._consts import DEFAULT_WAIT_FOR_FINISH, DEFAULT_WAIT_WHEN_JOB_
 from apify_client._docs import docs_group
 from apify_client._logging import WithLogDetailsClient
 from apify_client._types import ActorJobResponse
-from apify_client._utils import catch_not_found_or_throw, response_to_dict, to_safe_id, to_seconds
+from apify_client._utils import (
+    catch_not_found_for_resource_or_throw,
+    catch_not_found_or_throw,
+    response_to_dict,
+    to_safe_id,
+    to_seconds,
+)
 from apify_client.errors import ApifyApiError
 
 if TYPE_CHECKING:
@@ -196,9 +202,8 @@ class ResourceClient(ResourceClientBase):
     def _get(self, *, timeout: Timeout) -> dict | None:
         """Perform a GET request for this resource, returning the parsed response or None if not found.
 
-        404s collapse to `None` only when this client targets a specific resource by ID. For chained clients
-        without a `resource_id` (e.g. `run.dataset()`), a 404 could mean either the parent or the default
-        sub-resource is missing and the API body cannot disambiguate, so `NotFoundError` propagates to the caller.
+        404s collapse to `None` only for ID-identified clients. Chained clients without a `resource_id`
+        (e.g. `run.dataset()`) propagate `NotFoundError` — see `catch_not_found_for_resource_or_throw`.
         """
         try:
             response = self._http_client.call(
@@ -209,9 +214,7 @@ class ResourceClient(ResourceClientBase):
             )
             return response_to_dict(response)
         except ApifyApiError as exc:
-            if self._resource_id is None:
-                raise
-            catch_not_found_or_throw(exc)
+            catch_not_found_for_resource_or_throw(exc, self._resource_id)
             return None
 
     def _update(self, *, timeout: Timeout, **kwargs: Any) -> dict:
@@ -226,7 +229,11 @@ class ResourceClient(ResourceClientBase):
         return response_to_dict(response)
 
     def _delete(self, *, timeout: Timeout) -> None:
-        """Perform a DELETE request to delete this resource, ignoring 404 errors."""
+        """Perform a DELETE request to delete this resource.
+
+        404s are swallowed (idempotent DELETE) only for ID-identified clients. Chained clients without a
+        `resource_id` propagate `NotFoundError` — see `catch_not_found_for_resource_or_throw`.
+        """
         try:
             self._http_client.call(
                 url=self._build_url(),
@@ -235,7 +242,7 @@ class ResourceClient(ResourceClientBase):
                 timeout=timeout,
             )
         except ApifyApiError as exc:
-            catch_not_found_or_throw(exc)
+            catch_not_found_for_resource_or_throw(exc, self._resource_id)
 
     def _list(self, *, timeout: Timeout, **kwargs: Any) -> dict:
         """Perform a GET request to list resources."""
@@ -383,9 +390,8 @@ class ResourceClientAsync(ResourceClientBase):
     async def _get(self, *, timeout: Timeout) -> dict | None:
         """Perform a GET request for this resource, returning the parsed response or None if not found.
 
-        404s collapse to `None` only when this client targets a specific resource by ID. For chained clients
-        without a `resource_id` (e.g. `run.dataset()`), a 404 could mean either the parent or the default
-        sub-resource is missing and the API body cannot disambiguate, so `NotFoundError` propagates to the caller.
+        404s collapse to `None` only for ID-identified clients. Chained clients without a `resource_id`
+        (e.g. `run.dataset()`) propagate `NotFoundError` — see `catch_not_found_for_resource_or_throw`.
         """
         try:
             response = await self._http_client.call(
@@ -396,9 +402,7 @@ class ResourceClientAsync(ResourceClientBase):
             )
             return response_to_dict(response)
         except ApifyApiError as exc:
-            if self._resource_id is None:
-                raise
-            catch_not_found_or_throw(exc)
+            catch_not_found_for_resource_or_throw(exc, self._resource_id)
             return None
 
     async def _update(self, *, timeout: Timeout, **kwargs: Any) -> dict:
@@ -413,7 +417,11 @@ class ResourceClientAsync(ResourceClientBase):
         return response_to_dict(response)
 
     async def _delete(self, *, timeout: Timeout) -> None:
-        """Perform a DELETE request to delete this resource, ignoring 404 errors."""
+        """Perform a DELETE request to delete this resource.
+
+        404s are swallowed (idempotent DELETE) only for ID-identified clients. Chained clients without a
+        `resource_id` propagate `NotFoundError` — see `catch_not_found_for_resource_or_throw`.
+        """
         try:
             await self._http_client.call(
                 url=self._build_url(),
@@ -422,7 +430,7 @@ class ResourceClientAsync(ResourceClientBase):
                 timeout=timeout,
             )
         except ApifyApiError as exc:
-            catch_not_found_or_throw(exc)
+            catch_not_found_for_resource_or_throw(exc, self._resource_id)
 
     async def _list(self, *, timeout: Timeout, **kwargs: Any) -> dict:
         """Perform a GET request to list resources."""

--- a/src/apify_client/_resource_clients/dataset.py
+++ b/src/apify_client/_resource_clients/dataset.py
@@ -10,12 +10,10 @@ from apify_client._docs import docs_group
 from apify_client._models import Dataset, DatasetResponse, DatasetStatistics, DatasetStatisticsResponse
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 from apify_client._utils import (
-    catch_not_found_or_throw,
     create_storage_content_signature,
     response_to_dict,
     response_to_list,
 )
-from apify_client.errors import ApifyApiError
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
@@ -628,7 +626,7 @@ class DatasetClient(ResourceClient):
             timeout=timeout,
         )
 
-    def get_statistics(self, *, timeout: Timeout = 'short') -> DatasetStatistics | None:
+    def get_statistics(self, *, timeout: Timeout = 'short') -> DatasetStatistics:
         """Get the dataset statistics.
 
         https://docs.apify.com/api/v2#tag/DatasetsStatistics/operation/dataset_statistics_get
@@ -637,21 +635,19 @@ class DatasetClient(ResourceClient):
             timeout: Timeout for the API HTTP request.
 
         Returns:
-            The dataset statistics or None if the dataset does not exist.
-        """
-        try:
-            response = self._http_client.call(
-                url=self._build_url('statistics'),
-                method='GET',
-                params=self._build_params(),
-                timeout=timeout,
-            )
-            result = response_to_dict(response)
-            return DatasetStatisticsResponse.model_validate(result).data
-        except ApifyApiError as exc:
-            catch_not_found_or_throw(exc)
+            The dataset statistics.
 
-        return None
+        Raises:
+            NotFoundError: If the dataset does not exist.
+        """
+        response = self._http_client.call(
+            url=self._build_url('statistics'),
+            method='GET',
+            params=self._build_params(),
+            timeout=timeout,
+        )
+        result = response_to_dict(response)
+        return DatasetStatisticsResponse.model_validate(result).data
 
     def create_items_public_url(
         self,
@@ -1208,7 +1204,7 @@ class DatasetClientAsync(ResourceClientAsync):
             timeout=timeout,
         )
 
-    async def get_statistics(self, *, timeout: Timeout = 'short') -> DatasetStatistics | None:
+    async def get_statistics(self, *, timeout: Timeout = 'short') -> DatasetStatistics:
         """Get the dataset statistics.
 
         https://docs.apify.com/api/v2#tag/DatasetsStatistics/operation/dataset_statistics_get
@@ -1217,21 +1213,19 @@ class DatasetClientAsync(ResourceClientAsync):
             timeout: Timeout for the API HTTP request.
 
         Returns:
-            The dataset statistics or None if the dataset does not exist.
-        """
-        try:
-            response = await self._http_client.call(
-                url=self._build_url('statistics'),
-                method='GET',
-                params=self._build_params(),
-                timeout=timeout,
-            )
-            result = response_to_dict(response)
-            return DatasetStatisticsResponse.model_validate(result).data
-        except ApifyApiError as exc:
-            catch_not_found_or_throw(exc)
+            The dataset statistics.
 
-        return None
+        Raises:
+            NotFoundError: If the dataset does not exist.
+        """
+        response = await self._http_client.call(
+            url=self._build_url('statistics'),
+            method='GET',
+            params=self._build_params(),
+            timeout=timeout,
+        )
+        result = response_to_dict(response)
+        return DatasetStatisticsResponse.model_validate(result).data
 
     async def create_items_public_url(
         self,

--- a/src/apify_client/_resource_clients/log.py
+++ b/src/apify_client/_resource_clients/log.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 from apify_client._docs import docs_group
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
-from apify_client._utils import catch_not_found_or_throw
+from apify_client._utils import catch_not_found_for_resource_or_throw
 from apify_client.errors import ApifyApiError
 
 if TYPE_CHECKING:
@@ -39,6 +39,9 @@ class LogClient(ResourceClient):
 
         https://docs.apify.com/api/v2#/reference/logs/log/get-log
 
+        404s collapse to `None` only when this client targets a specific log by ID (e.g. `client.log(run_id).get()`).
+        For chained clients without a `resource_id` (e.g. `run.log().get()`), a 404 is ambiguous and propagates.
+
         Args:
             raw: If true, the log will include formatting. For example, coloring character sequences.
             timeout: Timeout for the API HTTP request.
@@ -57,7 +60,7 @@ class LogClient(ResourceClient):
             return response.text  # noqa: TRY300
 
         except ApifyApiError as exc:
-            catch_not_found_or_throw(exc)
+            catch_not_found_for_resource_or_throw(exc, self._resource_id)
 
         return None
 
@@ -84,7 +87,7 @@ class LogClient(ResourceClient):
             return response.content  # noqa: TRY300
 
         except ApifyApiError as exc:
-            catch_not_found_or_throw(exc)
+            catch_not_found_for_resource_or_throw(exc, self._resource_id)
 
         return None
 
@@ -113,7 +116,7 @@ class LogClient(ResourceClient):
 
             yield response
         except ApifyApiError as exc:
-            catch_not_found_or_throw(exc)
+            catch_not_found_for_resource_or_throw(exc, self._resource_id)
             yield None
         finally:
             if response:
@@ -144,6 +147,9 @@ class LogClientAsync(ResourceClientAsync):
 
         https://docs.apify.com/api/v2#/reference/logs/log/get-log
 
+        404s collapse to `None` only when this client targets a specific log by ID (e.g. `client.log(run_id).get()`).
+        For chained clients without a `resource_id` (e.g. `run.log().get()`), a 404 is ambiguous and propagates.
+
         Args:
             raw: If true, the log will include formatting. For example, coloring character sequences.
             timeout: Timeout for the API HTTP request.
@@ -162,7 +168,7 @@ class LogClientAsync(ResourceClientAsync):
             return response.text  # noqa: TRY300
 
         except ApifyApiError as exc:
-            catch_not_found_or_throw(exc)
+            catch_not_found_for_resource_or_throw(exc, self._resource_id)
 
         return None
 
@@ -189,7 +195,7 @@ class LogClientAsync(ResourceClientAsync):
             return response.content  # noqa: TRY300
 
         except ApifyApiError as exc:
-            catch_not_found_or_throw(exc)
+            catch_not_found_for_resource_or_throw(exc, self._resource_id)
 
         return None
 
@@ -218,7 +224,7 @@ class LogClientAsync(ResourceClientAsync):
 
             yield response
         except ApifyApiError as exc:
-            catch_not_found_or_throw(exc)
+            catch_not_found_for_resource_or_throw(exc, self._resource_id)
             yield None
         finally:
             if response:

--- a/src/apify_client/_resource_clients/schedule.py
+++ b/src/apify_client/_resource_clients/schedule.py
@@ -11,8 +11,7 @@ from apify_client._models import (
     ScheduleResponse,
 )
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
-from apify_client._utils import catch_not_found_or_throw, response_to_dict
-from apify_client.errors import ApifyApiError
+from apify_client._utils import response_to_dict
 
 if TYPE_CHECKING:
     from apify_client._types import Timeout
@@ -111,7 +110,7 @@ class ScheduleClient(ResourceClient):
         """
         self._delete(timeout=timeout)
 
-    def get_log(self, *, timeout: Timeout = 'medium') -> list[ScheduleInvoked] | None:
+    def get_log(self, *, timeout: Timeout = 'medium') -> list[ScheduleInvoked]:
         """Return log for the given schedule.
 
         https://docs.apify.com/api/v2#/reference/schedules/schedule-log/get-schedule-log
@@ -121,20 +120,18 @@ class ScheduleClient(ResourceClient):
 
         Returns:
             Retrieved log of the given schedule.
-        """
-        try:
-            response = self._http_client.call(
-                url=self._build_url('log'),
-                method='GET',
-                params=self._build_params(),
-                timeout=timeout,
-            )
-            result = response_to_dict(response)
-            return ScheduleLogResponse.model_validate(result).data
-        except ApifyApiError as exc:
-            catch_not_found_or_throw(exc)
 
-        return None
+        Raises:
+            NotFoundError: If the schedule does not exist.
+        """
+        response = self._http_client.call(
+            url=self._build_url('log'),
+            method='GET',
+            params=self._build_params(),
+            timeout=timeout,
+        )
+        result = response_to_dict(response)
+        return ScheduleLogResponse.model_validate(result).data
 
 
 @docs_group('Resource clients')
@@ -230,7 +227,7 @@ class ScheduleClientAsync(ResourceClientAsync):
         """
         await self._delete(timeout=timeout)
 
-    async def get_log(self, *, timeout: Timeout = 'medium') -> list[ScheduleInvoked] | None:
+    async def get_log(self, *, timeout: Timeout = 'medium') -> list[ScheduleInvoked]:
         """Return log for the given schedule.
 
         https://docs.apify.com/api/v2#/reference/schedules/schedule-log/get-schedule-log
@@ -240,17 +237,15 @@ class ScheduleClientAsync(ResourceClientAsync):
 
         Returns:
             Retrieved log of the given schedule.
-        """
-        try:
-            response = await self._http_client.call(
-                url=self._build_url('log'),
-                method='GET',
-                params=self._build_params(),
-                timeout=timeout,
-            )
-            result = response_to_dict(response)
-            return ScheduleLogResponse.model_validate(result).data
-        except ApifyApiError as exc:
-            catch_not_found_or_throw(exc)
 
-        return None
+        Raises:
+            NotFoundError: If the schedule does not exist.
+        """
+        response = await self._http_client.call(
+            url=self._build_url('log'),
+            method='GET',
+            params=self._build_params(),
+            timeout=timeout,
+        )
+        result = response_to_dict(response)
+        return ScheduleLogResponse.model_validate(result).data

--- a/src/apify_client/_resource_clients/task.py
+++ b/src/apify_client/_resource_clients/task.py
@@ -17,8 +17,7 @@ from apify_client._models import (
 )
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 from apify_client._types import WebhookRepresentationList
-from apify_client._utils import catch_not_found_or_throw, response_to_dict, to_seconds
-from apify_client.errors import ApifyApiError
+from apify_client._utils import response_to_dict, to_seconds
 
 if TYPE_CHECKING:
     from datetime import timedelta
@@ -280,7 +279,7 @@ class TaskClient(ResourceClient):
         )
         return run_client.wait_for_finish(wait_duration=wait_duration)
 
-    def get_input(self, *, timeout: Timeout = 'short') -> dict | None:
+    def get_input(self, *, timeout: Timeout = 'short') -> dict:
         """Retrieve the default input for this task.
 
         https://docs.apify.com/api/v2#/reference/actor-tasks/task-input-object/get-task-input
@@ -290,18 +289,17 @@ class TaskClient(ResourceClient):
 
         Returns:
             Retrieved task input.
+
+        Raises:
+            NotFoundError: If the task does not exist.
         """
-        try:
-            response = self._http_client.call(
-                url=self._build_url('input'),
-                method='GET',
-                params=self._build_params(),
-                timeout=timeout,
-            )
-            return response_to_dict(response)
-        except ApifyApiError as exc:
-            catch_not_found_or_throw(exc)
-        return None
+        response = self._http_client.call(
+            url=self._build_url('input'),
+            method='GET',
+            params=self._build_params(),
+            timeout=timeout,
+        )
+        return response_to_dict(response)
 
     def update_input(self, *, task_input: dict | TaskInput, timeout: Timeout = 'short') -> dict:
         """Update the default input for this task.
@@ -603,7 +601,7 @@ class TaskClientAsync(ResourceClientAsync):
         )
         return await run_client.wait_for_finish(wait_duration=wait_duration)
 
-    async def get_input(self, *, timeout: Timeout = 'short') -> dict | None:
+    async def get_input(self, *, timeout: Timeout = 'short') -> dict:
         """Retrieve the default input for this task.
 
         https://docs.apify.com/api/v2#/reference/actor-tasks/task-input-object/get-task-input
@@ -613,18 +611,17 @@ class TaskClientAsync(ResourceClientAsync):
 
         Returns:
             Retrieved task input.
+
+        Raises:
+            NotFoundError: If the task does not exist.
         """
-        try:
-            response = await self._http_client.call(
-                url=self._build_url('input'),
-                method='GET',
-                params=self._build_params(),
-                timeout=timeout,
-            )
-            return response_to_dict(response)
-        except ApifyApiError as exc:
-            catch_not_found_or_throw(exc)
-        return None
+        response = await self._http_client.call(
+            url=self._build_url('input'),
+            method='GET',
+            params=self._build_params(),
+            timeout=timeout,
+        )
+        return response_to_dict(response)
 
     async def update_input(self, *, task_input: dict | TaskInput, timeout: Timeout = 'short') -> dict:
         """Update the default input for this task.

--- a/src/apify_client/_resource_clients/user.py
+++ b/src/apify_client/_resource_clients/user.py
@@ -16,8 +16,7 @@ from apify_client._models import (
     UserPublicInfo,
 )
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
-from apify_client._utils import catch_not_found_or_throw, response_to_dict
-from apify_client.errors import ApifyApiError
+from apify_client._utils import response_to_dict
 
 if TYPE_CHECKING:
     from apify_client._types import Timeout
@@ -65,7 +64,7 @@ class UserClient(ResourceClient):
         except ValidationError:
             return PublicUserDataResponse.model_validate(result).data
 
-    def monthly_usage(self, *, timeout: Timeout = 'short') -> MonthlyUsage | None:
+    def monthly_usage(self, *, timeout: Timeout = 'short') -> MonthlyUsage:
         """Return monthly usage of the user account.
 
         This includes a complete usage summary for the current usage cycle, an overall sum, as well as a daily breakdown
@@ -78,24 +77,21 @@ class UserClient(ResourceClient):
             timeout: Timeout for the API HTTP request.
 
         Returns:
-            The retrieved request, or None, if it did not exist.
+            The retrieved monthly usage.
+
+        Raises:
+            NotFoundError: If the user does not exist.
         """
-        try:
-            response = self._http_client.call(
-                url=self._build_url('usage/monthly'),
-                method='GET',
-                params=self._build_params(),
-                timeout=timeout,
-            )
-            result = response_to_dict(response)
-            return MonthlyUsageResponse.model_validate(result).data
+        response = self._http_client.call(
+            url=self._build_url('usage/monthly'),
+            method='GET',
+            params=self._build_params(),
+            timeout=timeout,
+        )
+        result = response_to_dict(response)
+        return MonthlyUsageResponse.model_validate(result).data
 
-        except ApifyApiError as exc:
-            catch_not_found_or_throw(exc)
-
-        return None
-
-    def limits(self, *, timeout: Timeout = 'short') -> AccountLimits | None:
+    def limits(self, *, timeout: Timeout = 'short') -> AccountLimits:
         """Return a complete summary of the user account's limits.
 
         It is the same information which is available on the account's Limits page. The returned data includes
@@ -107,22 +103,19 @@ class UserClient(ResourceClient):
             timeout: Timeout for the API HTTP request.
 
         Returns:
-            The account limits, or None, if they could not be retrieved.
+            The account limits.
+
+        Raises:
+            NotFoundError: If the user does not exist.
         """
-        try:
-            response = self._http_client.call(
-                url=self._build_url('limits'),
-                method='GET',
-                params=self._build_params(),
-                timeout=timeout,
-            )
-            result = response_to_dict(response)
-            return LimitsResponse.model_validate(result).data
-
-        except ApifyApiError as exc:
-            catch_not_found_or_throw(exc)
-
-        return None
+        response = self._http_client.call(
+            url=self._build_url('limits'),
+            method='GET',
+            params=self._build_params(),
+            timeout=timeout,
+        )
+        result = response_to_dict(response)
+        return LimitsResponse.model_validate(result).data
 
     def update_limits(
         self,
@@ -194,7 +187,7 @@ class UserClientAsync(ResourceClientAsync):
         except ValidationError:
             return PublicUserDataResponse.model_validate(result).data
 
-    async def monthly_usage(self, *, timeout: Timeout = 'short') -> MonthlyUsage | None:
+    async def monthly_usage(self, *, timeout: Timeout = 'short') -> MonthlyUsage:
         """Return monthly usage of the user account.
 
         This includes a complete usage summary for the current usage cycle, an overall sum, as well as a daily breakdown
@@ -207,24 +200,21 @@ class UserClientAsync(ResourceClientAsync):
             timeout: Timeout for the API HTTP request.
 
         Returns:
-            The retrieved request, or None, if it did not exist.
+            The retrieved monthly usage.
+
+        Raises:
+            NotFoundError: If the user does not exist.
         """
-        try:
-            response = await self._http_client.call(
-                url=self._build_url('usage/monthly'),
-                method='GET',
-                params=self._build_params(),
-                timeout=timeout,
-            )
-            result = response_to_dict(response)
-            return MonthlyUsageResponse.model_validate(result).data
+        response = await self._http_client.call(
+            url=self._build_url('usage/monthly'),
+            method='GET',
+            params=self._build_params(),
+            timeout=timeout,
+        )
+        result = response_to_dict(response)
+        return MonthlyUsageResponse.model_validate(result).data
 
-        except ApifyApiError as exc:
-            catch_not_found_or_throw(exc)
-
-        return None
-
-    async def limits(self, *, timeout: Timeout = 'short') -> AccountLimits | None:
+    async def limits(self, *, timeout: Timeout = 'short') -> AccountLimits:
         """Return a complete summary of the user account's limits.
 
         It is the same information which is available on the account's Limits page. The returned data includes
@@ -236,22 +226,19 @@ class UserClientAsync(ResourceClientAsync):
             timeout: Timeout for the API HTTP request.
 
         Returns:
-            The account limits, or None, if they could not be retrieved.
+            The account limits.
+
+        Raises:
+            NotFoundError: If the user does not exist.
         """
-        try:
-            response = await self._http_client.call(
-                url=self._build_url('limits'),
-                method='GET',
-                params=self._build_params(),
-                timeout=timeout,
-            )
-            result = response_to_dict(response)
-            return LimitsResponse.model_validate(result).data
-
-        except ApifyApiError as exc:
-            catch_not_found_or_throw(exc)
-
-        return None
+        response = await self._http_client.call(
+            url=self._build_url('limits'),
+            method='GET',
+            params=self._build_params(),
+            timeout=timeout,
+        )
+        result = response_to_dict(response)
+        return LimitsResponse.model_validate(result).data
 
     async def update_limits(
         self,

--- a/src/apify_client/_resource_clients/webhook.py
+++ b/src/apify_client/_resource_clients/webhook.py
@@ -14,8 +14,7 @@ from apify_client._models import (
     WebhookUpdate,
 )
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
-from apify_client._utils import catch_not_found_or_throw, response_to_dict
-from apify_client.errors import ApifyApiError
+from apify_client._utils import response_to_dict
 
 if TYPE_CHECKING:
     from apify_client._models import WebhookEventType
@@ -123,7 +122,7 @@ class WebhookClient(ResourceClient):
         """
         self._delete(timeout=timeout)
 
-    def test(self, *, timeout: Timeout = 'medium') -> WebhookDispatch | None:
+    def test(self, *, timeout: Timeout = 'medium') -> WebhookDispatch:
         """Test a webhook.
 
         Creates a webhook dispatch with a dummy payload.
@@ -135,22 +134,19 @@ class WebhookClient(ResourceClient):
 
         Returns:
             The webhook dispatch created by the test.
+
+        Raises:
+            NotFoundError: If the webhook does not exist.
         """
-        try:
-            response = self._http_client.call(
-                url=self._build_url('test'),
-                method='POST',
-                params=self._build_params(),
-                timeout=timeout,
-            )
+        response = self._http_client.call(
+            url=self._build_url('test'),
+            method='POST',
+            params=self._build_params(),
+            timeout=timeout,
+        )
 
-            result = response_to_dict(response)
-            return TestWebhookResponse.model_validate(result).data
-
-        except ApifyApiError as exc:
-            catch_not_found_or_throw(exc)
-
-        return None
+        result = response_to_dict(response)
+        return TestWebhookResponse.model_validate(result).data
 
     def dispatches(self) -> WebhookDispatchCollectionClient:
         """Get dispatches of the webhook.
@@ -266,7 +262,7 @@ class WebhookClientAsync(ResourceClientAsync):
         """
         await self._delete(timeout=timeout)
 
-    async def test(self, *, timeout: Timeout = 'medium') -> WebhookDispatch | None:
+    async def test(self, *, timeout: Timeout = 'medium') -> WebhookDispatch:
         """Test a webhook.
 
         Creates a webhook dispatch with a dummy payload.
@@ -278,22 +274,19 @@ class WebhookClientAsync(ResourceClientAsync):
 
         Returns:
             The webhook dispatch created by the test.
+
+        Raises:
+            NotFoundError: If the webhook does not exist.
         """
-        try:
-            response = await self._http_client.call(
-                url=self._build_url('test'),
-                method='POST',
-                params=self._build_params(),
-                timeout=timeout,
-            )
+        response = await self._http_client.call(
+            url=self._build_url('test'),
+            method='POST',
+            params=self._build_params(),
+            timeout=timeout,
+        )
 
-            result = response_to_dict(response)
-            return TestWebhookResponse.model_validate(result).data
-
-        except ApifyApiError as exc:
-            catch_not_found_or_throw(exc)
-
-        return None
+        result = response_to_dict(response)
+        return TestWebhookResponse.model_validate(result).data
 
     def dispatches(self) -> WebhookDispatchCollectionClientAsync:
         """Get dispatches of the webhook.

--- a/src/apify_client/_utils.py
+++ b/src/apify_client/_utils.py
@@ -66,6 +66,18 @@ def catch_not_found_or_throw(exc: ApifyApiError) -> None:
         raise exc
 
 
+def catch_not_found_for_resource_or_throw(exc: ApifyApiError, resource_id: str | None) -> None:
+    """Like `catch_not_found_or_throw`, but only suppress 404s when the client targets a specific resource by ID.
+
+    For chained clients without a `resource_id` (e.g. `run.dataset()`, `run.log()`), a 404 could mean either the
+    parent or the default sub-resource is missing — the API body cannot disambiguate — so the error propagates
+    rather than being swallowed.
+    """
+    if resource_id is None:
+        raise exc
+    catch_not_found_or_throw(exc)
+
+
 def encode_key_value_store_record_value(value: Any, content_type: str | None = None) -> tuple[Any, str]:
     """Encode a value for storage in a key-value store record.
 

--- a/tests/unit/test_client_errors.py
+++ b/tests/unit/test_client_errors.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from werkzeug import Response
@@ -20,6 +20,8 @@ from apify_client.errors import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from pytest_httpserver import HTTPServer
     from werkzeug import Request
 
@@ -40,13 +42,34 @@ RAW_ERROR = (
     b'}'
 )
 
+_DATASET_FIXTURE = {
+    'id': 'ds-1',
+    'userId': 'u-1',
+    'createdAt': '2026-01-01T00:00:00.000Z',
+    'modifiedAt': '2026-01-01T00:00:00.000Z',
+    'accessedAt': '2026-01-01T00:00:00.000Z',
+    'itemCount': 0,
+    'cleanItemCount': 0,
+    'consoleUrl': 'https://console.apify.com/storage/datasets/ds-1',
+}
 
-@pytest.fixture
-def test_endpoint(httpserver: HTTPServer) -> str:
-    httpserver.expect_request(_TEST_PATH).respond_with_json(
-        {'error': {'message': _EXPECTED_MESSAGE, 'type': _EXPECTED_TYPE, 'data': _EXPECTED_DATA}}, status=400
-    )
-    return str(httpserver.url_for(_TEST_PATH))
+# Singleton sub-path endpoints — fetch a fixed path under an ID-identified parent (e.g. /schedules/{id}/log). A 404
+# always means the parent is missing, so `NotFoundError` propagates instead of collapsing to `None`.
+_SINGLETON_SUBPATH_404_CASES = [
+    pytest.param('/v2/schedules/missing/log', 'GET', lambda c: c.schedule('missing').get_log(), id='schedule_get_log'),
+    pytest.param('/v2/actor-tasks/missing/input', 'GET', lambda c: c.task('missing').get_input(), id='task_get_input'),
+    pytest.param(
+        '/v2/datasets/missing/statistics',
+        'GET',
+        lambda c: c.dataset('missing').get_statistics(),
+        id='dataset_get_statistics',
+    ),
+    pytest.param('/v2/webhooks/missing/test', 'POST', lambda c: c.webhook('missing').test(), id='webhook_test'),
+]
+
+
+def _not_found_body() -> dict:
+    return {'error': {'type': 'record-not-found', 'message': 'not found'}}
 
 
 def streaming_handler(_request: Request) -> Response:
@@ -57,6 +80,24 @@ def streaming_handler(_request: Request) -> Response:
         mimetype='application/octet-stream',
         headers={'Content-Length': str(len(RAW_ERROR))},
     )
+
+
+@pytest.fixture
+def sync_client(httpserver: HTTPServer) -> ApifyClient:
+    return ApifyClient(token='test', api_url=httpserver.url_for('/').removesuffix('/'))
+
+
+@pytest.fixture
+def async_client(httpserver: HTTPServer) -> ApifyClientAsync:
+    return ApifyClientAsync(token='test', api_url=httpserver.url_for('/').removesuffix('/'))
+
+
+@pytest.fixture
+def test_endpoint(httpserver: HTTPServer) -> str:
+    httpserver.expect_request(_TEST_PATH).respond_with_json(
+        {'error': {'message': _EXPECTED_MESSAGE, 'type': _EXPECTED_TYPE, 'data': _EXPECTED_DATA}}, status=400
+    )
+    return str(httpserver.url_for(_TEST_PATH))
 
 
 def test_client_apify_api_error_with_data(test_endpoint: str) -> None:
@@ -214,39 +255,130 @@ def test_apify_api_error_falls_back_for_unparsable_body(httpserver: HTTPServer) 
     assert exc.value.type is None
 
 
-def _not_found_body() -> dict:
-    return {'error': {'type': 'record-not-found', 'message': 'not found'}}
-
-
-def test_direct_get_returns_none_on_404(httpserver: HTTPServer) -> None:
-    """`client.dataset("X").get()` — a direct, ID-identified fetch — swallows 404 into `None`."""
+def test_direct_get_returns_none_on_404(httpserver: HTTPServer, sync_client: ApifyClient) -> None:
     httpserver.expect_request('/v2/datasets/missing').respond_with_json(_not_found_body(), status=404)
-    client = ApifyClient(token='test', api_url=httpserver.url_for('/').removesuffix('/'))
-
-    assert client.dataset('missing').get() is None
+    assert sync_client.dataset('missing').get() is None
 
 
-async def test_direct_get_returns_none_on_404_async(httpserver: HTTPServer) -> None:
-    """Async mirror: direct `.get()` swallows 404."""
+async def test_direct_get_returns_none_on_404_async(httpserver: HTTPServer, async_client: ApifyClientAsync) -> None:
     httpserver.expect_request('/v2/datasets/missing').respond_with_json(_not_found_body(), status=404)
-    client = ApifyClientAsync(token='test', api_url=httpserver.url_for('/').removesuffix('/'))
-
-    assert await client.dataset('missing').get() is None
+    assert await async_client.dataset('missing').get() is None
 
 
-def test_chained_get_raises_on_404(httpserver: HTTPServer) -> None:
-    """`run("X").dataset().get()` is ambiguous on 404 (run or dataset missing) — propagate instead of `None`."""
+def test_chained_get_raises_on_404(httpserver: HTTPServer, sync_client: ApifyClient) -> None:
     httpserver.expect_request('/v2/actor-runs/missing-run/dataset').respond_with_json(_not_found_body(), status=404)
-    client = ApifyClient(token='test', api_url=httpserver.url_for('/').removesuffix('/'))
-
     with pytest.raises(NotFoundError):
-        client.run('missing-run').dataset().get()
+        sync_client.run('missing-run').dataset().get()
 
 
-async def test_chained_get_raises_on_404_async(httpserver: HTTPServer) -> None:
-    """Async mirror: chained `.get()` propagates NotFoundError."""
+async def test_chained_get_raises_on_404_async(httpserver: HTTPServer, async_client: ApifyClientAsync) -> None:
     httpserver.expect_request('/v2/actor-runs/missing-run/dataset').respond_with_json(_not_found_body(), status=404)
-    client = ApifyClientAsync(token='test', api_url=httpserver.url_for('/').removesuffix('/'))
-
     with pytest.raises(NotFoundError):
-        await client.run('missing-run').dataset().get()
+        await async_client.run('missing-run').dataset().get()
+
+
+def test_actor_last_run_dataset_get_raises_on_404(httpserver: HTTPServer, sync_client: ApifyClient) -> None:
+    """404 covers missing actor, missing last_run, or missing dataset — all three are indistinguishable from the single
+    HTTP response (the client only hits the final URL), so `NotFoundError` propagates uniformly.
+    """
+    httpserver.expect_request('/v2/acts/actor-id/runs/last/dataset').respond_with_json(_not_found_body(), status=404)
+    with pytest.raises(NotFoundError):
+        sync_client.actor('actor-id').last_run().dataset().get()
+
+
+async def test_actor_last_run_dataset_get_raises_on_404_async(
+    httpserver: HTTPServer, async_client: ApifyClientAsync
+) -> None:
+    httpserver.expect_request('/v2/acts/actor-id/runs/last/dataset').respond_with_json(_not_found_body(), status=404)
+    with pytest.raises(NotFoundError):
+        await async_client.actor('actor-id').last_run().dataset().get()
+
+
+def test_actor_last_run_dataset_get_returns_dataset(httpserver: HTTPServer, sync_client: ApifyClient) -> None:
+    httpserver.expect_request('/v2/acts/actor-id/runs/last/dataset').respond_with_json({'data': _DATASET_FIXTURE})
+    dataset = sync_client.actor('actor-id').last_run().dataset().get()
+    assert dataset is not None
+    assert dataset.id == 'ds-1'
+
+
+async def test_actor_last_run_dataset_get_returns_dataset_async(
+    httpserver: HTTPServer, async_client: ApifyClientAsync
+) -> None:
+    httpserver.expect_request('/v2/acts/actor-id/runs/last/dataset').respond_with_json({'data': _DATASET_FIXTURE})
+    dataset = await async_client.actor('actor-id').last_run().dataset().get()
+    assert dataset is not None
+    assert dataset.id == 'ds-1'
+
+
+def test_direct_delete_swallows_404(httpserver: HTTPServer, sync_client: ApifyClient) -> None:
+    httpserver.expect_request('/v2/datasets/missing', method='DELETE').respond_with_json(_not_found_body(), status=404)
+    sync_client.dataset('missing').delete()
+
+
+async def test_direct_delete_swallows_404_async(httpserver: HTTPServer, async_client: ApifyClientAsync) -> None:
+    httpserver.expect_request('/v2/datasets/missing', method='DELETE').respond_with_json(_not_found_body(), status=404)
+    await async_client.dataset('missing').delete()
+
+
+def test_chained_delete_raises_on_404(httpserver: HTTPServer, sync_client: ApifyClient) -> None:
+    httpserver.expect_request('/v2/actor-runs/missing-run/dataset', method='DELETE').respond_with_json(
+        _not_found_body(), status=404
+    )
+    with pytest.raises(NotFoundError):
+        sync_client.run('missing-run').dataset().delete()
+
+
+async def test_chained_delete_raises_on_404_async(httpserver: HTTPServer, async_client: ApifyClientAsync) -> None:
+    httpserver.expect_request('/v2/actor-runs/missing-run/dataset', method='DELETE').respond_with_json(
+        _not_found_body(), status=404
+    )
+    with pytest.raises(NotFoundError):
+        await async_client.run('missing-run').dataset().delete()
+
+
+def test_direct_log_get_returns_none_on_404(httpserver: HTTPServer, sync_client: ApifyClient) -> None:
+    httpserver.expect_request('/v2/logs/missing').respond_with_json(_not_found_body(), status=404)
+    assert sync_client.log('missing').get() is None
+
+
+async def test_direct_log_get_returns_none_on_404_async(httpserver: HTTPServer, async_client: ApifyClientAsync) -> None:
+    httpserver.expect_request('/v2/logs/missing').respond_with_json(_not_found_body(), status=404)
+    assert await async_client.log('missing').get() is None
+
+
+def test_chained_log_get_raises_on_404(httpserver: HTTPServer, sync_client: ApifyClient) -> None:
+    httpserver.expect_request('/v2/actor-runs/missing-run/log').respond_with_json(_not_found_body(), status=404)
+    with pytest.raises(NotFoundError):
+        sync_client.run('missing-run').log().get()
+
+
+async def test_chained_log_get_raises_on_404_async(httpserver: HTTPServer, async_client: ApifyClientAsync) -> None:
+    httpserver.expect_request('/v2/actor-runs/missing-run/log').respond_with_json(_not_found_body(), status=404)
+    with pytest.raises(NotFoundError):
+        await async_client.run('missing-run').log().get()
+
+
+@pytest.mark.parametrize(('path', 'method', 'call'), _SINGLETON_SUBPATH_404_CASES)
+def test_singleton_subpath_raises_on_404(
+    httpserver: HTTPServer,
+    sync_client: ApifyClient,
+    path: str,
+    method: str,
+    call: Callable[[ApifyClient], Any],
+) -> None:
+    httpserver.expect_request(path, method=method).respond_with_json(_not_found_body(), status=404)
+    with pytest.raises(NotFoundError):
+        call(sync_client)
+
+
+@pytest.mark.parametrize(('path', 'method', 'call'), _SINGLETON_SUBPATH_404_CASES)
+async def test_singleton_subpath_raises_on_404_async(
+    httpserver: HTTPServer,
+    async_client: ApifyClientAsync,
+    path: str,
+    method: str,
+    call: Callable[[ApifyClientAsync], Awaitable[Any]],
+) -> None:
+    httpserver.expect_request(path, method=method).respond_with_json(_not_found_body(), status=404)
+    with pytest.raises(NotFoundError):
+        await call(async_client)

--- a/tests/unit/test_client_errors.py
+++ b/tests/unit/test_client_errors.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import pytest
 from werkzeug import Response
 
+from apify_client import ApifyClient, ApifyClientAsync
 from apify_client._http_clients import ImpitHttpClient, ImpitHttpClientAsync
 from apify_client.errors import (
     ApifyApiError,
@@ -211,3 +212,41 @@ def test_apify_api_error_falls_back_for_unparsable_body(httpserver: HTTPServer) 
 
     assert type(exc.value) is ApifyApiError
     assert exc.value.type is None
+
+
+def _not_found_body() -> dict:
+    return {'error': {'type': 'record-not-found', 'message': 'not found'}}
+
+
+def test_direct_get_returns_none_on_404(httpserver: HTTPServer) -> None:
+    """`client.dataset("X").get()` — a direct, ID-identified fetch — swallows 404 into `None`."""
+    httpserver.expect_request('/v2/datasets/missing').respond_with_json(_not_found_body(), status=404)
+    client = ApifyClient(token='test', api_url=httpserver.url_for('/').removesuffix('/'))
+
+    assert client.dataset('missing').get() is None
+
+
+async def test_direct_get_returns_none_on_404_async(httpserver: HTTPServer) -> None:
+    """Async mirror: direct `.get()` swallows 404."""
+    httpserver.expect_request('/v2/datasets/missing').respond_with_json(_not_found_body(), status=404)
+    client = ApifyClientAsync(token='test', api_url=httpserver.url_for('/').removesuffix('/'))
+
+    assert await client.dataset('missing').get() is None
+
+
+def test_chained_get_raises_on_404(httpserver: HTTPServer) -> None:
+    """`run("X").dataset().get()` is ambiguous on 404 (run or dataset missing) — propagate instead of `None`."""
+    httpserver.expect_request('/v2/actor-runs/missing-run/dataset').respond_with_json(_not_found_body(), status=404)
+    client = ApifyClient(token='test', api_url=httpserver.url_for('/').removesuffix('/'))
+
+    with pytest.raises(NotFoundError):
+        client.run('missing-run').dataset().get()
+
+
+async def test_chained_get_raises_on_404_async(httpserver: HTTPServer) -> None:
+    """Async mirror: chained `.get()` propagates NotFoundError."""
+    httpserver.expect_request('/v2/actor-runs/missing-run/dataset').respond_with_json(_not_found_body(), status=404)
+    client = ApifyClientAsync(token='test', api_url=httpserver.url_for('/').removesuffix('/'))
+
+    with pytest.raises(NotFoundError):
+        await client.run('missing-run').dataset().get()


### PR DESCRIPTION
Follow-up to https://github.com/apify/apify-client-python/pull/737#discussion_r3117539782

`.get()` previously collapsed every 404 into `None` via `catch_not_found_or_throw`. That works for direct, ID-identified fetches (`client.dataset(id).get()`), where a 404 unambiguously means the named resource is missing. It's misleading whenever a 404 is ambiguous — the client can't tell which resource in the path is actually gone, and silently returning `None` hides the cause.

This PR identifies three categories where a 404 is ambiguous and propagates `NotFoundError` instead:

1. **Chained calls without an ID** (`run.dataset()`, `run.key_value_store()`, `run.request_queue()`, `run.log()`) — a 404 could mean either the parent run is missing or the default sub-resource. Covered by the base `_get` / `_delete` via a `resource_id is None → raise` guard, so `.delete()` on a chained client also raises now; direct `dataset(id).delete()` keeps its idempotent-DELETE semantics.
2. **Chained `LogClient`** — `run.log().get()` / `.get_as_bytes()` / `.stream()` raise; direct `client.log(id).get()` still returns `None`.
3. **Singleton sub-path endpoints** — `ScheduleClient.get_log`, `TaskClient.get_input`, `DatasetClient.get_statistics`, `UserClient.monthly_usage`, `UserClient.limits`, `WebhookClient.test`. These hit a fixed path (`/.../{id}/log`, `/.../{id}/input`, etc.) where a 404 effectively always means the parent is missing. Return types moved from `T | None` to `T`.

Record-by-key lookups (`KeyValueStoreClient.get_record(key)`, `RequestQueueClient.get_request(request_id)`) keep the existing "None on missing" behavior — the 404 is specifically about the record/request, which is the natural meaning.

A shared helper `catch_not_found_for_resource_or_throw(exc, resource_id)` in `_utils.py` centralizes the `resource_id is None → raise` pattern across all 10 call sites. The v3 upgrade guide documents the new semantics. Sync/async tests cover every code path, including `client.actor('id').last_run().dataset().get()` (happy path + ambiguous-404 case).