### PR TITLE
test: raise timeout for presigned URL fetches in integration tests

### DIFF
--- a/tests/integration/test_dataset.py
+++ b/tests/integration/test_dataset.py
@@ -88,7 +88,7 @@ async def test_dataset_should_create_public_items_expiring_url_with_params(
         assert 'offset=0' in items_public_url
 
         impit_client = impit.Client()
-        response = impit_client.get(items_public_url, timeout=5)
+        response = impit_client.get(items_public_url, timeout=30)
         assert response.status_code == 200
     finally:
         await maybe_await(dataset.delete())
@@ -110,7 +110,7 @@ async def test_dataset_should_create_public_items_non_expiring_url(
         assert 'signature=' in items_public_url
 
         impit_client = impit.Client()
-        response = impit_client.get(items_public_url, timeout=5)
+        response = impit_client.get(items_public_url, timeout=30)
         assert response.status_code == 200
     finally:
         await maybe_await(dataset.delete())

--- a/tests/integration/test_key_value_store.py
+++ b/tests/integration/test_key_value_store.py
@@ -82,7 +82,7 @@ async def test_key_value_store_should_create_expiring_keys_public_url_with_param
         assert 'limit=10' in keys_public_url
 
         impit_client = impit.Client()
-        response = impit_client.get(keys_public_url, timeout=5)
+        response = impit_client.get(keys_public_url, timeout=30)
         assert response.status_code == 200
     finally:
         await maybe_await(store.delete())
@@ -104,7 +104,7 @@ async def test_key_value_store_should_create_public_keys_non_expiring_url(
         assert 'signature=' in keys_public_url
 
         impit_client = impit.Client()
-        response = impit_client.get(keys_public_url, timeout=5)
+        response = impit_client.get(keys_public_url, timeout=30)
         assert response.status_code == 200
     finally:
         await maybe_await(store.delete())


### PR DESCRIPTION
## Summary

The 5s HTTP timeout on presigned-URL fetches in integration tests was too tight for the external Apify platform and occasionally tripped, causing flaky failures (e.g. [this job run](https://github.com/apify/apify-client-python/actions/runs/24832416128/job/72683975229?pr=738)). Bumped the timeout to 30s in all four affected tests (`test_dataset.py`, `test_key_value_store.py`) to absorb transient slowness while still failing fast on a truly broken endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)