### PR TITLE
feat: Add iterate methods for paginated collections

### DIFF
--- a/docs/02_concepts/08_pagination.mdx
+++ b/docs/02_concepts/08_pagination.mdx
@@ -12,7 +12,6 @@ import ApiLink from '@site/src/components/ApiLink';
 
 import PaginationAsyncExample from '!!raw-loader!./code/08_pagination_async.py';
 import PaginationSyncExample from '!!raw-loader!./code/08_pagination_sync.py';
-
 import IterateItemsAsyncExample from '!!raw-loader!./code/08_iterate_items_async.py';
 import IterateItemsSyncExample from '!!raw-loader!./code/08_iterate_items_sync.py';
 
@@ -45,7 +44,10 @@ The <ApiLink to="class/ListPage">`ListPage`</ApiLink> interface offers several k
 
 ## Generator-based iteration
 
-For most use cases, `iterate_items()` is the recommended way to process all items in a dataset. It handles pagination automatically using a Python generator, fetching items in batches behind the scenes so you don't need to manage offsets or limits yourself.
+For collection clients, the `iterate` method returns an iterator that lazily fetches as many pages as needed
+to retrieve every item matching the filters. For dataset, key-value store and request queue clients, the
+matching helpers are `iterate_items`, `iterate_keys` and `iterate_requests`. They handle pagination
+automatically, so you don't need to manage offsets, limits or cursors yourself.
 
 <Tabs>
     <TabItem value="AsyncExample" label="Async client" default>
@@ -59,7 +61,3 @@ For most use cases, `iterate_items()` is the recommended way to process all item
         </CodeBlock>
     </TabItem>
 </Tabs>
-
-`iterate_items()` accepts the same filtering parameters as `list_items()` (`clean`, `fields`, `omit`, `unwind`, `skip_empty`, `skip_hidden`), so you can combine automatic pagination with data filtering.
-
-Similarly, `KeyValueStoreClient` provides an `iterate_keys()` method for iterating over all keys in a key-value store without manual pagination.

--- a/docs/02_concepts/08_pagination.mdx
+++ b/docs/02_concepts/08_pagination.mdx
@@ -14,6 +14,8 @@ import PaginationAsyncExample from '!!raw-loader!./code/08_pagination_async.py';
 import PaginationSyncExample from '!!raw-loader!./code/08_pagination_sync.py';
 import IterateItemsAsyncExample from '!!raw-loader!./code/08_iterate_items_async.py';
 import IterateItemsSyncExample from '!!raw-loader!./code/08_iterate_items_sync.py';
+import IterateCollectionAsyncExample from '!!raw-loader!./code/08_iterate_collection_async.py';
+import IterateCollectionSyncExample from '!!raw-loader!./code/08_iterate_collection_sync.py';
 
 Most methods named `list` or `list_something` in the Apify client return a <ApiLink to="class/ListPage">`ListPage`</ApiLink>  object. This object provides a consistent interface for working with paginated data and includes the following properties:
 
@@ -48,6 +50,24 @@ For collection clients, the `iterate` method returns an iterator that lazily fet
 to retrieve every item matching the filters. For dataset, key-value store and request queue clients, the
 matching helpers are `iterate_items`, `iterate_keys` and `iterate_requests`. They handle pagination
 automatically, so you don't need to manage offsets, limits or cursors yourself.
+
+The example below iterates over every Actor owned by the current user using a collection client's `iterate`
+method:
+
+<Tabs>
+    <TabItem value="AsyncExample" label="Async client" default>
+        <CodeBlock className="language-python">
+            {IterateCollectionAsyncExample}
+        </CodeBlock>
+    </TabItem>
+    <TabItem value="SyncExample" label="Sync client">
+        <CodeBlock className="language-python">
+            {IterateCollectionSyncExample}
+        </CodeBlock>
+    </TabItem>
+</Tabs>
+
+The next example uses `iterate_items` on a dataset client to stream items past a given offset:
 
 <Tabs>
     <TabItem value="AsyncExample" label="Async client" default>

--- a/docs/02_concepts/code/08_iterate_collection_async.py
+++ b/docs/02_concepts/code/08_iterate_collection_async.py
@@ -1,0 +1,12 @@
+from apify_client import ApifyClientAsync
+
+TOKEN = 'MY-APIFY-TOKEN'
+
+
+async def main() -> None:
+    apify_client = ApifyClientAsync(TOKEN)
+
+    # Iterate over all Actors owned by the current user, lazily fetching
+    # as many pages as needed under the hood.
+    async for actor in apify_client.actors().iterate(my=True):
+        print(actor.id)

--- a/docs/02_concepts/code/08_iterate_collection_sync.py
+++ b/docs/02_concepts/code/08_iterate_collection_sync.py
@@ -1,0 +1,16 @@
+from apify_client import ApifyClient
+
+TOKEN = 'MY-APIFY-TOKEN'
+
+
+def main() -> None:
+    apify_client = ApifyClient(TOKEN)
+
+    # Iterate over all Actors owned by the current user, lazily fetching
+    # as many pages as needed under the hood.
+    for actor in apify_client.actors().iterate(my=True):
+        print(actor.id)
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/02_concepts/code/08_iterate_items_async.py
+++ b/docs/02_concepts/code/08_iterate_items_async.py
@@ -7,6 +7,11 @@ async def main() -> None:
     apify_client = ApifyClientAsync(TOKEN)
     dataset_client = apify_client.dataset('dataset-id')
 
-    # Iterate through all items automatically.
-    async for item in dataset_client.iterate_items():
-        print(item)
+    # Define the pagination parameters
+    limit = 1500  # Number of items in total
+    offset = 100  # Starting offset
+
+    # Iterate through items automatically, lazily sending as many API calls
+    # as needed and receiving items in chunks.
+    async for item in dataset_client.iterate_items(limit=limit, offset=offset):
+        print(item)  # Process the item as needed

--- a/docs/02_concepts/code/08_iterate_items_sync.py
+++ b/docs/02_concepts/code/08_iterate_items_sync.py
@@ -7,9 +7,14 @@ def main() -> None:
     apify_client = ApifyClient(TOKEN)
     dataset_client = apify_client.dataset('dataset-id')
 
-    # Iterate through all items automatically.
-    for item in dataset_client.iterate_items():
-        print(item)
+    # Define the pagination parameters
+    limit = 1500  # Number of items in total
+    offset = 100  # Starting offset
+
+    # Iterate through items automatically, lazily sending as many API calls
+    # as needed and receiving items in chunks.
+    for item in dataset_client.iterate_items(limit=limit, offset=offset):
+        print(item)  # Process the item as needed
 
 
 if __name__ == '__main__':

--- a/docs/02_concepts/code/08_pagination_async.py
+++ b/docs/02_concepts/code/08_pagination_async.py
@@ -10,26 +10,15 @@ async def main() -> None:
     dataset_client = apify_client.dataset('dataset-id')
 
     # Define the pagination parameters
-    limit = 1000  # Number of items per page
+    limit = 1000  # Number items to request from API
     offset = 0  # Starting offset
-    all_items = []  # List to store all fetched items
 
-    while True:
-        # Fetch a page of items
-        response = await dataset_client.list_items(limit=limit, offset=offset)
-        items = response.items
-        total = response.total
+    # Send single API call to fetch paginated items.
+    # (number of items per single call can be limited by API)
+    paginated_items = await dataset_client.list_items(limit=limit, offset=offset)
 
-        print(f'Fetched {len(items)} items')
+    # Inspect pagination metadata returned by API
+    print(paginated_items.total)
 
-        # Add the fetched items to the complete list
-        all_items.extend(items)
-
-        # Exit the loop if there are no more items to fetch
-        if offset + limit >= total:
-            break
-
-        # Increment the offset for the next page
-        offset += limit
-
-    print(f'Overall fetched {len(all_items)} items')
+    for item in paginated_items.items:
+        print(item)  # Process the item as needed

--- a/docs/02_concepts/code/08_pagination_sync.py
+++ b/docs/02_concepts/code/08_pagination_sync.py
@@ -10,26 +10,15 @@ def main() -> None:
     dataset_client = apify_client.dataset('dataset-id')
 
     # Define the pagination parameters
-    limit = 1000  # Number of items per page
+    limit = 1000  # Number items to request from API
     offset = 0  # Starting offset
-    all_items = []  # List to store all fetched items
 
-    while True:
-        # Fetch a page of items
-        response = dataset_client.list_items(limit=limit, offset=offset)
-        items = response.items
-        total = response.total
+    # Send single API call to fetch paginated items.
+    # (number of items per single call can be limited by API)
+    paginated_items = dataset_client.list_items(limit=limit, offset=offset)
 
-        print(f'Fetched {len(items)} items')
+    # Inspect pagination metadata returned by API
+    print(paginated_items.total)
 
-        # Add the fetched items to the complete list
-        all_items.extend(items)
-
-        # Exit the loop if there are no more items to fetch
-        if offset + limit >= total:
-            break
-
-        # Increment the offset for the next page
-        offset += limit
-
-    print(f'Overall fetched {len(all_items)} items')
+    for item in paginated_items.items:
+        print(item)  # Process the item as needed

--- a/docs/04_upgrading/upgrading_to_v3.mdx
+++ b/docs/04_upgrading/upgrading_to_v3.mdx
@@ -320,3 +320,22 @@ from apify_client._literals import WebhookEventType
 
 events: list[WebhookEventType] = ['ACTOR.RUN.SUCCEEDED', 'ACTOR.RUN.FAILED']
 ```
+
+## Async `iterate_*` methods are plain functions, not async generators
+
+Async iteration helpers — <ApiLink to="class/DatasetClientAsync#iterate_items">`DatasetClientAsync.iterate_items()`</ApiLink> and <ApiLink to="class/KeyValueStoreClientAsync#iterate_keys">`KeyValueStoreClientAsync.iterate_keys()`</ApiLink> — were previously declared as `async def` (async generator functions). They are now plain `def` functions that return an `AsyncIterator` produced by a shared pagination helper.
+
+Consumer-side iteration is unchanged — `async for item in client.iterate_items(...)` works the same in both versions:
+
+```python
+# Works in both v2 and v3
+async for item in client.dataset('my-dataset').iterate_items():
+    print(item)
+```
+
+The difference matters only if your code inspects the function itself:
+
+- The call is no longer a coroutine function — `inspect.iscoroutinefunction(client.iterate_items)` returns `False`, and `inspect.isasyncgenfunction(client.iterate_items)` also returns `False` (it returns a regular function whose result is an async iterator).
+- Type checkers see `def (...) -> AsyncIterator[T]` instead of `async def (...) -> AsyncIterator[T]`. Annotations on variables that hold the call's result may need to change from `AsyncGenerator[T, None]` to `AsyncIterator[T]`.
+
+A new <ApiLink to="class/RequestQueueClientAsync#iterate_requests">`RequestQueueClientAsync.iterate_requests()`</ApiLink> helper is also introduced and follows the same `def ... -> AsyncIterator[T]` shape.

--- a/scripts/_utils.py
+++ b/scripts/_utils.py
@@ -27,6 +27,7 @@ _SUBSTITUTIONS = [
     (re.compile(r'\bSynchronous\b'), 'Asynchronous'),
     (re.compile(r'Retry a function'), 'Retry an async function'),
     (re.compile(r'Function to retry'), 'Async function to retry'),
+    (re.compile(r'returned page also supports iteration: `for'), 'returned page also supports iteration: `async for'),
 ]
 """Patterns for converting sync docstrings to async docstrings."""
 

--- a/scripts/_utils.py
+++ b/scripts/_utils.py
@@ -27,7 +27,6 @@ _SUBSTITUTIONS = [
     (re.compile(r'\bSynchronous\b'), 'Asynchronous'),
     (re.compile(r'Retry a function'), 'Retry an async function'),
     (re.compile(r'Function to retry'), 'Async function to retry'),
-    (re.compile(r'returned page also supports iteration: `for'), 'returned page also supports iteration: `async for'),
 ]
 """Patterns for converting sync docstrings to async docstrings."""
 

--- a/src/apify_client/_pagination.py
+++ b/src/apify_client/_pagination.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol, TypeVar
+from typing import TYPE_CHECKING, Protocol, TypeVar, overload
+
+from apify_client._models import KeyValueStoreKey, ListOfKeys, ListOfRequests, Request
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
@@ -96,23 +98,37 @@ async def get_items_iterator_async(
             break
 
 
+@overload
 def get_cursor_iterator(
-    callback: Callable[..., HasItems[T]],
+    callback: Callable[..., ListOfKeys],
     *,
-    next_cursor: Callable[[Any], str | None],
     cursor: str | None = None,
     limit: int | None = None,
     chunk_size: int | None = None,
-) -> Iterator[T]:
+) -> Iterator[KeyValueStoreKey]: ...
+@overload
+def get_cursor_iterator(
+    callback: Callable[..., ListOfRequests],
+    *,
+    cursor: str | None = None,
+    limit: int | None = None,
+    chunk_size: int | None = None,
+) -> Iterator[Request]: ...
+def get_cursor_iterator(
+    callback: Callable[..., ListOfKeys | ListOfRequests],
+    *,
+    cursor: str | None = None,
+    limit: int | None = None,
+    chunk_size: int | None = None,
+) -> Iterator[KeyValueStoreKey] | Iterator[Request]:
     """Yield individual items from cursor-paginated API responses.
 
-    Each page is expected to expose `items`; iteration ends when a page returns no items, the cursor extracted by
-    `next_cursor` is `None`, or the user-requested `limit` is reached.
+    Cursor pagination is restricted to the two API responses that expose it: `ListOfKeys` (for key-value store keys) and
+    `ListOfRequests` (for request queue requests). Iteration ends when a page returns no items, the next cursor is
+    `None`, or the user-requested `limit` is reached.
 
     Args:
         callback: Function returning a single page of items. Receives `cursor` and `limit` kwargs.
-        next_cursor: Callable that extracts the next-page cursor from the returned page (e.g. `lambda p: p.next_cursor`)
-            and returns `None` when there are no more pages.
         cursor: Value of the cursor for the first request, or `None` to start from the beginning.
         limit: Maximum total number of items to yield across all pages.
         chunk_size: Maximum number of items requested per API call.
@@ -129,20 +145,37 @@ def get_cursor_iterator(
         yield from current_page.items
 
         fetched_items += max(getattr(current_page, 'count', 0), len(current_page.items))
-        cursor = next_cursor(current_page)
+        cursor = (
+            current_page.next_exclusive_start_key if isinstance(current_page, ListOfKeys) else current_page.next_cursor
+        )
 
         if not current_page.items or cursor is None or (initial_limit and fetched_items >= initial_limit):
             break
 
 
-async def get_cursor_iterator_async(
-    callback: Callable[..., Awaitable[HasItems[T]]],
+@overload
+def get_cursor_iterator_async(
+    callback: Callable[..., Awaitable[ListOfKeys]],
     *,
-    next_cursor: Callable[[Any], str | None],
     cursor: str | None = None,
     limit: int | None = None,
     chunk_size: int | None = None,
-) -> AsyncIterator[T]:
+) -> AsyncIterator[KeyValueStoreKey]: ...
+@overload
+def get_cursor_iterator_async(
+    callback: Callable[..., Awaitable[ListOfRequests]],
+    *,
+    cursor: str | None = None,
+    limit: int | None = None,
+    chunk_size: int | None = None,
+) -> AsyncIterator[Request]: ...
+async def get_cursor_iterator_async(
+    callback: Callable[..., Awaitable[ListOfKeys | ListOfRequests]],
+    *,
+    cursor: str | None = None,
+    limit: int | None = None,
+    chunk_size: int | None = None,
+) -> AsyncIterator[KeyValueStoreKey] | AsyncIterator[Request]:
     """Async variant of :func:`get_cursor_iterator`."""
     effective_chunk = chunk_size or 0
     initial_limit = limit or 0
@@ -157,7 +190,9 @@ async def get_cursor_iterator_async(
             yield item
 
         fetched_items += max(getattr(current_page, 'count', 0), len(current_page.items))
-        cursor = next_cursor(current_page)
+        cursor = (
+            current_page.next_exclusive_start_key if isinstance(current_page, ListOfKeys) else current_page.next_cursor
+        )
 
         if not current_page.items or cursor is None or (initial_limit and fetched_items >= initial_limit):
             break

--- a/src/apify_client/_pagination.py
+++ b/src/apify_client/_pagination.py
@@ -7,8 +7,21 @@ if TYPE_CHECKING:
 
 T = TypeVar('T')
 
+DEFAULT_CHUNK_SIZE = 1000
+"""Default per-page size used by the iterate helpers when the caller does not specify one.
+
+The value of 1000 keeps backwards compatibility with the previous fixed cache size.
+"""
+
 
 class HasItems(Protocol[T]):
+    """Structural contract for a single page of results from a paginated API endpoint.
+
+    Implementations must expose `items`. They may optionally expose `count` — the number of items scanned by the API for
+    this page, which can exceed `len(items)` when filters drop items from the response. The iterator helpers consult
+    `count` opportunistically via `getattr` for offset bookkeeping and fall back to `len(items)` when it is absent.
+    """
+
     items: list[T]
 
 

--- a/src/apify_client/_pagination.py
+++ b/src/apify_client/_pagination.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol, TypeVar, overload
-
-from apify_client._models import KeyValueStoreKey, ListOfKeys, ListOfRequests, Request
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
@@ -14,23 +12,6 @@ class HasItems(Protocol[T]):
     items: list[T]
 
 
-def _min_for_limit_param(a: int | None, b: int | None) -> int | None:
-    """Return minimum of two limit parameters, treating `None` or `0` as infinity.
-
-    The Apify API treats `0` as no limit for the `limit` parameter, so `0` here means infinity.
-    Returns `None` when both inputs represent infinity.
-    """
-    if a == 0:
-        a = None
-    if b == 0:
-        b = None
-    if a is None:
-        return b
-    if b is None:
-        return a
-    return min(a, b)
-
-
 def get_items_iterator(
     callback: Callable[..., HasItems[T]],
     *,
@@ -40,13 +21,13 @@ def get_items_iterator(
 ) -> Iterator[T]:
     """Yield individual items from offset-based paginated API responses.
 
-    The `callback` is invoked lazily to fetch each page from the API. It must accept `limit` and
-    `offset` keyword arguments and return an object whose `items` attribute is a list. If the
-    object also exposes a `count` attribute, it is used for offset bookkeeping (the Apify API's
-    `count` reflects items scanned, which can exceed items returned when filters are applied).
+    The `callback` is invoked lazily to fetch each page from the API. It must accept `limit` and `offset` keyword
+    arguments and return an object whose `items` attribute is a list. If the object also exposes a `count` attribute, it
+    is used for offset bookkeeping (the Apify API's `count` reflects items scanned, which can exceed items returned when
+    filters are applied).
 
-    Iteration stops when a page returns no items or when the user-requested `limit` is reached.
-    The `total` field is intentionally not consulted, because it can change between calls.
+    Iteration stops when a page returns no items or when the user-requested `limit` is reached. The `total` field is
+    intentionally not consulted, because it can change between calls.
 
     Args:
         callback: Function returning a single page of items.
@@ -61,14 +42,12 @@ def get_items_iterator(
 
     while True:
         current_page = callback(
-            limit=effective_chunk
-            if not initial_limit
-            else _min_for_limit_param(initial_limit - fetched_items, effective_chunk),
+            limit=_next_page_limit(initial_limit, fetched_items, effective_chunk),
             offset=initial_offset + fetched_items,
         )
         yield from current_page.items
 
-        fetched_items += getattr(current_page, 'count', len(current_page.items))
+        fetched_items += max(getattr(current_page, 'count', 0), len(current_page.items))
 
         if not current_page.items or (initial_limit and fetched_items >= initial_limit):
             break
@@ -92,54 +71,35 @@ async def get_items_iterator_async(
 
     while True:
         current_page = await callback(
-            limit=effective_chunk
-            if not initial_limit
-            else _min_for_limit_param(initial_limit - fetched_items, effective_chunk),
+            limit=_next_page_limit(initial_limit, fetched_items, effective_chunk),
             offset=initial_offset + fetched_items,
         )
         for item in current_page.items:
             yield item
 
-        fetched_items += getattr(current_page, 'count', len(current_page.items))
+        fetched_items += max(getattr(current_page, 'count', 0), len(current_page.items))
 
         if not current_page.items or (initial_limit and fetched_items >= initial_limit):
             break
 
 
-@overload
 def get_cursor_iterator(
-    callback: Callable[..., ListOfKeys],
+    callback: Callable[..., HasItems[T]],
     *,
+    next_cursor: Callable[[Any], str | None],
     cursor: str | None = None,
     limit: int | None = None,
     chunk_size: int | None = None,
-) -> Iterator[KeyValueStoreKey]: ...
-@overload
-def get_cursor_iterator(
-    callback: Callable[..., ListOfRequests],
-    *,
-    cursor: str | None = None,
-    limit: int | None = None,
-    chunk_size: int | None = None,
-) -> Iterator[Request]: ...
-
-
-def get_cursor_iterator(
-    callback: Callable[..., ListOfKeys] | Callable[..., ListOfRequests],
-    *,
-    cursor: str | None = None,
-    limit: int | None = None,
-    chunk_size: int | None = None,
-) -> Iterator[Request] | Iterator[KeyValueStoreKey]:
+) -> Iterator[T]:
     """Yield individual items from cursor-paginated API responses.
 
-    Each page is expected to expose `items` and `next_<cursor_param>`; iteration ends when a
-    page returns no items, the next cursor is `None`, or the user-requested `limit` is reached.
+    Each page is expected to expose `items`; iteration ends when a page returns no items, the cursor extracted by
+    `next_cursor` is `None`, or the user-requested `limit` is reached.
 
     Args:
-        callback: Function returning a single page of items. Receives the cursor as a kwarg
-            named after `cursor_param` and a `limit` kwarg.
-        cursor_param: Name of the cursor query-parameter (e.g. `cursor` or `exclusive_start_key`).
+        callback: Function returning a single page of items. Receives `cursor` and `limit` kwargs.
+        next_cursor: Callable that extracts the next-page cursor from the returned page (e.g. `lambda p: p.next_cursor`)
+            and returns `None` when there are no more pages.
         cursor: Value of the cursor for the first request, or `None` to start from the beginning.
         limit: Maximum total number of items to yield across all pages.
         chunk_size: Maximum number of items requested per API call.
@@ -150,51 +110,26 @@ def get_cursor_iterator(
 
     while True:
         current_page = callback(
-            limit=effective_chunk
-            if not initial_limit
-            else _min_for_limit_param(initial_limit - fetched_items, effective_chunk),
+            limit=_next_page_limit(initial_limit, fetched_items, effective_chunk),
             cursor=cursor,
         )
         yield from current_page.items
 
-        fetched_items += getattr(current_page, 'count', len(current_page.items))
-
-        if isinstance(current_page, ListOfKeys):
-            cursor = current_page.next_exclusive_start_key
-        elif isinstance(current_page, ListOfRequests):
-            cursor = current_page.next_cursor
-        else:
-            raise TypeError('Unsupported page type returned by callback; expected ListOfKeys or ListOfRequests.')
+        fetched_items += max(getattr(current_page, 'count', 0), len(current_page.items))
+        cursor = next_cursor(current_page)
 
         if not current_page.items or cursor is None or (initial_limit and fetched_items >= initial_limit):
             break
 
 
-@overload
-def get_cursor_iterator_async(
-    callback: Callable[..., Awaitable[ListOfKeys]],
-    *,
-    cursor: str | None = None,
-    limit: int | None = None,
-    chunk_size: int | None = None,
-) -> AsyncIterator[KeyValueStoreKey]: ...
-@overload
-def get_cursor_iterator_async(
-    callback: Callable[..., Awaitable[ListOfRequests]],
-    *,
-    cursor: str | None = None,
-    limit: int | None = None,
-    chunk_size: int | None = None,
-) -> AsyncIterator[Request]: ...
-
-
 async def get_cursor_iterator_async(
-    callback: Callable[..., Awaitable[ListOfKeys]] | Callable[..., Awaitable[ListOfRequests]],
+    callback: Callable[..., Awaitable[HasItems[T]]],
     *,
+    next_cursor: Callable[[Any], str | None],
     cursor: str | None = None,
     limit: int | None = None,
     chunk_size: int | None = None,
-) -> AsyncIterator[KeyValueStoreKey] | AsyncIterator[Request]:
+) -> AsyncIterator[T]:
     """Async variant of :func:`get_cursor_iterator`."""
     effective_chunk = chunk_size or 0
     initial_limit = limit or 0
@@ -202,22 +137,28 @@ async def get_cursor_iterator_async(
 
     while True:
         current_page = await callback(
-            limit=effective_chunk
-            if not initial_limit
-            else _min_for_limit_param(initial_limit - fetched_items, effective_chunk),
+            limit=_next_page_limit(initial_limit, fetched_items, effective_chunk),
             cursor=cursor,
         )
         for item in current_page.items:
             yield item
 
-        fetched_items += getattr(current_page, 'count', len(current_page.items))
-
-        if isinstance(current_page, ListOfKeys):
-            cursor = current_page.next_exclusive_start_key
-        elif isinstance(current_page, ListOfRequests):
-            cursor = current_page.next_cursor
-        else:
-            raise TypeError('Unsupported page type returned by callback; expected ListOfKeys or ListOfRequests.')
+        fetched_items += max(getattr(current_page, 'count', 0), len(current_page.items))
+        cursor = next_cursor(current_page)
 
         if not current_page.items or cursor is None or (initial_limit and fetched_items >= initial_limit):
             break
+
+
+def _next_page_limit(initial_limit: int, fetched_items: int, effective_chunk: int) -> int:
+    """Compute the `limit` value for the next API call.
+
+    `0` means no limit on the wire (matches the Apify API contract). When both an overall `initial_limit` and a per-page
+    `effective_chunk` are set, the call is clamped to whichever is smaller; if either is unset (`0`), the other wins.
+    """
+    if not initial_limit:
+        return effective_chunk
+    remaining = initial_limit - fetched_items
+    if not effective_chunk:
+        return remaining
+    return min(remaining, effective_chunk)

--- a/src/apify_client/_pagination.py
+++ b/src/apify_client/_pagination.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, TypeVar, overload
+
+from apify_client._models import KeyValueStoreKey, ListOfKeys, ListOfRequests, Request
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
+
+T = TypeVar('T')
+
+
+class HasItems(Protocol[T]):
+    items: list[T]
+
+
+def _min_for_limit_param(a: int | None, b: int | None) -> int | None:
+    """Return minimum of two limit parameters, treating `None` or `0` as infinity.
+
+    The Apify API treats `0` as no limit for the `limit` parameter, so `0` here means infinity.
+    Returns `None` when both inputs represent infinity.
+    """
+    if a == 0:
+        a = None
+    if b == 0:
+        b = None
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return min(a, b)
+
+
+def get_items_iterator(
+    callback: Callable[..., HasItems[T]],
+    *,
+    limit: int | None = None,
+    offset: int | None = None,
+    chunk_size: int | None = None,
+) -> Iterator[T]:
+    """Yield individual items from offset-based paginated API responses.
+
+    The `callback` is invoked lazily to fetch each page from the API. It must accept `limit` and
+    `offset` keyword arguments and return an object whose `items` attribute is a list. If the
+    object also exposes a `count` attribute, it is used for offset bookkeeping (the Apify API's
+    `count` reflects items scanned, which can exceed items returned when filters are applied).
+
+    Iteration stops when a page returns no items or when the user-requested `limit` is reached.
+    The `total` field is intentionally not consulted, because it can change between calls.
+
+    Args:
+        callback: Function returning a single page of items.
+        limit: Maximum total number of items to yield across all pages. `None` or `0` means no limit.
+        offset: Starting offset for the first page.
+        chunk_size: Maximum number of items requested per API call. `None` or `0` lets the API decide.
+    """
+    effective_chunk = chunk_size or 0
+    initial_offset = offset or 0
+    initial_limit = limit or 0
+    fetched_items = 0
+
+    while True:
+        current_page = callback(
+            limit=effective_chunk
+            if not initial_limit
+            else _min_for_limit_param(initial_limit - fetched_items, effective_chunk),
+            offset=initial_offset + fetched_items,
+        )
+        yield from current_page.items
+
+        fetched_items += getattr(current_page, 'count', len(current_page.items))
+
+        if not current_page.items or (initial_limit and fetched_items >= initial_limit):
+            break
+
+
+async def get_items_iterator_async(
+    callback: Callable[..., Awaitable[HasItems[T]]],
+    *,
+    limit: int | None = None,
+    offset: int | None = None,
+    chunk_size: int | None = None,
+) -> AsyncIterator[T]:
+    """Async variant of :func:`get_items_iterator`.
+
+    The `callback` must be an awaitable returning a single page of items.
+    """
+    effective_chunk = chunk_size or 0
+    initial_offset = offset or 0
+    initial_limit = limit or 0
+    fetched_items = 0
+
+    while True:
+        current_page = await callback(
+            limit=effective_chunk
+            if not initial_limit
+            else _min_for_limit_param(initial_limit - fetched_items, effective_chunk),
+            offset=initial_offset + fetched_items,
+        )
+        for item in current_page.items:
+            yield item
+
+        fetched_items += getattr(current_page, 'count', len(current_page.items))
+
+        if not current_page.items or (initial_limit and fetched_items >= initial_limit):
+            break
+
+
+@overload
+def get_cursor_iterator(
+    callback: Callable[..., ListOfKeys],
+    *,
+    cursor: str | None = None,
+    limit: int | None = None,
+    chunk_size: int | None = None,
+) -> Iterator[KeyValueStoreKey]: ...
+@overload
+def get_cursor_iterator(
+    callback: Callable[..., ListOfRequests],
+    *,
+    cursor: str | None = None,
+    limit: int | None = None,
+    chunk_size: int | None = None,
+) -> Iterator[Request]: ...
+
+
+def get_cursor_iterator(
+    callback: Callable[..., ListOfKeys] | Callable[..., ListOfRequests],
+    *,
+    cursor: str | None = None,
+    limit: int | None = None,
+    chunk_size: int | None = None,
+) -> Iterator[Request] | Iterator[KeyValueStoreKey]:
+    """Yield individual items from cursor-paginated API responses.
+
+    Each page is expected to expose `items` and `next_<cursor_param>`; iteration ends when a
+    page returns no items, the next cursor is `None`, or the user-requested `limit` is reached.
+
+    Args:
+        callback: Function returning a single page of items. Receives the cursor as a kwarg
+            named after `cursor_param` and a `limit` kwarg.
+        cursor_param: Name of the cursor query-parameter (e.g. `cursor` or `exclusive_start_key`).
+        cursor: Value of the cursor for the first request, or `None` to start from the beginning.
+        limit: Maximum total number of items to yield across all pages.
+        chunk_size: Maximum number of items requested per API call.
+    """
+    effective_chunk = chunk_size or 0
+    initial_limit = limit or 0
+    fetched_items = 0
+
+    while True:
+        current_page = callback(
+            limit=effective_chunk
+            if not initial_limit
+            else _min_for_limit_param(initial_limit - fetched_items, effective_chunk),
+            cursor=cursor,
+        )
+        yield from current_page.items
+
+        fetched_items += getattr(current_page, 'count', len(current_page.items))
+
+        if isinstance(current_page, ListOfKeys):
+            cursor = current_page.next_exclusive_start_key
+        elif isinstance(current_page, ListOfRequests):
+            cursor = current_page.next_cursor
+        else:
+            raise TypeError('Unsupported page type returned by callback; expected ListOfKeys or ListOfRequests.')
+
+        if not current_page.items or cursor is None or (initial_limit and fetched_items >= initial_limit):
+            break
+
+
+@overload
+def get_cursor_iterator_async(
+    callback: Callable[..., Awaitable[ListOfKeys]],
+    *,
+    cursor: str | None = None,
+    limit: int | None = None,
+    chunk_size: int | None = None,
+) -> AsyncIterator[KeyValueStoreKey]: ...
+@overload
+def get_cursor_iterator_async(
+    callback: Callable[..., Awaitable[ListOfRequests]],
+    *,
+    cursor: str | None = None,
+    limit: int | None = None,
+    chunk_size: int | None = None,
+) -> AsyncIterator[Request]: ...
+
+
+async def get_cursor_iterator_async(
+    callback: Callable[..., Awaitable[ListOfKeys]] | Callable[..., Awaitable[ListOfRequests]],
+    *,
+    cursor: str | None = None,
+    limit: int | None = None,
+    chunk_size: int | None = None,
+) -> AsyncIterator[KeyValueStoreKey] | AsyncIterator[Request]:
+    """Async variant of :func:`get_cursor_iterator`."""
+    effective_chunk = chunk_size or 0
+    initial_limit = limit or 0
+    fetched_items = 0
+
+    while True:
+        current_page = await callback(
+            limit=effective_chunk
+            if not initial_limit
+            else _min_for_limit_param(initial_limit - fetched_items, effective_chunk),
+            cursor=cursor,
+        )
+        for item in current_page.items:
+            yield item
+
+        fetched_items += getattr(current_page, 'count', len(current_page.items))
+
+        if isinstance(current_page, ListOfKeys):
+            cursor = current_page.next_exclusive_start_key
+        elif isinstance(current_page, ListOfRequests):
+            cursor = current_page.next_cursor
+        else:
+            raise TypeError('Unsupported page type returned by callback; expected ListOfKeys or ListOfRequests.')
+
+        if not current_page.items or cursor is None or (initial_limit and fetched_items >= initial_limit):
+            break

--- a/src/apify_client/_resource_clients/actor_collection.py
+++ b/src/apify_client/_resource_clients/actor_collection.py
@@ -13,12 +13,15 @@ from apify_client._models import (
     ListOfActors,
     ListOfActorsResponse,
 )
+from apify_client._pagination import get_items_iterator, get_items_iterator_async
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 from apify_client._utils import to_seconds
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
     from datetime import timedelta
 
+    from apify_client._models import ActorShort
     from apify_client._types import Timeout
 
 
@@ -68,6 +71,40 @@ class ActorCollectionClient(ResourceClient):
         """
         result = self._list(timeout=timeout, my=my, limit=limit, offset=offset, desc=desc, sortBy=sort_by)
         return ListOfActorsResponse.model_validate(result).data
+
+    def iterate(
+        self,
+        *,
+        my: bool | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        desc: bool | None = None,
+        sort_by: Literal['createdAt', 'stats.lastRunStartedAt'] | None = 'createdAt',
+        timeout: Timeout = 'medium',
+    ) -> Iterator[ActorShort]:
+        """Iterate over the Actors the user has created or used.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2#/reference/actors/actor-collection/get-list-of-actors
+
+        Args:
+            my: If True, will return only Actors which the user has created themselves.
+            limit: How many Actors to list.
+            offset: What Actor to include as first when retrieving the list.
+            desc: Whether to sort the Actors in descending order based on their creation date.
+            sort_by: Field to sort the results by.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The Actors available to the user matching the specified filters.
+        """
+
+        def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfActors:
+            return self.list(my=my, limit=limit, offset=offset, desc=desc, sort_by=sort_by, timeout=timeout)
+
+        return get_items_iterator(_callback, limit=limit, offset=offset)
 
     def create(
         self,
@@ -213,6 +250,40 @@ class ActorCollectionClientAsync(ResourceClientAsync):
         """
         result = await self._list(timeout=timeout, my=my, limit=limit, offset=offset, desc=desc, sortBy=sort_by)
         return ListOfActorsResponse.model_validate(result).data
+
+    def iterate(
+        self,
+        *,
+        my: bool | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        desc: bool | None = None,
+        sort_by: Literal['createdAt', 'stats.lastRunStartedAt'] | None = 'createdAt',
+        timeout: Timeout = 'medium',
+    ) -> AsyncIterator[ActorShort]:
+        """Iterate over the Actors the user has created or used.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2#/reference/actors/actor-collection/get-list-of-actors
+
+        Args:
+            my: If True, will return only Actors which the user has created themselves.
+            limit: How many Actors to list.
+            offset: What Actor to include as first when retrieving the list.
+            desc: Whether to sort the Actors in descending order based on their creation date.
+            sort_by: Field to sort the results by.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The Actors available to the user matching the specified filters.
+        """
+
+        async def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfActors:
+            return await self.list(my=my, limit=limit, offset=offset, desc=desc, sort_by=sort_by, timeout=timeout)
+
+        return get_items_iterator_async(_callback, limit=limit, offset=offset)
 
     async def create(
         self,

--- a/src/apify_client/_resource_clients/actor_env_var_collection.py
+++ b/src/apify_client/_resource_clients/actor_env_var_collection.py
@@ -7,6 +7,8 @@ from apify_client._models import EnvVar, EnvVarResponse, ListOfEnvVars, ListOfEn
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
     from apify_client._types import Timeout
 
 
@@ -42,6 +44,13 @@ class ActorEnvVarCollectionClient(ResourceClient):
         """
         result = self._list(timeout=timeout)
         return ListOfEnvVarsResponse.model_validate(result).data
+
+    def iterate(self, *, timeout: Timeout = 'short') -> Iterator[EnvVar]:
+        """Iterate over the available Actor environment variables.
+
+        There is no possibility to control the pagination on this endpoint.
+        """
+        return iter(self.list(timeout=timeout).items)
 
     def create(
         self,
@@ -103,6 +112,14 @@ class ActorEnvVarCollectionClientAsync(ResourceClientAsync):
         """
         result = await self._list(timeout=timeout)
         return ListOfEnvVarsResponse.model_validate(result).data
+
+    async def iterate(self, *, timeout: Timeout = 'short') -> AsyncIterator[EnvVar]:
+        """Iterate over the available Actor environment variables.
+
+        There is no possibility to control the pagination on this endpoint.
+        """
+        for item in (await self.list(timeout=timeout)).items:
+            yield item
 
     async def create(
         self,

--- a/src/apify_client/_resource_clients/actor_env_var_collection.py
+++ b/src/apify_client/_resource_clients/actor_env_var_collection.py
@@ -48,7 +48,18 @@ class ActorEnvVarCollectionClient(ResourceClient):
     def iterate(self, *, timeout: Timeout = 'short') -> Iterator[EnvVar]:
         """Iterate over the available Actor environment variables.
 
-        There is no possibility to control the pagination on this endpoint.
+        The underlying API endpoint does not support pagination, so this method performs a single API call and yields
+        the items from its response. If the endpoint returns more items than fit in one response (the API caps the page
+        size), the rest are not returned. In practice this is rarely a concern — Actors are not expected to define more
+        environment variables than the cap.
+
+        https://docs.apify.com/api/v2#/reference/actors/environment-variable-collection/get-list-of-environment-variables
+
+        Args:
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            An Actor environment variable.
         """
         return iter(self.list(timeout=timeout).items)
 
@@ -116,7 +127,18 @@ class ActorEnvVarCollectionClientAsync(ResourceClientAsync):
     async def iterate(self, *, timeout: Timeout = 'short') -> AsyncIterator[EnvVar]:
         """Iterate over the available Actor environment variables.
 
-        There is no possibility to control the pagination on this endpoint.
+        The underlying API endpoint does not support pagination, so this method performs a single API call and yields
+        the items from its response. If the endpoint returns more items than fit in one response (the API caps the page
+        size), the rest are not returned. In practice this is rarely a concern — Actors are not expected to define more
+        environment variables than the cap.
+
+        https://docs.apify.com/api/v2#/reference/actors/environment-variable-collection/get-list-of-environment-variables
+
+        Args:
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            An Actor environment variable.
         """
         for item in (await self.list(timeout=timeout)).items:
             yield item

--- a/src/apify_client/_resource_clients/actor_version_collection.py
+++ b/src/apify_client/_resource_clients/actor_version_collection.py
@@ -63,7 +63,18 @@ class ActorVersionCollectionClient(ResourceClient):
     def iterate(self, *, timeout: Timeout = 'short') -> Iterator[Version]:
         """Iterate over the available Actor versions.
 
-        There is no possibility to control the pagination on this endpoint.
+        The underlying API endpoint does not support pagination, so this method performs a single API call and yields
+        the items from its response. If the endpoint returns more items than fit in one response (the API caps the page
+        size), the rest are not returned. In practice this is rarely a concern — Actors are not expected to have more
+        versions than the cap.
+
+        https://docs.apify.com/api/v2#/reference/actors/version-collection/get-list-of-versions
+
+        Args:
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            An Actor version.
         """
         return iter(self.list(timeout=timeout).items)
 
@@ -157,7 +168,18 @@ class ActorVersionCollectionClientAsync(ResourceClientAsync):
     async def iterate(self, *, timeout: Timeout = 'short') -> AsyncIterator[Version]:
         """Iterate over the available Actor versions.
 
-        There is no possibility to control the pagination on this endpoint.
+        The underlying API endpoint does not support pagination, so this method performs a single API call and yields
+        the items from its response. If the endpoint returns more items than fit in one response (the API caps the page
+        size), the rest are not returned. In practice this is rarely a concern — Actors are not expected to have more
+        versions than the cap.
+
+        https://docs.apify.com/api/v2#/reference/actors/version-collection/get-list-of-versions
+
+        Args:
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            An Actor version.
         """
         for item in (await self.list(timeout=timeout)).items:
             yield item

--- a/src/apify_client/_resource_clients/actor_version_collection.py
+++ b/src/apify_client/_resource_clients/actor_version_collection.py
@@ -18,6 +18,8 @@ from apify_client._models import (
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
     from apify_client._literals import VersionSourceType
     from apify_client._types import Timeout
 
@@ -47,6 +49,8 @@ class ActorVersionCollectionClient(ResourceClient):
     def list(self, *, timeout: Timeout = 'short') -> ListOfVersions:
         """List the available Actor versions.
 
+        The returned page also supports iteration: `for item in client.list()` yields individual versions.
+
         https://docs.apify.com/api/v2#/reference/actors/version-collection/get-list-of-versions
 
         Args:
@@ -57,6 +61,13 @@ class ActorVersionCollectionClient(ResourceClient):
         """
         result = self._list(timeout=timeout)
         return ListOfVersionsResponse.model_validate(result).data
+
+    def iterate(self, *, timeout: Timeout = 'short') -> Iterator[Version]:
+        """Iterate over the available Actor environment variables.
+
+        There is no possibility to control the pagination on this endpoint.
+        """
+        return iter(self.list(timeout=timeout).items)
 
     def create(
         self,
@@ -134,6 +145,8 @@ class ActorVersionCollectionClientAsync(ResourceClientAsync):
     async def list(self, *, timeout: Timeout = 'short') -> ListOfVersions:
         """List the available Actor versions.
 
+        The returned page also supports iteration: `async for item in client.list()` yields individual versions.
+
         https://docs.apify.com/api/v2#/reference/actors/version-collection/get-list-of-versions
 
         Args:
@@ -144,6 +157,14 @@ class ActorVersionCollectionClientAsync(ResourceClientAsync):
         """
         result = await self._list(timeout=timeout)
         return ListOfVersionsResponse.model_validate(result).data
+
+    async def iterate(self, *, timeout: Timeout = 'short') -> AsyncIterator[Version]:
+        """Iterate over the available Actor environment variables.
+
+        There is no possibility to control the pagination on this endpoint.
+        """
+        for item in (await self.list(timeout=timeout)).items:
+            yield item
 
     async def create(
         self,

--- a/src/apify_client/_resource_clients/actor_version_collection.py
+++ b/src/apify_client/_resource_clients/actor_version_collection.py
@@ -49,8 +49,6 @@ class ActorVersionCollectionClient(ResourceClient):
     def list(self, *, timeout: Timeout = 'short') -> ListOfVersions:
         """List the available Actor versions.
 
-        The returned page also supports iteration: `for item in client.list()` yields individual versions.
-
         https://docs.apify.com/api/v2#/reference/actors/version-collection/get-list-of-versions
 
         Args:
@@ -63,7 +61,7 @@ class ActorVersionCollectionClient(ResourceClient):
         return ListOfVersionsResponse.model_validate(result).data
 
     def iterate(self, *, timeout: Timeout = 'short') -> Iterator[Version]:
-        """Iterate over the available Actor environment variables.
+        """Iterate over the available Actor versions.
 
         There is no possibility to control the pagination on this endpoint.
         """
@@ -145,8 +143,6 @@ class ActorVersionCollectionClientAsync(ResourceClientAsync):
     async def list(self, *, timeout: Timeout = 'short') -> ListOfVersions:
         """List the available Actor versions.
 
-        The returned page also supports iteration: `async for item in client.list()` yields individual versions.
-
         https://docs.apify.com/api/v2#/reference/actors/version-collection/get-list-of-versions
 
         Args:
@@ -159,7 +155,7 @@ class ActorVersionCollectionClientAsync(ResourceClientAsync):
         return ListOfVersionsResponse.model_validate(result).data
 
     async def iterate(self, *, timeout: Timeout = 'short') -> AsyncIterator[Version]:
-        """Iterate over the available Actor environment variables.
+        """Iterate over the available Actor versions.
 
         There is no possibility to control the pagination on this endpoint.
         """

--- a/src/apify_client/_resource_clients/build_collection.py
+++ b/src/apify_client/_resource_clients/build_collection.py
@@ -4,9 +4,13 @@ from typing import TYPE_CHECKING, Any
 
 from apify_client._docs import docs_group
 from apify_client._models import ListOfBuilds, ListOfBuildsResponse
+from apify_client._pagination import get_items_iterator, get_items_iterator_async
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
+    from apify_client._models import BuildShort
     from apify_client._types import Timeout
 
 
@@ -57,6 +61,37 @@ class BuildCollectionClient(ResourceClient):
         result = self._list(timeout=timeout, limit=limit, offset=offset, desc=desc)
         return ListOfBuildsResponse.model_validate(result).data
 
+    def iterate(
+        self,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+        desc: bool | None = None,
+        timeout: Timeout = 'medium',
+    ) -> Iterator[BuildShort]:
+        """Iterate over all Actor builds.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2#/reference/actors/build-collection/get-list-of-builds
+        https://docs.apify.com/api/v2#/reference/actor-builds/build-collection/get-user-builds-list
+
+        Args:
+            limit: How many builds to retrieve.
+            offset: What build to include as first when retrieving the list.
+            desc: Whether to sort the builds in descending order based on their start date.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The Actor builds matching the specified filters.
+        """
+
+        def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfBuilds:
+            return self.list(limit=limit, offset=offset, desc=desc, timeout=timeout)
+
+        return get_items_iterator(_callback, limit=limit, offset=offset)
+
 
 @docs_group('Resource clients')
 class BuildCollectionClientAsync(ResourceClientAsync):
@@ -104,3 +139,34 @@ class BuildCollectionClientAsync(ResourceClientAsync):
         """
         result = await self._list(timeout=timeout, limit=limit, offset=offset, desc=desc)
         return ListOfBuildsResponse.model_validate(result).data
+
+    def iterate(
+        self,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+        desc: bool | None = None,
+        timeout: Timeout = 'medium',
+    ) -> AsyncIterator[BuildShort]:
+        """Iterate over all Actor builds.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2#/reference/actors/build-collection/get-list-of-builds
+        https://docs.apify.com/api/v2#/reference/actor-builds/build-collection/get-user-builds-list
+
+        Args:
+            limit: How many builds to retrieve.
+            offset: What build to include as first when retrieving the list.
+            desc: Whether to sort the builds in descending order based on their start date.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The Actor builds matching the specified filters.
+        """
+
+        async def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfBuilds:
+            return await self.list(limit=limit, offset=offset, desc=desc, timeout=timeout)
+
+        return get_items_iterator_async(_callback, limit=limit, offset=offset)

--- a/src/apify_client/_resource_clients/dataset.py
+++ b/src/apify_client/_resource_clients/dataset.py
@@ -8,6 +8,7 @@ from urllib.parse import urlencode, urlparse, urlunparse
 
 from apify_client._docs import docs_group
 from apify_client._models import Dataset, DatasetResponse, DatasetStatistics, DatasetStatisticsResponse
+from apify_client._pagination import get_items_iterator, get_items_iterator_async
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 from apify_client._utils import (
     create_storage_content_signature,
@@ -208,8 +209,9 @@ class DatasetClient(ResourceClient):
             items=items,
             total=int(response.headers['x-apify-pagination-total']),
             offset=int(response.headers['x-apify-pagination-offset']),
-            # x-apify-pagination-count returns invalid values when hidden/empty items are skipped
-            count=len(items),
+            # x-apify-pagination-count returns count of processed items, not count of returned items
+            # This makes difference when items were filtered using hidden/empty
+            count=max(int(response.headers['x-apify-pagination-count']), len(items)),
             # API returns 999999999999 when no limit is used
             limit=int(response.headers['x-apify-pagination-limit']),
             desc=response.headers['x-apify-pagination-desc'].lower() == 'true',
@@ -218,7 +220,7 @@ class DatasetClient(ResourceClient):
     def iterate_items(
         self,
         *,
-        offset: int = 0,
+        offset: int | None = None,
         limit: int | None = None,
         clean: bool | None = None,
         desc: bool | None = None,
@@ -228,9 +230,13 @@ class DatasetClient(ResourceClient):
         skip_empty: bool | None = None,
         skip_hidden: bool | None = None,
         signature: str | None = None,
+        chunk_size: int | None = None,
         timeout: Timeout = 'long',
     ) -> Iterator[dict]:
         """Iterate over the items in the dataset.
+
+        Simple `list_items` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
 
         https://docs.apify.com/api/v2#/reference/datasets/item-collection/get-items
 
@@ -259,29 +265,17 @@ class DatasetClient(ResourceClient):
             skip_hidden: If True, then hidden fields are skipped from the output, i.e. fields starting with
                 the # character.
             signature: Signature used to access the items.
+            chunk_size: Maximum number of items requested per API call when iterating across pages.
             timeout: Timeout for the API HTTP request.
 
         Yields:
             An item from the dataset.
         """
-        cache_size = 1000
 
-        should_finish = False
-        read_items = 0
-
-        # We can't rely on DatasetItemsPage.total because that is updated with a delay,
-        # so if you try to read the dataset items right after a run finishes, you could miss some.
-        # Instead, we just read and read until we reach the limit, or until there are no more items to read.
-        while not should_finish:
-            effective_limit = cache_size
-            if limit is not None:
-                if read_items == limit:
-                    break
-                effective_limit = min(cache_size, limit - read_items)
-
-            current_items_page = self.list_items(
-                offset=offset + read_items,
-                limit=effective_limit,
+        def _callback(*, limit: int | None = None, offset: int | None = None) -> DatasetItemsPage:
+            return self.list_items(
+                offset=offset,
+                limit=limit,
                 clean=clean,
                 desc=desc,
                 fields=fields,
@@ -293,13 +287,8 @@ class DatasetClient(ResourceClient):
                 timeout=timeout,
             )
 
-            yield from current_items_page.items
-
-            current_page_item_count = len(current_items_page.items)
-            read_items += current_page_item_count
-
-            if current_page_item_count < cache_size:
-                should_finish = True
+        # Default chunk size of 1000 keeps backwards compatibility with the previous fixed cache size.
+        return get_items_iterator(_callback, limit=limit, offset=offset, chunk_size=chunk_size or 1000)
 
     def download_items(
         self,
@@ -883,17 +872,18 @@ class DatasetClientAsync(ResourceClientAsync):
             items=items,
             total=int(response.headers['x-apify-pagination-total']),
             offset=int(response.headers['x-apify-pagination-offset']),
-            # x-apify-pagination-count returns invalid values when hidden/empty items are skipped
-            count=len(items),
+            # x-apify-pagination-count returns count of processed items, not count of returned items
+            # This makes difference when items were filtered using hidden/empty
+            count=max(int(response.headers['x-apify-pagination-count']), len(items)),
             # API returns 999999999999 when no limit is used
             limit=int(response.headers['x-apify-pagination-limit']),
             desc=response.headers['x-apify-pagination-desc'].lower() == 'true',
         )
 
-    async def iterate_items(
+    def iterate_items(
         self,
         *,
-        offset: int = 0,
+        offset: int | None = None,
         limit: int | None = None,
         clean: bool | None = None,
         desc: bool | None = None,
@@ -903,9 +893,13 @@ class DatasetClientAsync(ResourceClientAsync):
         skip_empty: bool | None = None,
         skip_hidden: bool | None = None,
         signature: str | None = None,
+        chunk_size: int | None = None,
         timeout: Timeout = 'long',
     ) -> AsyncIterator[dict]:
         """Iterate over the items in the dataset.
+
+        Simple `list_items` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
 
         https://docs.apify.com/api/v2#/reference/datasets/item-collection/get-items
 
@@ -934,29 +928,17 @@ class DatasetClientAsync(ResourceClientAsync):
             skip_hidden: If True, then hidden fields are skipped from the output, i.e. fields starting with
                 the # character.
             signature: Signature used to access the items.
+            chunk_size: Maximum number of items requested per API call when iterating across pages.
             timeout: Timeout for the API HTTP request.
 
         Yields:
             An item from the dataset.
         """
-        cache_size = 1000
 
-        should_finish = False
-        read_items = 0
-
-        # We can't rely on DatasetItemsPage.total because that is updated with a delay,
-        # so if you try to read the dataset items right after a run finishes, you could miss some.
-        # Instead, we just read and read until we reach the limit, or until there are no more items to read.
-        while not should_finish:
-            effective_limit = cache_size
-            if limit is not None:
-                if read_items == limit:
-                    break
-                effective_limit = min(cache_size, limit - read_items)
-
-            current_items_page = await self.list_items(
-                offset=offset + read_items,
-                limit=effective_limit,
+        async def _callback(*, limit: int | None = None, offset: int | None = None) -> DatasetItemsPage:
+            return await self.list_items(
+                offset=offset,
+                limit=limit,
                 clean=clean,
                 desc=desc,
                 fields=fields,
@@ -968,14 +950,7 @@ class DatasetClientAsync(ResourceClientAsync):
                 timeout=timeout,
             )
 
-            for item in current_items_page.items:
-                yield item
-
-            current_page_item_count = len(current_items_page.items)
-            read_items += current_page_item_count
-
-            if current_page_item_count < cache_size:
-                should_finish = True
+        return get_items_iterator_async(_callback, limit=limit, offset=offset, chunk_size=chunk_size or 1000)
 
     async def get_items_as_bytes(
         self,

--- a/src/apify_client/_resource_clients/dataset.py
+++ b/src/apify_client/_resource_clients/dataset.py
@@ -8,7 +8,7 @@ from urllib.parse import urlencode, urlparse, urlunparse
 
 from apify_client._docs import docs_group
 from apify_client._models import Dataset, DatasetResponse, DatasetStatistics, DatasetStatisticsResponse
-from apify_client._pagination import get_items_iterator, get_items_iterator_async
+from apify_client._pagination import DEFAULT_CHUNK_SIZE, get_items_iterator, get_items_iterator_async
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 from apify_client._utils import (
     create_storage_content_signature,
@@ -287,8 +287,7 @@ class DatasetClient(ResourceClient):
                 timeout=timeout,
             )
 
-        # Default chunk size of 1000 keeps backwards compatibility with the previous fixed cache size.
-        return get_items_iterator(_callback, limit=limit, offset=offset, chunk_size=chunk_size or 1000)
+        return get_items_iterator(_callback, limit=limit, offset=offset, chunk_size=chunk_size or DEFAULT_CHUNK_SIZE)
 
     def download_items(
         self,
@@ -950,7 +949,9 @@ class DatasetClientAsync(ResourceClientAsync):
                 timeout=timeout,
             )
 
-        return get_items_iterator_async(_callback, limit=limit, offset=offset, chunk_size=chunk_size or 1000)
+        return get_items_iterator_async(
+            _callback, limit=limit, offset=offset, chunk_size=chunk_size or DEFAULT_CHUNK_SIZE
+        )
 
     async def get_items_as_bytes(
         self,

--- a/src/apify_client/_resource_clients/dataset_collection.py
+++ b/src/apify_client/_resource_clients/dataset_collection.py
@@ -9,10 +9,14 @@ from apify_client._models import (
     ListOfDatasets,
     ListOfDatasetsResponse,
 )
+from apify_client._pagination import get_items_iterator, get_items_iterator_async
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
     from apify_client._literals import StorageOwnership
+    from apify_client._models import DatasetListItem
     from apify_client._types import Timeout
 
 
@@ -70,6 +74,43 @@ class DatasetCollectionClient(ResourceClient):
             ownership=ownership,
         )
         return ListOfDatasetsResponse.model_validate(result).data
+
+    def iterate(
+        self,
+        *,
+        unnamed: bool | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        desc: bool | None = None,
+        ownership: StorageOwnership | None = None,
+        timeout: Timeout = 'medium',
+    ) -> Iterator[DatasetListItem]:
+        """Iterate over the available datasets.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2#/reference/datasets/dataset-collection/get-list-of-datasets
+
+        Args:
+            unnamed: Whether to include unnamed datasets in the list.
+            limit: How many datasets to retrieve.
+            offset: What dataset to include as first when retrieving the list.
+            desc: Whether to sort the datasets in descending order based on their modification date.
+            ownership: Filter by ownership. 'ownedByMe' returns only user's own datasets,
+                'sharedWithMe' returns only datasets shared with the user.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The available datasets matching the specified filters.
+        """
+
+        def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfDatasets:
+            return self.list(
+                unnamed=unnamed, limit=limit, offset=offset, desc=desc, ownership=ownership, timeout=timeout
+            )
+
+        return get_items_iterator(_callback, limit=limit, offset=offset)
 
     def get_or_create(
         self,
@@ -148,6 +189,43 @@ class DatasetCollectionClientAsync(ResourceClientAsync):
             ownership=ownership,
         )
         return ListOfDatasetsResponse.model_validate(result).data
+
+    def iterate(
+        self,
+        *,
+        unnamed: bool | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        desc: bool | None = None,
+        ownership: StorageOwnership | None = None,
+        timeout: Timeout = 'medium',
+    ) -> AsyncIterator[DatasetListItem]:
+        """Iterate over the available datasets.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2#/reference/datasets/dataset-collection/get-list-of-datasets
+
+        Args:
+            unnamed: Whether to include unnamed datasets in the list.
+            limit: How many datasets to retrieve.
+            offset: What dataset to include as first when retrieving the list.
+            desc: Whether to sort the datasets in descending order based on their modification date.
+            ownership: Filter by ownership. 'ownedByMe' returns only user's own datasets,
+                'sharedWithMe' returns only datasets shared with the user.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The available datasets matching the specified filters.
+        """
+
+        async def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfDatasets:
+            return await self.list(
+                unnamed=unnamed, limit=limit, offset=offset, desc=desc, ownership=ownership, timeout=timeout
+            )
+
+        return get_items_iterator_async(_callback, limit=limit, offset=offset)
 
     async def get_or_create(
         self,

--- a/src/apify_client/_resource_clients/key_value_store.py
+++ b/src/apify_client/_resource_clients/key_value_store.py
@@ -223,7 +223,6 @@ class KeyValueStoreClient(ResourceClient):
 
         return get_cursor_iterator(
             _callback,
-            next_cursor=lambda page: page.next_exclusive_start_key,
             cursor=exclusive_start_key,
             limit=limit,
             chunk_size=chunk_size or DEFAULT_CHUNK_SIZE,
@@ -650,7 +649,6 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
 
         return get_cursor_iterator_async(
             _callback,
-            next_cursor=lambda page: page.next_exclusive_start_key,
             cursor=exclusive_start_key,
             limit=limit,
             chunk_size=chunk_size or DEFAULT_CHUNK_SIZE,

--- a/src/apify_client/_resource_clients/key_value_store.py
+++ b/src/apify_client/_resource_clients/key_value_store.py
@@ -14,7 +14,7 @@ from apify_client._models import (
     ListOfKeys,
     ListOfKeysResponse,
 )
-from apify_client._pagination import get_cursor_iterator, get_cursor_iterator_async
+from apify_client._pagination import DEFAULT_CHUNK_SIZE, get_cursor_iterator, get_cursor_iterator_async
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 from apify_client._utils import (
     catch_not_found_or_throw,
@@ -226,7 +226,7 @@ class KeyValueStoreClient(ResourceClient):
             next_cursor=lambda page: page.next_exclusive_start_key,
             cursor=exclusive_start_key,
             limit=limit,
-            chunk_size=chunk_size or 1000,
+            chunk_size=chunk_size or DEFAULT_CHUNK_SIZE,
         )
 
     def get_record(self, key: str, *, signature: str | None = None, timeout: Timeout = 'long') -> dict | None:
@@ -653,7 +653,7 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
             next_cursor=lambda page: page.next_exclusive_start_key,
             cursor=exclusive_start_key,
             limit=limit,
-            chunk_size=chunk_size or 1000,
+            chunk_size=chunk_size or DEFAULT_CHUNK_SIZE,
         )
 
     async def get_record(self, key: str, *, signature: str | None = None, timeout: Timeout = 'long') -> dict | None:

--- a/src/apify_client/_resource_clients/key_value_store.py
+++ b/src/apify_client/_resource_clients/key_value_store.py
@@ -223,6 +223,7 @@ class KeyValueStoreClient(ResourceClient):
 
         return get_cursor_iterator(
             _callback,
+            next_cursor=lambda page: page.next_exclusive_start_key,
             cursor=exclusive_start_key,
             limit=limit,
             chunk_size=chunk_size or 1000,
@@ -649,6 +650,7 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
 
         return get_cursor_iterator_async(
             _callback,
+            next_cursor=lambda page: page.next_exclusive_start_key,
             cursor=exclusive_start_key,
             limit=limit,
             chunk_size=chunk_size or 1000,

--- a/src/apify_client/_resource_clients/key_value_store.py
+++ b/src/apify_client/_resource_clients/key_value_store.py
@@ -14,6 +14,7 @@ from apify_client._models import (
     ListOfKeys,
     ListOfKeysResponse,
 )
+from apify_client._pagination import get_cursor_iterator, get_cursor_iterator_async
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 from apify_client._utils import (
     catch_not_found_or_throw,
@@ -183,53 +184,49 @@ class KeyValueStoreClient(ResourceClient):
         self,
         *,
         limit: int | None = None,
+        exclusive_start_key: str | None = None,
         collection: str | None = None,
         prefix: str | None = None,
         signature: str | None = None,
+        chunk_size: int | None = None,
         timeout: Timeout = 'long',
     ) -> Iterator[KeyValueStoreKey]:
         """Iterate over the keys in the key-value store.
+
+        Simple `list_keys` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
 
         https://docs.apify.com/api/v2#/reference/key-value-stores/key-collection/get-list-of-keys
 
         Args:
             limit: Maximum number of keys to return. By default there is no limit.
+            exclusive_start_key: All keys up to this one (including) are skipped from the result.
             collection: The name of the collection in store schema to list keys from.
             prefix: The prefix of the keys to be listed.
             signature: Signature used to access the items.
+            chunk_size: Maximum number of keys requested per API call when iterating across pages.
             timeout: Timeout for the API HTTP request.
 
         Yields:
             A key from the key-value store.
         """
-        cache_size = 1000
-        read_keys = 0
-        exclusive_start_key: str | None = None
 
-        while True:
-            effective_limit = cache_size
-            if limit is not None:
-                if read_keys == limit:
-                    break
-                effective_limit = min(cache_size, limit - read_keys)
-
-            current_keys_page = self.list_keys(
-                limit=effective_limit,
-                exclusive_start_key=exclusive_start_key,
+        def _callback(*, cursor: str | None = None, limit: int | None = None) -> ListOfKeys:
+            return self.list_keys(
+                limit=limit,
+                exclusive_start_key=cursor,
                 collection=collection,
                 prefix=prefix,
                 signature=signature,
                 timeout=timeout,
             )
 
-            yield from current_keys_page.items
-
-            read_keys += len(current_keys_page.items)
-
-            if not current_keys_page.is_truncated:
-                break
-
-            exclusive_start_key = current_keys_page.next_exclusive_start_key
+        return get_cursor_iterator(
+            _callback,
+            cursor=exclusive_start_key,
+            limit=limit,
+            chunk_size=chunk_size or 1000,
+        )
 
     def get_record(self, key: str, *, signature: str | None = None, timeout: Timeout = 'long') -> dict | None:
         """Retrieve the given record from the key-value store.
@@ -609,58 +606,53 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
         result = response_to_dict(response)
         return ListOfKeysResponse.model_validate(result).data
 
-    async def iterate_keys(
+    def iterate_keys(
         self,
         *,
         limit: int | None = None,
+        exclusive_start_key: str | None = None,
         collection: str | None = None,
         prefix: str | None = None,
         signature: str | None = None,
+        chunk_size: int | None = None,
         timeout: Timeout = 'long',
     ) -> AsyncIterator[KeyValueStoreKey]:
         """Iterate over the keys in the key-value store.
+
+        Simple `list_keys` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
 
         https://docs.apify.com/api/v2#/reference/key-value-stores/key-collection/get-list-of-keys
 
         Args:
             limit: Maximum number of keys to return. By default there is no limit.
+            exclusive_start_key: All keys up to this one (including) are skipped from the result.
             collection: The name of the collection in store schema to list keys from.
             prefix: The prefix of the keys to be listed.
             signature: Signature used to access the items.
+            chunk_size: Maximum number of keys requested per API call when iterating across pages.
             timeout: Timeout for the API HTTP request.
 
         Yields:
             A key from the key-value store.
         """
-        cache_size = 1000
-        read_keys = 0
-        exclusive_start_key: str | None = None
 
-        while True:
-            effective_limit = cache_size
-            if limit is not None:
-                if read_keys == limit:
-                    break
-                effective_limit = min(cache_size, limit - read_keys)
-
-            current_keys_page = await self.list_keys(
-                limit=effective_limit,
-                exclusive_start_key=exclusive_start_key,
+        async def _callback(*, cursor: str | None = None, limit: int | None = None) -> ListOfKeys:
+            return await self.list_keys(
+                limit=limit,
+                exclusive_start_key=cursor,
                 collection=collection,
                 prefix=prefix,
                 signature=signature,
                 timeout=timeout,
             )
 
-            for key in current_keys_page.items:
-                yield key
-
-            read_keys += len(current_keys_page.items)
-
-            if not current_keys_page.is_truncated:
-                break
-
-            exclusive_start_key = current_keys_page.next_exclusive_start_key
+        return get_cursor_iterator_async(
+            _callback,
+            cursor=exclusive_start_key,
+            limit=limit,
+            chunk_size=chunk_size or 1000,
+        )
 
     async def get_record(self, key: str, *, signature: str | None = None, timeout: Timeout = 'long') -> dict | None:
         """Retrieve the given record from the key-value store.

--- a/src/apify_client/_resource_clients/key_value_store_collection.py
+++ b/src/apify_client/_resource_clients/key_value_store_collection.py
@@ -9,9 +9,12 @@ from apify_client._models import (
     ListOfKeyValueStores,
     ListOfKeyValueStoresResponse,
 )
+from apify_client._pagination import get_items_iterator, get_items_iterator_async
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
     from apify_client._literals import StorageOwnership
     from apify_client._types import Timeout
 
@@ -70,6 +73,43 @@ class KeyValueStoreCollectionClient(ResourceClient):
             ownership=ownership,
         )
         return ListOfKeyValueStoresResponse.model_validate(result).data
+
+    def iterate(
+        self,
+        *,
+        unnamed: bool | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        desc: bool | None = None,
+        ownership: StorageOwnership | None = None,
+        timeout: Timeout = 'medium',
+    ) -> Iterator[KeyValueStore]:
+        """Iterate over the available key-value stores.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2#/reference/key-value-stores/store-collection/get-list-of-key-value-stores
+
+        Args:
+            unnamed: Whether to include unnamed key-value stores in the list.
+            limit: How many key-value stores to retrieve.
+            offset: What key-value store to include as first when retrieving the list.
+            desc: Whether to sort the key-value stores in descending order based on their modification date.
+            ownership: Filter by ownership. 'ownedByMe' returns only user's own key-value stores,
+                'sharedWithMe' returns only key-value stores shared with the user.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The available key-value stores matching the specified filters.
+        """
+
+        def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfKeyValueStores:
+            return self.list(
+                unnamed=unnamed, limit=limit, offset=offset, desc=desc, ownership=ownership, timeout=timeout
+            )
+
+        return get_items_iterator(_callback, limit=limit, offset=offset)
 
     def get_or_create(
         self,
@@ -148,6 +188,43 @@ class KeyValueStoreCollectionClientAsync(ResourceClientAsync):
             ownership=ownership,
         )
         return ListOfKeyValueStoresResponse.model_validate(result).data
+
+    def iterate(
+        self,
+        *,
+        unnamed: bool | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        desc: bool | None = None,
+        ownership: StorageOwnership | None = None,
+        timeout: Timeout = 'medium',
+    ) -> AsyncIterator[KeyValueStore]:
+        """Iterate over the available key-value stores.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2#/reference/key-value-stores/store-collection/get-list-of-key-value-stores
+
+        Args:
+            unnamed: Whether to include unnamed key-value stores in the list.
+            limit: How many key-value stores to retrieve.
+            offset: What key-value store to include as first when retrieving the list.
+            desc: Whether to sort the key-value stores in descending order based on their modification date.
+            ownership: Filter by ownership. 'ownedByMe' returns only user's own key-value stores,
+                'sharedWithMe' returns only key-value stores shared with the user.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The available key-value stores matching the specified filters.
+        """
+
+        async def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfKeyValueStores:
+            return await self.list(
+                unnamed=unnamed, limit=limit, offset=offset, desc=desc, ownership=ownership, timeout=timeout
+            )
+
+        return get_items_iterator_async(_callback, limit=limit, offset=offset)
 
     async def get_or_create(
         self,

--- a/src/apify_client/_resource_clients/request_queue.py
+++ b/src/apify_client/_resource_clients/request_queue.py
@@ -561,7 +561,7 @@ class RequestQueueClient(ResourceClient):
 
         Simple `list_requests` does only one API call, possibly not listing all items matching the criteria.
         This method returns an iterator that is capable of making multiple API calls to retrieve all items
-        matching the criteria using the opaque ``cursor`` returned by the API.
+        matching the criteria using the opaque `cursor` returned by the API.
 
         https://docs.apify.com/api/v2#/reference/request-queues/request-collection/list-requests
 
@@ -581,9 +581,10 @@ class RequestQueueClient(ResourceClient):
 
         return get_cursor_iterator(
             _callback,
+            next_cursor=lambda page: page.next_cursor,
             cursor=cursor,
             limit=limit,
-            chunk_size=chunk_size,
+            chunk_size=chunk_size or 1000,
         )
 
     def unlock_requests(self: RequestQueueClient, *, timeout: Timeout = 'long') -> UnlockRequestsResult:
@@ -1173,7 +1174,7 @@ class RequestQueueClientAsync(ResourceClientAsync):
 
         Simple `list_requests` does only one API call, possibly not listing all items matching the criteria.
         This method returns an iterator that is capable of making multiple API calls to retrieve all items
-        matching the criteria using the opaque ``cursor`` returned by the API.
+        matching the criteria using the opaque `cursor` returned by the API.
 
         https://docs.apify.com/api/v2#/reference/request-queues/request-collection/list-requests
 
@@ -1193,9 +1194,10 @@ class RequestQueueClientAsync(ResourceClientAsync):
 
         return get_cursor_iterator_async(
             _callback,
+            next_cursor=lambda page: page.next_cursor,
             cursor=cursor,
             limit=limit,
-            chunk_size=chunk_size,
+            chunk_size=chunk_size or 1000,
         )
 
     async def unlock_requests(

--- a/src/apify_client/_resource_clients/request_queue.py
+++ b/src/apify_client/_resource_clients/request_queue.py
@@ -35,11 +35,13 @@ from apify_client._models import (
     UnlockRequestsResponse,
     UnlockRequestsResult,
 )
+from apify_client._pagination import get_cursor_iterator, get_cursor_iterator_async
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 from apify_client._utils import catch_not_found_or_throw, response_to_dict, to_seconds
 from apify_client.errors import ApifyApiError
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
     from datetime import timedelta
 
     from apify_client._literals import GeneralAccess
@@ -545,6 +547,44 @@ class RequestQueueClient(ResourceClient):
 
         result = response_to_dict(response)
         return ListOfRequestsResponse.model_validate(result).data
+
+    def iterate_requests(
+        self,
+        *,
+        limit: int | None = None,
+        filter: list[Literal['pending', 'locked']] | None = None,  # noqa: A002
+        cursor: str | None = None,
+        chunk_size: int | None = None,
+        timeout: Timeout = 'medium',
+    ) -> Iterator[Request]:
+        """Iterate over requests in the queue.
+
+        Simple `list_requests` does only one API call, possibly not listing all items matching the criteria.
+        This method returns an iterator that is capable of making multiple API calls to retrieve all items
+        matching the criteria using the opaque ``cursor`` returned by the API.
+
+        https://docs.apify.com/api/v2#/reference/request-queues/request-collection/list-requests
+
+        Args:
+            limit: Maximum number of requests to yield across all pages.
+            filter: List of request states to use as a filter. Multiple values mean union of the given filters.
+            cursor: A token returned in a previous API response, used as the initial pagination cursor.
+            chunk_size: Maximum number of requests requested per API call when iterating across pages.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            A request from the queue.
+        """
+
+        def _callback(*, cursor: str | None = None, limit: int | None = None) -> ListOfRequests:
+            return self.list_requests(limit=limit, filter=filter, cursor=cursor, timeout=timeout)
+
+        return get_cursor_iterator(
+            _callback,
+            cursor=cursor,
+            limit=limit,
+            chunk_size=chunk_size,
+        )
 
     def unlock_requests(self: RequestQueueClient, *, timeout: Timeout = 'long') -> UnlockRequestsResult:
         """Unlock all requests in the queue, which were locked by the same clientKey or from the same Actor run.
@@ -1119,6 +1159,44 @@ class RequestQueueClientAsync(ResourceClientAsync):
 
         result = response_to_dict(response)
         return ListOfRequestsResponse.model_validate(result).data
+
+    def iterate_requests(
+        self,
+        *,
+        limit: int | None = None,
+        filter: list[Literal['pending', 'locked']] | None = None,  # noqa: A002
+        cursor: str | None = None,
+        chunk_size: int | None = None,
+        timeout: Timeout = 'medium',
+    ) -> AsyncIterator[Request]:
+        """Iterate over requests in the queue.
+
+        Simple `list_requests` does only one API call, possibly not listing all items matching the criteria.
+        This method returns an iterator that is capable of making multiple API calls to retrieve all items
+        matching the criteria using the opaque ``cursor`` returned by the API.
+
+        https://docs.apify.com/api/v2#/reference/request-queues/request-collection/list-requests
+
+        Args:
+            limit: Maximum number of requests to yield across all pages.
+            filter: List of request states to use as a filter. Multiple values mean union of the given filters.
+            cursor: A token returned in a previous API response, used as the initial pagination cursor.
+            chunk_size: Maximum number of requests requested per API call when iterating across pages.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            A request from the queue.
+        """
+
+        async def _callback(*, cursor: str | None = None, limit: int | None = None) -> ListOfRequests:
+            return await self.list_requests(limit=limit, filter=filter, cursor=cursor, timeout=timeout)
+
+        return get_cursor_iterator_async(
+            _callback,
+            cursor=cursor,
+            limit=limit,
+            chunk_size=chunk_size,
+        )
 
     async def unlock_requests(
         self: RequestQueueClientAsync,

--- a/src/apify_client/_resource_clients/request_queue.py
+++ b/src/apify_client/_resource_clients/request_queue.py
@@ -35,7 +35,7 @@ from apify_client._models import (
     UnlockRequestsResponse,
     UnlockRequestsResult,
 )
-from apify_client._pagination import get_cursor_iterator, get_cursor_iterator_async
+from apify_client._pagination import DEFAULT_CHUNK_SIZE, get_cursor_iterator, get_cursor_iterator_async
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 from apify_client._utils import catch_not_found_or_throw, response_to_dict, to_seconds
 from apify_client.errors import ApifyApiError
@@ -584,7 +584,7 @@ class RequestQueueClient(ResourceClient):
             next_cursor=lambda page: page.next_cursor,
             cursor=cursor,
             limit=limit,
-            chunk_size=chunk_size or 1000,
+            chunk_size=chunk_size or DEFAULT_CHUNK_SIZE,
         )
 
     def unlock_requests(self: RequestQueueClient, *, timeout: Timeout = 'long') -> UnlockRequestsResult:
@@ -1197,7 +1197,7 @@ class RequestQueueClientAsync(ResourceClientAsync):
             next_cursor=lambda page: page.next_cursor,
             cursor=cursor,
             limit=limit,
-            chunk_size=chunk_size or 1000,
+            chunk_size=chunk_size or DEFAULT_CHUNK_SIZE,
         )
 
     async def unlock_requests(

--- a/src/apify_client/_resource_clients/request_queue.py
+++ b/src/apify_client/_resource_clients/request_queue.py
@@ -581,7 +581,6 @@ class RequestQueueClient(ResourceClient):
 
         return get_cursor_iterator(
             _callback,
-            next_cursor=lambda page: page.next_cursor,
             cursor=cursor,
             limit=limit,
             chunk_size=chunk_size or DEFAULT_CHUNK_SIZE,
@@ -1194,7 +1193,6 @@ class RequestQueueClientAsync(ResourceClientAsync):
 
         return get_cursor_iterator_async(
             _callback,
-            next_cursor=lambda page: page.next_cursor,
             cursor=cursor,
             limit=limit,
             chunk_size=chunk_size or DEFAULT_CHUNK_SIZE,

--- a/src/apify_client/_resource_clients/request_queue_collection.py
+++ b/src/apify_client/_resource_clients/request_queue_collection.py
@@ -9,10 +9,14 @@ from apify_client._models import (
     RequestQueue,
     RequestQueueResponse,
 )
+from apify_client._pagination import get_items_iterator, get_items_iterator_async
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
     from apify_client._literals import StorageOwnership
+    from apify_client._models import RequestQueueShort
     from apify_client._types import Timeout
 
 
@@ -70,6 +74,43 @@ class RequestQueueCollectionClient(ResourceClient):
             ownership=ownership,
         )
         return ListOfRequestQueuesResponse.model_validate(result).data
+
+    def iterate(
+        self,
+        *,
+        unnamed: bool | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        desc: bool | None = None,
+        ownership: StorageOwnership | None = None,
+        timeout: Timeout = 'medium',
+    ) -> Iterator[RequestQueueShort]:
+        """Iterate over the available request queues.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2#/reference/request-queues/queue-collection/get-list-of-request-queues
+
+        Args:
+            unnamed: Whether to include unnamed request queues in the list.
+            limit: How many request queues to retrieve.
+            offset: What request queue to include as first when retrieving the list.
+            desc: Whether to sort the request queues in descending order based on their modification date.
+            ownership: Filter by ownership. 'ownedByMe' returns only user's own request queues,
+                'sharedWithMe' returns only request queues shared with the user.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The available request queues matching the specified filters.
+        """
+
+        def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfRequestQueues:
+            return self.list(
+                unnamed=unnamed, limit=limit, offset=offset, desc=desc, ownership=ownership, timeout=timeout
+            )
+
+        return get_items_iterator(_callback, limit=limit, offset=offset)
 
     def get_or_create(
         self,
@@ -146,6 +187,43 @@ class RequestQueueCollectionClientAsync(ResourceClientAsync):
             ownership=ownership,
         )
         return ListOfRequestQueuesResponse.model_validate(result).data
+
+    def iterate(
+        self,
+        *,
+        unnamed: bool | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        desc: bool | None = None,
+        ownership: StorageOwnership | None = None,
+        timeout: Timeout = 'medium',
+    ) -> AsyncIterator[RequestQueueShort]:
+        """Iterate over the available request queues.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2#/reference/request-queues/queue-collection/get-list-of-request-queues
+
+        Args:
+            unnamed: Whether to include unnamed request queues in the list.
+            limit: How many request queues to retrieve.
+            offset: What request queue to include as first when retrieving the list.
+            desc: Whether to sort the request queues in descending order based on their modification date.
+            ownership: Filter by ownership. 'ownedByMe' returns only user's own request queues,
+                'sharedWithMe' returns only request queues shared with the user.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The available request queues matching the specified filters.
+        """
+
+        async def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfRequestQueues:
+            return await self.list(
+                unnamed=unnamed, limit=limit, offset=offset, desc=desc, ownership=ownership, timeout=timeout
+            )
+
+        return get_items_iterator_async(_callback, limit=limit, offset=offset)
 
     async def get_or_create(
         self,

--- a/src/apify_client/_resource_clients/run_collection.py
+++ b/src/apify_client/_resource_clients/run_collection.py
@@ -4,12 +4,15 @@ from typing import TYPE_CHECKING, Any
 
 from apify_client._docs import docs_group
 from apify_client._models import ListOfRuns, ListOfRunsResponse
+from apify_client._pagination import get_items_iterator, get_items_iterator_async
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
     from datetime import datetime
 
     from apify_client._literals import ActorJobStatus
+    from apify_client._models import RunShort
     from apify_client._types import Timeout
 
 
@@ -76,6 +79,51 @@ class RunCollectionClient(ResourceClient):
         )
         return ListOfRunsResponse.model_validate(result).data
 
+    def iterate(
+        self,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+        desc: bool | None = None,
+        status: ActorJobStatus | list[ActorJobStatus] | None = None,  # ty: ignore[invalid-type-form]
+        started_before: str | datetime | None = None,
+        started_after: str | datetime | None = None,
+        timeout: Timeout = 'medium',
+    ) -> Iterator[RunShort]:
+        """Iterate over all Actor runs.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2#/reference/actors/run-collection/get-list-of-runs
+        https://docs.apify.com/api/v2#/reference/actor-runs/run-collection/get-user-runs-list
+
+        Args:
+            limit: How many runs to retrieve.
+            offset: What run to include as first when retrieving the list.
+            desc: Whether to sort the runs in descending order based on their start date.
+            status: Retrieve only runs with the provided statuses.
+            started_before: Only return runs started before this date (inclusive).
+            started_after: Only return runs started after this date (inclusive).
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The Actor runs matching the specified filters.
+        """
+
+        def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfRuns:
+            return self.list(
+                limit=limit,
+                offset=offset,
+                desc=desc,
+                status=status,
+                started_before=started_before,
+                started_after=started_after,
+                timeout=timeout,
+            )
+
+        return get_items_iterator(_callback, limit=limit, offset=offset)
+
 
 @docs_group('Resource clients')
 class RunCollectionClientAsync(ResourceClientAsync):
@@ -139,3 +187,48 @@ class RunCollectionClientAsync(ResourceClientAsync):
             startedAfter=started_after,
         )
         return ListOfRunsResponse.model_validate(result).data
+
+    def iterate(
+        self,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+        desc: bool | None = None,
+        status: ActorJobStatus | list[ActorJobStatus] | None = None,  # ty: ignore[invalid-type-form]
+        started_before: str | datetime | None = None,
+        started_after: str | datetime | None = None,
+        timeout: Timeout = 'medium',
+    ) -> AsyncIterator[RunShort]:
+        """Iterate over all Actor runs.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2#/reference/actors/run-collection/get-list-of-runs
+        https://docs.apify.com/api/v2#/reference/actor-runs/run-collection/get-user-runs-list
+
+        Args:
+            limit: How many runs to retrieve.
+            offset: What run to include as first when retrieving the list.
+            desc: Whether to sort the runs in descending order based on their start date.
+            status: Retrieve only runs with the provided statuses.
+            started_before: Only return runs started before this date (inclusive).
+            started_after: Only return runs started after this date (inclusive).
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The Actor runs matching the specified filters.
+        """
+
+        async def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfRuns:
+            return await self.list(
+                limit=limit,
+                offset=offset,
+                desc=desc,
+                status=status,
+                started_before=started_before,
+                started_after=started_after,
+                timeout=timeout,
+            )
+
+        return get_items_iterator_async(_callback, limit=limit, offset=offset)

--- a/src/apify_client/_resource_clients/schedule_collection.py
+++ b/src/apify_client/_resource_clients/schedule_collection.py
@@ -10,9 +10,13 @@ from apify_client._models import (
     ScheduleCreate,
     ScheduleResponse,
 )
+from apify_client._pagination import get_items_iterator, get_items_iterator_async
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
+    from apify_client._models import ScheduleShort
     from apify_client._types import Timeout
 
 
@@ -58,6 +62,36 @@ class ScheduleCollectionClient(ResourceClient):
         """
         result = self._list(timeout=timeout, limit=limit, offset=offset, desc=desc)
         return ListOfSchedulesResponse.model_validate(result).data
+
+    def iterate(
+        self,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+        desc: bool | None = None,
+        timeout: Timeout = 'medium',
+    ) -> Iterator[ScheduleShort]:
+        """Iterate over the available schedules.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2#/reference/schedules/schedules-collection/get-list-of-schedules
+
+        Args:
+            limit: How many schedules to retrieve.
+            offset: What schedules to include as first when retrieving the list.
+            desc: Whether to sort the schedules in descending order based on their modification date.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The available schedules matching the specified filters.
+        """
+
+        def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfSchedules:
+            return self.list(limit=limit, offset=offset, desc=desc, timeout=timeout)
+
+        return get_items_iterator(_callback, limit=limit, offset=offset)
 
     def create(
         self,
@@ -151,6 +185,36 @@ class ScheduleCollectionClientAsync(ResourceClientAsync):
         """
         result = await self._list(timeout=timeout, limit=limit, offset=offset, desc=desc)
         return ListOfSchedulesResponse.model_validate(result).data
+
+    def iterate(
+        self,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+        desc: bool | None = None,
+        timeout: Timeout = 'medium',
+    ) -> AsyncIterator[ScheduleShort]:
+        """Iterate over the available schedules.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2#/reference/schedules/schedules-collection/get-list-of-schedules
+
+        Args:
+            limit: How many schedules to retrieve.
+            offset: What schedules to include as first when retrieving the list.
+            desc: Whether to sort the schedules in descending order based on their modification date.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The available schedules matching the specified filters.
+        """
+
+        async def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfSchedules:
+            return await self.list(limit=limit, offset=offset, desc=desc, timeout=timeout)
+
+        return get_items_iterator_async(_callback, limit=limit, offset=offset)
 
     async def create(
         self,

--- a/src/apify_client/_resource_clients/store_collection.py
+++ b/src/apify_client/_resource_clients/store_collection.py
@@ -4,9 +4,13 @@ from typing import TYPE_CHECKING, Any
 
 from apify_client._docs import docs_group
 from apify_client._models import ListOfActorsInStoreResponse, ListOfStoreActors
+from apify_client._pagination import get_items_iterator, get_items_iterator_async
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
+    from apify_client._models import StoreListActor
     from apify_client._types import Timeout
 
 
@@ -71,6 +75,54 @@ class StoreCollectionClient(ResourceClient):
         )
         return ListOfActorsInStoreResponse.model_validate(result).data
 
+    def iterate(
+        self,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+        search: str | None = None,
+        sort_by: str | None = None,
+        category: str | None = None,
+        username: str | None = None,
+        pricing_model: str | None = None,
+        timeout: Timeout = 'medium',
+    ) -> Iterator[StoreListActor]:
+        """Iterate over Actors in Apify store.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2/#/reference/store/store-actors-collection/get-list-of-actors-in-store
+
+        Args:
+            limit: How many Actors to list.
+            offset: What Actor to include as first when retrieving the list.
+            search: String to search by. The search runs on the following fields: title, name, description, username,
+                readme.
+            sort_by: Specifies the field by which to sort the results.
+            category: Filter by this category.
+            username: Filter by this username.
+            pricing_model: Filter by this pricing model.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The Actors in the store matching the specified filters.
+        """
+
+        def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfStoreActors:
+            return self.list(
+                limit=limit,
+                offset=offset,
+                search=search,
+                sort_by=sort_by,
+                category=category,
+                username=username,
+                pricing_model=pricing_model,
+                timeout=timeout,
+            )
+
+        return get_items_iterator(_callback, limit=limit, offset=offset)
+
 
 @docs_group('Resource clients')
 class StoreCollectionClientAsync(ResourceClientAsync):
@@ -132,3 +184,51 @@ class StoreCollectionClientAsync(ResourceClientAsync):
             pricingModel=pricing_model,
         )
         return ListOfActorsInStoreResponse.model_validate(result).data
+
+    def iterate(
+        self,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+        search: str | None = None,
+        sort_by: str | None = None,
+        category: str | None = None,
+        username: str | None = None,
+        pricing_model: str | None = None,
+        timeout: Timeout = 'medium',
+    ) -> AsyncIterator[StoreListActor]:
+        """Iterate over Actors in Apify store.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2/#/reference/store/store-actors-collection/get-list-of-actors-in-store
+
+        Args:
+            limit: How many Actors to list.
+            offset: What Actor to include as first when retrieving the list.
+            search: String to search by. The search runs on the following fields: title, name, description, username,
+                readme.
+            sort_by: Specifies the field by which to sort the results.
+            category: Filter by this category.
+            username: Filter by this username.
+            pricing_model: Filter by this pricing model.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The Actors in the store matching the specified filters.
+        """
+
+        async def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfStoreActors:
+            return await self.list(
+                limit=limit,
+                offset=offset,
+                search=search,
+                sort_by=sort_by,
+                category=category,
+                username=username,
+                pricing_model=pricing_model,
+                timeout=timeout,
+            )
+
+        return get_items_iterator_async(_callback, limit=limit, offset=offset)

--- a/src/apify_client/_resource_clients/task_collection.py
+++ b/src/apify_client/_resource_clients/task_collection.py
@@ -13,12 +13,15 @@ from apify_client._models import (
     TaskOptions,
     TaskResponse,
 )
+from apify_client._pagination import get_items_iterator, get_items_iterator_async
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 from apify_client._utils import to_seconds
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
     from datetime import timedelta
 
+    from apify_client._models import TaskShort
     from apify_client._typeddicts import TaskInputDict
     from apify_client._types import Timeout
 
@@ -65,6 +68,36 @@ class TaskCollectionClient(ResourceClient):
         """
         result = self._list(timeout=timeout, limit=limit, offset=offset, desc=desc)
         return ListOfTasksResponse.model_validate(result).data
+
+    def iterate(
+        self,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+        desc: bool | None = None,
+        timeout: Timeout = 'medium',
+    ) -> Iterator[TaskShort]:
+        """Iterate over the available tasks.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2#/reference/actor-tasks/task-collection/get-list-of-tasks
+
+        Args:
+            limit: How many tasks to list.
+            offset: What task to include as first when retrieving the list.
+            desc: Whether to sort the tasks in descending order based on their creation date.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The available tasks matching the specified filters.
+        """
+
+        def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfTasks:
+            return self.list(limit=limit, offset=offset, desc=desc, timeout=timeout)
+
+        return get_items_iterator(_callback, limit=limit, offset=offset)
 
     def create(
         self,
@@ -186,6 +219,36 @@ class TaskCollectionClientAsync(ResourceClientAsync):
         """
         result = await self._list(timeout=timeout, limit=limit, offset=offset, desc=desc)
         return ListOfTasksResponse.model_validate(result).data
+
+    def iterate(
+        self,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+        desc: bool | None = None,
+        timeout: Timeout = 'medium',
+    ) -> AsyncIterator[TaskShort]:
+        """Iterate over the available tasks.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2#/reference/actor-tasks/task-collection/get-list-of-tasks
+
+        Args:
+            limit: How many tasks to list.
+            offset: What task to include as first when retrieving the list.
+            desc: Whether to sort the tasks in descending order based on their creation date.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The available tasks matching the specified filters.
+        """
+
+        async def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfTasks:
+            return await self.list(limit=limit, offset=offset, desc=desc, timeout=timeout)
+
+        return get_items_iterator_async(_callback, limit=limit, offset=offset)
 
     async def create(
         self,

--- a/src/apify_client/_resource_clients/webhook_collection.py
+++ b/src/apify_client/_resource_clients/webhook_collection.py
@@ -10,11 +10,14 @@ from apify_client._models import (
     WebhookCreate,
     WebhookResponse,
 )
+from apify_client._pagination import get_items_iterator, get_items_iterator_async
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
     from apify_client._literals import WebhookEventType
-    from apify_client._models import Webhook
+    from apify_client._models import Webhook, WebhookShort
     from apify_client._types import Timeout
 
 
@@ -60,6 +63,36 @@ class WebhookCollectionClient(ResourceClient):
         """
         result = self._list(timeout=timeout, limit=limit, offset=offset, desc=desc)
         return ListOfWebhooksResponse.model_validate(result).data
+
+    def iterate(
+        self,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+        desc: bool | None = None,
+        timeout: Timeout = 'medium',
+    ) -> Iterator[WebhookShort]:
+        """Iterate over the available webhooks.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2#/reference/webhooks/webhook-collection/get-list-of-webhooks
+
+        Args:
+            limit: How many webhooks to retrieve.
+            offset: What webhook to include as first when retrieving the list.
+            desc: Whether to sort the webhooks in descending order based on their date of creation.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The available webhooks matching the specified filters.
+        """
+
+        def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfWebhooks:
+            return self.list(limit=limit, offset=offset, desc=desc, timeout=timeout)
+
+        return get_items_iterator(_callback, limit=limit, offset=offset)
 
     def create(
         self,
@@ -163,6 +196,36 @@ class WebhookCollectionClientAsync(ResourceClientAsync):
         """
         result = await self._list(timeout=timeout, limit=limit, offset=offset, desc=desc)
         return ListOfWebhooksResponse.model_validate(result).data
+
+    def iterate(
+        self,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+        desc: bool | None = None,
+        timeout: Timeout = 'medium',
+    ) -> AsyncIterator[WebhookShort]:
+        """Iterate over the available webhooks.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2#/reference/webhooks/webhook-collection/get-list-of-webhooks
+
+        Args:
+            limit: How many webhooks to retrieve.
+            offset: What webhook to include as first when retrieving the list.
+            desc: Whether to sort the webhooks in descending order based on their date of creation.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The available webhooks matching the specified filters.
+        """
+
+        async def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfWebhooks:
+            return await self.list(limit=limit, offset=offset, desc=desc, timeout=timeout)
+
+        return get_items_iterator_async(_callback, limit=limit, offset=offset)
 
     async def create(
         self,

--- a/src/apify_client/_resource_clients/webhook_dispatch_collection.py
+++ b/src/apify_client/_resource_clients/webhook_dispatch_collection.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from apify_client._docs import docs_group
 from apify_client._models import ListOfWebhookDispatches, ListOfWebhookDispatchesResponse
@@ -40,7 +40,7 @@ class WebhookDispatchCollectionClient(ResourceClient):
         offset: int | None = None,
         desc: bool | None = None,
         timeout: Timeout = 'medium',
-    ) -> ListOfWebhookDispatches | None:
+    ) -> ListOfWebhookDispatches:
         """List all webhook dispatches of a user.
 
         https://docs.apify.com/api/v2#/reference/webhook-dispatches/webhook-dispatches-collection/get-list-of-webhook-dispatches
@@ -83,7 +83,7 @@ class WebhookDispatchCollectionClient(ResourceClient):
         """
 
         def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfWebhookDispatches:
-            return cast('ListOfWebhookDispatches', self.list(limit=limit, offset=offset, desc=desc, timeout=timeout))
+            return self.list(limit=limit, offset=offset, desc=desc, timeout=timeout)
 
         return get_items_iterator(_callback, limit=limit, offset=offset)
 
@@ -114,7 +114,7 @@ class WebhookDispatchCollectionClientAsync(ResourceClientAsync):
         offset: int | None = None,
         desc: bool | None = None,
         timeout: Timeout = 'medium',
-    ) -> ListOfWebhookDispatches | None:
+    ) -> ListOfWebhookDispatches:
         """List all webhook dispatches of a user.
 
         https://docs.apify.com/api/v2#/reference/webhook-dispatches/webhook-dispatches-collection/get-list-of-webhook-dispatches
@@ -157,9 +157,6 @@ class WebhookDispatchCollectionClientAsync(ResourceClientAsync):
         """
 
         async def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfWebhookDispatches:
-            return cast(
-                'ListOfWebhookDispatches',
-                await self.list(limit=limit, offset=offset, desc=desc, timeout=timeout),
-            )
+            return await self.list(limit=limit, offset=offset, desc=desc, timeout=timeout)
 
         return get_items_iterator_async(_callback, limit=limit, offset=offset)

--- a/src/apify_client/_resource_clients/webhook_dispatch_collection.py
+++ b/src/apify_client/_resource_clients/webhook_dispatch_collection.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from apify_client._docs import docs_group
 from apify_client._models import ListOfWebhookDispatches, ListOfWebhookDispatchesResponse
+from apify_client._pagination import get_items_iterator, get_items_iterator_async
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
+    from apify_client._models import WebhookDispatch
     from apify_client._types import Timeout
 
 
@@ -53,6 +57,36 @@ class WebhookDispatchCollectionClient(ResourceClient):
         result = self._list(timeout=timeout, limit=limit, offset=offset, desc=desc)
         return ListOfWebhookDispatchesResponse.model_validate(result).data
 
+    def iterate(
+        self,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+        desc: bool | None = None,
+        timeout: Timeout = 'medium',
+    ) -> Iterator[WebhookDispatch]:
+        """Iterate over all webhook dispatches of a user.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2#/reference/webhook-dispatches/webhook-dispatches-collection/get-list-of-webhook-dispatches
+
+        Args:
+            limit: How many webhook dispatches to retrieve.
+            offset: What webhook dispatch to include as first when retrieving the list.
+            desc: Whether to sort the webhook dispatches in descending order based on the date of their creation.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The webhook dispatches of a user matching the specified filters.
+        """
+
+        def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfWebhookDispatches:
+            return cast('ListOfWebhookDispatches', self.list(limit=limit, offset=offset, desc=desc, timeout=timeout))
+
+        return get_items_iterator(_callback, limit=limit, offset=offset)
+
 
 @docs_group('Resource clients')
 class WebhookDispatchCollectionClientAsync(ResourceClientAsync):
@@ -96,3 +130,36 @@ class WebhookDispatchCollectionClientAsync(ResourceClientAsync):
         """
         result = await self._list(timeout=timeout, limit=limit, offset=offset, desc=desc)
         return ListOfWebhookDispatchesResponse.model_validate(result).data
+
+    def iterate(
+        self,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+        desc: bool | None = None,
+        timeout: Timeout = 'medium',
+    ) -> AsyncIterator[WebhookDispatch]:
+        """Iterate over all webhook dispatches of a user.
+
+        Simple `list` does only one API call, possibly not listing all items matching the criteria. This method
+        returns an iterator that is capable of making multiple API calls to retrieve all items matching the criteria.
+
+        https://docs.apify.com/api/v2#/reference/webhook-dispatches/webhook-dispatches-collection/get-list-of-webhook-dispatches
+
+        Args:
+            limit: How many webhook dispatches to retrieve.
+            offset: What webhook dispatch to include as first when retrieving the list.
+            desc: Whether to sort the webhook dispatches in descending order based on the date of their creation.
+            timeout: Timeout for the API HTTP request.
+
+        Yields:
+            The webhook dispatches of a user matching the specified filters.
+        """
+
+        async def _callback(*, limit: int | None = None, offset: int | None = None) -> ListOfWebhookDispatches:
+            return cast(
+                'ListOfWebhookDispatches',
+                await self.list(limit=limit, offset=offset, desc=desc, timeout=timeout),
+            )
+
+        return get_items_iterator_async(_callback, limit=limit, offset=offset)

--- a/tests/unit/test_client_pagination.py
+++ b/tests/unit/test_client_pagination.py
@@ -88,10 +88,12 @@ CollectionClientAsync: TypeAlias = (
 )
 
 ID_PLACEHOLDER = 'some-id'
+NORMAL_ITEMS = 2500
+EXTRA_ITEMS_UNNAMED = 100
+MAX_ITEMS_PER_PAGE = 1000
 
-
-# Inner list models whose `items: list[<specific schema>]` is relaxed to `list[dict]`.
-# Point of these tests is pagination mechanism, not internal object validation.
+# Inner list models whose `items: list[<specific schema>]` is relaxed to `list[dict]`. Point of these tests is
+# pagination mechanism, not internal object validation.
 _RELAXED_LIST_MODELS = (
     'ListOfActors',
     'ListOfBuilds',
@@ -110,9 +112,9 @@ _RELAXED_LIST_MODELS = (
     'ListOfWebhooks',
 )
 
-# Outer wrappers that embed a relaxed list model via `.data`. Their compiled schema pins the
-# inner's schema at construction time, so they need a forced rebuild to pick up the relaxation.
-# The wrappers themselves are not mutated — their own field annotations stay as-is.
+# Outer wrappers that embed a relaxed list model via `.data`. Their compiled schema pins the inner's schema at
+# construction time, so they need a forced rebuild to pick up the relaxation. The wrappers themselves are not mutated —
+# their own field annotations stay as-is.
 _REBUILT_RESPONSE_WRAPPERS = (
     'ListOfActorsInStoreResponse',
     'ListOfActorsResponse',
@@ -135,10 +137,10 @@ _REBUILT_RESPONSE_WRAPPERS = (
 def _relax_item_validation() -> Any:
     """Relax only the element type of `items` on paginated list models for the test run.
 
-    Pagination tests feed synthetic `{'id': N}` items that don't satisfy the real API schemas
-    (`ActorShort`, `BuildShort`, `Request`, `EnvVar`, …). Instead of bypassing validation
-    wholesale, each inner `ListOf*` model has its `items` field swapped to `list[dict]`
-    and rebuilt. Outer `.data` wrapping and every pagination-metadata field remain validated.
+    Pagination tests feed synthetic `{'id': N}` items that don't satisfy the real API schemas (`ActorShort`,
+    `BuildShort`, `Request`, `EnvVar`, …). Instead of bypassing validation wholesale, each inner `ListOf*` model has its
+    `items` field swapped to `list[dict]` and rebuilt. Outer `.data` wrapping and every pagination-metadata field remain
+    validated.
     """
     relaxed_field = FieldInfo.from_annotation(list[dict])
     originals: dict[type[BaseModel], FieldInfo] = {}
@@ -168,11 +170,6 @@ def create_items(start: int, end: int, step: int | None = None) -> list[dict[str
     return [{'id': i} for i in range(start, end, step)]
 
 
-NORMAL_ITEMS = 2500
-EXTRA_ITEMS_UNNAMED = 100
-MAX_ITEMS_PER_PAGE = 1000
-
-
 def _is_true(value: str | None) -> bool:
     """Match the `'true'` wire form produced by the client's bool→string serialization."""
     return value == 'true'
@@ -185,10 +182,9 @@ def _parse_int_param(value: str | None) -> int:
 def _handle_offset_pagination(request: Request) -> Response:
     """Serve an offset-paginated Apify API response.
 
-    The simulated platform holds 2500 items normally and an additional 100 when
-    ``unnamed=true`` is requested. Pages are capped at 1000 items regardless of the requested
-    limit, mirroring the real API. The dataset items endpoint returns items as a raw list;
-    all other endpoints wrap them in ``{'data': {...}}``.
+    The simulated platform holds 2500 items normally and an additional 100 when `unnamed=true` is requested. Pages are
+    capped at 1000 items regardless of the requested limit, mirroring the real API. The dataset items endpoint returns
+    items as a raw list; all other endpoints wrap them in `{'data': {...}}`.
     """
     params = request.args
 
@@ -238,10 +234,9 @@ def _handle_offset_pagination(request: Request) -> Response:
 def _handle_cursor_pagination(request: Request) -> Response:
     """Serve a cursor-paginated Apify API response for KVS keys and RQ requests.
 
-    Holds 2500 synthetic items whose integer `id` equals their position. Each page is capped
-    at 1000 items. KVS uses `exclusiveStartKey`; RQ accepts either the deprecated
-    `exclusiveStartId` on the initial call or the opaque `cursor` on subsequent calls. All
-    three values encode the last-seen item id as a string — the next page starts at id + 1.
+    Holds 2500 synthetic items whose integer `id` equals their position. Each page is capped at 1000 items. KVS uses
+    `exclusiveStartKey`; RQ accepts either the deprecated `exclusiveStartId` on the initial call or the opaque `cursor`
+    on subsequent calls. All three values encode the last-seen item id as a string — the next page starts at id + 1.
     """
     params = request.args
     limit = _parse_int_param(params.get('limit'))
@@ -303,9 +298,8 @@ def _make_async_client(httpserver: HTTPServer) -> ApifyClientAsync:
     return ApifyClientAsync(token='test', api_url=httpserver.url_for('/'))
 
 
-# Map resource-client class name to a factory that, given an `ApifyClient`/`ApifyClientAsync`,
-# returns the sub-client under test. Usable for both sync and async since every accessor is
-# available symmetrically on both root clients.
+# Map resource-client class name to a factory that, given an `ApifyClient`/`ApifyClientAsync`, returns the sub-client
+# under test. Usable for both sync and async since every accessor is available symmetrically on both root clients.
 _CLIENT_FACTORIES: dict[str, Callable[[Any], Any]] = {
     'ActorCollectionClient': lambda c: c.actors(),
     'ScheduleCollectionClient': lambda c: c.schedules(),
@@ -390,8 +384,8 @@ OPTIONS_CLIENTS = COLLECTION_CLIENTS | STORAGE_CLIENTS
 
 TEST_CASES = (
     _PaginationCase('No options normal', {}, create_items(0, 2500), OPTIONS_CLIENTS),
-    # These clients can't iterate over all items if there is more of them than the API limit as they offer no
-    # pagination parameters.
+    # These clients can't iterate over all items if there is more of them than the API limit as they offer no pagination
+    # parameters.
     _PaginationCase('No options limited', {}, create_items(0, 1000), NO_OPTIONS_CLIENTS),
     _PaginationCase('Limit', {'limit': 1100}, create_items(0, 1100), OPTIONS_CLIENTS),
     _PaginationCase('Out of range limit', {'limit': 3000}, create_items(0, 2500), OPTIONS_CLIENTS),
@@ -470,9 +464,8 @@ TEST_CASES = (
 def _generate_test_params(client_set: Literal['collection', 'dataset', 'kvs', 'rq']) -> list[ParameterSet]:
     """Build the pytest parameter set for the given client category.
 
-    Each parameter carries the resource-client class name; the test body instantiates
-    the real client against the `httpserver` URL and looks up the factory in
-    `_CLIENT_FACTORIES`.
+    Each parameter carries the resource-client class name; the test body instantiates the real client against the
+    `httpserver` URL and looks up the factory in `_CLIENT_FACTORIES`.
     """
     client_names = _CLIENT_SET_NAMES[client_set]
     return [

--- a/tests/unit/test_client_pagination.py
+++ b/tests/unit/test_client_pagination.py
@@ -1,0 +1,640 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+import re
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
+
+import pytest
+from pydantic.fields import FieldInfo
+from werkzeug import Response
+
+from apify_client import ApifyClient, ApifyClientAsync
+from apify_client import _models as _models_module
+from apify_client._resource_clients import (
+    ActorCollectionClient,
+    ActorCollectionClientAsync,
+    ActorEnvVarCollectionClient,
+    ActorEnvVarCollectionClientAsync,
+    ActorVersionCollectionClient,
+    ActorVersionCollectionClientAsync,
+    BuildCollectionClient,
+    BuildCollectionClientAsync,
+    DatasetClient,
+    DatasetClientAsync,
+    DatasetCollectionClient,
+    DatasetCollectionClientAsync,
+    KeyValueStoreClient,
+    KeyValueStoreClientAsync,
+    KeyValueStoreCollectionClient,
+    KeyValueStoreCollectionClientAsync,
+    RequestQueueClient,
+    RequestQueueClientAsync,
+    RequestQueueCollectionClient,
+    RequestQueueCollectionClientAsync,
+    RunCollectionClient,
+    RunCollectionClientAsync,
+    ScheduleCollectionClient,
+    ScheduleCollectionClientAsync,
+    StoreCollectionClient,
+    StoreCollectionClientAsync,
+    TaskCollectionClient,
+    TaskCollectionClientAsync,
+    WebhookCollectionClient,
+    WebhookCollectionClientAsync,
+    WebhookDispatchCollectionClient,
+    WebhookDispatchCollectionClientAsync,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from _pytest.mark import ParameterSet
+    from pydantic import BaseModel
+    from pytest_httpserver import HTTPServer
+    from werkzeug import Request
+
+
+CollectionClient: TypeAlias = (
+    ActorCollectionClient
+    | BuildCollectionClient
+    | RunCollectionClient
+    | ScheduleCollectionClient
+    | TaskCollectionClient
+    | WebhookCollectionClient
+    | WebhookDispatchCollectionClient
+    | DatasetCollectionClient
+    | KeyValueStoreCollectionClient
+    | RequestQueueCollectionClient
+    | StoreCollectionClient
+    | ActorEnvVarCollectionClient
+    | ActorVersionCollectionClient
+)
+
+CollectionClientAsync: TypeAlias = (
+    ActorCollectionClientAsync
+    | BuildCollectionClientAsync
+    | RunCollectionClientAsync
+    | ScheduleCollectionClientAsync
+    | TaskCollectionClientAsync
+    | WebhookCollectionClientAsync
+    | WebhookDispatchCollectionClientAsync
+    | DatasetCollectionClientAsync
+    | KeyValueStoreCollectionClientAsync
+    | RequestQueueCollectionClientAsync
+    | StoreCollectionClientAsync
+    | ActorEnvVarCollectionClientAsync
+    | ActorVersionCollectionClientAsync
+)
+
+ID_PLACEHOLDER = 'some-id'
+
+
+# Inner list models whose `items: list[<specific schema>]` is relaxed to `list[dict]`.
+# Point of these tests is pagination mechanism, not internal object validation.
+_RELAXED_LIST_MODELS = (
+    'ListOfActors',
+    'ListOfBuilds',
+    'ListOfDatasets',
+    'ListOfEnvVars',
+    'ListOfKeys',
+    'ListOfKeyValueStores',
+    'ListOfRequestQueues',
+    'ListOfRequests',
+    'ListOfRuns',
+    'ListOfSchedules',
+    'ListOfStoreActors',
+    'ListOfTasks',
+    'ListOfVersions',
+    'ListOfWebhookDispatches',
+    'ListOfWebhooks',
+)
+
+# Outer wrappers that embed a relaxed list model via `.data`. Their compiled schema pins the
+# inner's schema at construction time, so they need a forced rebuild to pick up the relaxation.
+# The wrappers themselves are not mutated — their own field annotations stay as-is.
+_REBUILT_RESPONSE_WRAPPERS = (
+    'ListOfActorsInStoreResponse',
+    'ListOfActorsResponse',
+    'ListOfBuildsResponse',
+    'ListOfDatasetsResponse',
+    'ListOfEnvVarsResponse',
+    'ListOfKeyValueStoresResponse',
+    'ListOfKeysResponse',
+    'ListOfRequestQueuesResponse',
+    'ListOfRequestsResponse',
+    'ListOfRunsResponse',
+    'ListOfSchedulesResponse',
+    'ListOfTasksResponse',
+    'ListOfVersionsResponse',
+    'ListOfWebhooksResponse',
+)
+
+
+@pytest.fixture(autouse=True)
+def _relax_item_validation() -> Any:
+    """Relax only the element type of `items` on paginated list models for the test run.
+
+    Pagination tests feed synthetic `{'id': N}` items that don't satisfy the real API schemas
+    (`ActorShort`, `BuildShort`, `Request`, `EnvVar`, …). Instead of bypassing validation
+    wholesale, each inner `ListOf*` model has its `items` field swapped to `list[dict]`
+    and rebuilt. Outer `.data` wrapping and every pagination-metadata field remain validated.
+    """
+    relaxed_field = FieldInfo.from_annotation(list[dict])
+    originals: dict[type[BaseModel], FieldInfo] = {}
+    wrappers = [getattr(_models_module, name) for name in _REBUILT_RESPONSE_WRAPPERS]
+
+    for name in _RELAXED_LIST_MODELS:
+        cls = getattr(_models_module, name)
+        originals[cls] = cls.model_fields['items']
+        cls.model_fields['items'] = relaxed_field
+        cls.model_rebuild(force=True)
+    for wrapper in wrappers:
+        wrapper.model_rebuild(force=True)
+    try:
+        yield
+    finally:
+        for cls, field in originals.items():
+            cls.model_fields['items'] = field
+            cls.model_rebuild(force=True)
+        for wrapper in wrappers:
+            wrapper.model_rebuild(force=True)
+
+
+def create_items(start: int, end: int, step: int | None = None) -> list[dict[str, int]]:
+    """Create a list of test items for the given index range."""
+    if not step:
+        step = -1 if end < start else 1
+    return [{'id': i} for i in range(start, end, step)]
+
+
+NORMAL_ITEMS = 2500
+EXTRA_ITEMS_UNNAMED = 100
+MAX_ITEMS_PER_PAGE = 1000
+
+
+def _is_true(value: str | None) -> bool:
+    """Match the `'true'` wire form produced by the client's bool→string serialization."""
+    return value == 'true'
+
+
+def _parse_int_param(value: str | None) -> int:
+    return int(value) if value not in (None, '') else 0
+
+
+def _handle_offset_pagination(request: Request) -> Response:
+    """Serve an offset-paginated Apify API response.
+
+    The simulated platform holds 2500 items normally and an additional 100 when
+    ``unnamed=true`` is requested. Pages are capped at 1000 items regardless of the requested
+    limit, mirroring the real API. The dataset items endpoint returns items as a raw list;
+    all other endpoints wrap them in ``{'data': {...}}``.
+    """
+    params = request.args
+
+    total_items = (NORMAL_ITEMS + EXTRA_ITEMS_UNNAMED) if _is_true(params.get('unnamed')) else NORMAL_ITEMS
+    offset = _parse_int_param(params.get('offset'))
+    limit = _parse_int_param(params.get('limit'))
+    assert offset >= 0, 'Invalid offset sent to API'
+    assert limit >= 0, 'Invalid limit sent to API'
+
+    desc = _is_true(params.get('desc'))
+    items = create_items(total_items, 0) if desc else create_items(0, total_items)
+
+    lower_index = min(offset, total_items)
+    upper_index = min(offset + (limit or total_items), total_items)
+    count = min(max(upper_index - lower_index, 0), MAX_ITEMS_PER_PAGE)
+    selected_items = items[lower_index : min(upper_index, lower_index + MAX_ITEMS_PER_PAGE)]
+
+    # Every second item is filtered out when `skipEmpty=true`, `skipHidden=true`, or `clean=true`.
+    if _is_true(params.get('skipEmpty')) or _is_true(params.get('skipHidden')) or _is_true(params.get('clean')):
+        selected_items = selected_items[::2]
+
+    headers = {
+        'x-apify-pagination-count': str(count),
+        'x-apify-pagination-total': str(total_items),
+        'x-apify-pagination-offset': str(offset),
+        'x-apify-pagination-limit': str(limit or count or 1),
+        'x-apify-pagination-desc': str(desc).lower(),
+        'content-type': 'application/json',
+    }
+
+    if request.path.endswith(f'/datasets/{ID_PLACEHOLDER}/items'):
+        body: Any = selected_items
+    else:
+        body = {
+            'data': {
+                'total': total_items,
+                'count': count,
+                'offset': offset,
+                'limit': limit or (count or 1),
+                'desc': desc,
+                'items': selected_items,
+            }
+        }
+    return Response(status=200, headers=headers, response=json.dumps(body))
+
+
+def _handle_cursor_pagination(request: Request) -> Response:
+    """Serve a cursor-paginated Apify API response for KVS keys and RQ requests.
+
+    Holds 2500 synthetic items whose integer `id` equals their position. Each page is capped
+    at 1000 items. KVS uses `exclusiveStartKey`; RQ accepts either the deprecated
+    `exclusiveStartId` on the initial call or the opaque `cursor` on subsequent calls. All
+    three values encode the last-seen item id as a string — the next page starts at id + 1.
+    """
+    params = request.args
+    limit = _parse_int_param(params.get('limit'))
+    assert limit >= 0, 'Invalid limit sent to API'
+
+    cursor_raw = params.get('exclusiveStartKey') or params.get('exclusiveStartId') or params.get('cursor')
+
+    total_items = NORMAL_ITEMS
+    start = int(cursor_raw) + 1 if cursor_raw not in (None, '') else 0
+    end = total_items if not limit else min(start + limit, total_items)
+    page_end = min(end, start + MAX_ITEMS_PER_PAGE)
+    selected_items = [{'id': i} for i in range(start, page_end)]
+
+    if request.path.endswith('/keys'):
+        is_truncated = page_end < total_items and bool(selected_items)
+        next_exclusive_start_key = str(selected_items[-1]['id']) if selected_items and is_truncated else None
+        body: dict[str, Any] = {
+            'data': {
+                'items': selected_items,
+                'count': len(selected_items),
+                'limit': limit or (len(selected_items) or 1),
+                'is_truncated': is_truncated,
+                'next_exclusive_start_key': next_exclusive_start_key,
+            }
+        }
+    else:  # `/requests`
+        has_more = page_end < total_items and bool(selected_items)
+        next_cursor = str(selected_items[-1]['id']) if has_more else None
+        body = {
+            'data': {
+                'items': selected_items,
+                'count': len(selected_items),
+                'limit': limit or (len(selected_items) or 1),
+                'next_cursor': next_cursor,
+            }
+        }
+    return Response(status=200, headers={'content-type': 'application/json'}, response=json.dumps(body))
+
+
+def _pagination_handler(request: Request) -> Response:
+    """Dispatch between cursor-based (KVS keys, RQ requests) and offset-based endpoints."""
+    if request.path.endswith(('/keys', '/requests')):
+        return _handle_cursor_pagination(request)
+    return _handle_offset_pagination(request)
+
+
+@pytest.fixture
+def pagination_server(httpserver: HTTPServer) -> HTTPServer:
+    """Register a catch-all handler that mirrors the Apify paginated endpoints."""
+    httpserver.expect_request(re.compile(r'.*')).respond_with_handler(_pagination_handler)
+    return httpserver
+
+
+def _make_sync_client(httpserver: HTTPServer) -> ApifyClient:
+    return ApifyClient(token='test', api_url=httpserver.url_for('/'))
+
+
+def _make_async_client(httpserver: HTTPServer) -> ApifyClientAsync:
+    return ApifyClientAsync(token='test', api_url=httpserver.url_for('/'))
+
+
+# Map resource-client class name to a factory that, given an `ApifyClient`/`ApifyClientAsync`,
+# returns the sub-client under test. Usable for both sync and async since every accessor is
+# available symmetrically on both root clients.
+_CLIENT_FACTORIES: dict[str, Callable[[Any], Any]] = {
+    'ActorCollectionClient': lambda c: c.actors(),
+    'ScheduleCollectionClient': lambda c: c.schedules(),
+    'TaskCollectionClient': lambda c: c.tasks(),
+    'WebhookCollectionClient': lambda c: c.webhooks(),
+    'WebhookDispatchCollectionClient': lambda c: c.webhook_dispatches(),
+    'StoreCollectionClient': lambda c: c.store(),
+    'DatasetCollectionClient': lambda c: c.datasets(),
+    'KeyValueStoreCollectionClient': lambda c: c.key_value_stores(),
+    'RequestQueueCollectionClient': lambda c: c.request_queues(),
+    'BuildCollectionClient': lambda c: c.actor(ID_PLACEHOLDER).builds(),
+    'RunCollectionClient': lambda c: c.actor(ID_PLACEHOLDER).runs(),
+    'ActorVersionCollectionClient': lambda c: c.actor(ID_PLACEHOLDER).versions(),
+    'ActorEnvVarCollectionClient': lambda c: c.actor(ID_PLACEHOLDER).version('some-version').env_vars(),
+    'DatasetClient': lambda c: c.dataset(ID_PLACEHOLDER),
+    'KeyValueStoreClient': lambda c: c.key_value_store(ID_PLACEHOLDER),
+    'RequestQueueClient': lambda c: c.request_queue(ID_PLACEHOLDER),
+}
+
+
+_CLIENT_SET_NAMES: dict[Literal['collection', 'dataset', 'kvs', 'rq'], tuple[str, ...]] = {
+    # Tuple rather than set: pytest-xdist requires a stable iteration order across workers.
+    # https://pytest-xdist.readthedocs.io/en/stable/known-limitations.html#order-and-amount-of-test-must-be-consistent
+    'collection': (
+        'ActorCollectionClient',
+        'ScheduleCollectionClient',
+        'TaskCollectionClient',
+        'WebhookCollectionClient',
+        'WebhookDispatchCollectionClient',
+        'StoreCollectionClient',
+        'DatasetCollectionClient',
+        'KeyValueStoreCollectionClient',
+        'RequestQueueCollectionClient',
+        'BuildCollectionClient',
+        'RunCollectionClient',
+        'ActorVersionCollectionClient',
+        'ActorEnvVarCollectionClient',
+    ),
+    'dataset': ('DatasetClient',),
+    'kvs': ('KeyValueStoreClient',),
+    'rq': ('RequestQueueClient',),
+}
+
+
+@dataclasses.dataclass
+class _PaginationCase:
+    """A single parametrized pagination test case."""
+
+    id: str
+    inputs: dict
+    expected_items: list[dict[str, int]]
+    supported_clients: set[str]
+
+    def __hash__(self) -> int:
+        return hash(self.id)
+
+
+COLLECTION_CLIENTS = {
+    'ActorCollectionClient',
+    'BuildCollectionClient',
+    'RunCollectionClient',
+    'ScheduleCollectionClient',
+    'TaskCollectionClient',
+    'WebhookCollectionClient',
+    'WebhookDispatchCollectionClient',
+    'DatasetCollectionClient',
+    'KeyValueStoreCollectionClient',
+    'RequestQueueCollectionClient',
+    'StoreCollectionClient',
+}
+
+NO_OPTIONS_CLIENTS = {
+    'ActorEnvVarCollectionClient',
+    'ActorVersionCollectionClient',
+}
+
+DATASET_CLIENTS = {'DatasetClient'}
+RQ_CLIENTS = {'RequestQueueClient'}
+KVS_CLIENTS = {'KeyValueStoreClient'}
+STORAGE_CLIENTS = DATASET_CLIENTS | RQ_CLIENTS | KVS_CLIENTS
+OPTIONS_CLIENTS = COLLECTION_CLIENTS | STORAGE_CLIENTS
+
+TEST_CASES = (
+    _PaginationCase('No options normal', {}, create_items(0, 2500), OPTIONS_CLIENTS),
+    # These clients can't iterate over all items if there is more of them than the API limit as they offer no
+    # pagination parameters.
+    _PaginationCase('No options limited', {}, create_items(0, 1000), NO_OPTIONS_CLIENTS),
+    _PaginationCase('Limit', {'limit': 1100}, create_items(0, 1100), OPTIONS_CLIENTS),
+    _PaginationCase('Out of range limit', {'limit': 3000}, create_items(0, 2500), OPTIONS_CLIENTS),
+    _PaginationCase(
+        'Offset',
+        {'offset': 1000},
+        create_items(1000, 2500),
+        OPTIONS_CLIENTS - KVS_CLIENTS - RQ_CLIENTS,
+    ),
+    _PaginationCase(
+        'Offset and limit',
+        {'offset': 1000, 'limit': 1100},
+        create_items(1000, 2100),
+        OPTIONS_CLIENTS - KVS_CLIENTS - RQ_CLIENTS,
+    ),
+    _PaginationCase('Out of range offset', {'offset': 3000}, [], OPTIONS_CLIENTS - KVS_CLIENTS - RQ_CLIENTS),
+    _PaginationCase(
+        'Offset, limit, descending',
+        {'offset': 1000, 'limit': 1100, 'desc': True},
+        create_items(1500, 400),
+        OPTIONS_CLIENTS - {'StoreCollectionClient'} - KVS_CLIENTS - RQ_CLIENTS,
+    ),
+    _PaginationCase(
+        'Offset, limit, descending, unnamed',
+        {'offset': 50, 'limit': 1100, 'desc': True, 'unnamed': True},
+        create_items(2550, 1450),
+        {'DatasetCollectionClient', 'KeyValueStoreCollectionClient', 'RequestQueueCollectionClient'},
+    ),
+    _PaginationCase(
+        'chunk_size',
+        {'chunk_size': 100, 'limit': 250},
+        create_items(0, 250),
+        STORAGE_CLIENTS,
+    ),
+    _PaginationCase(
+        'Offset, limit, descending, chunk_size',
+        {'offset': 50, 'limit': 1100, 'desc': True, 'chunk_size': 100},
+        create_items(2450, 1350),
+        DATASET_CLIENTS,
+    ),
+    _PaginationCase(
+        'Offset, limit, descending, chunk_size, clean',
+        {'limit': 1500, 'chunk_size': 100, 'clean': True},
+        # API behavior with `clean=True` is to apply the cleaning after pagination, so we end up with missing items
+        # being counted towards the limit and thus fewer total items returned.
+        create_items(0, 1500, 2),
+        DATASET_CLIENTS,
+    ),
+    _PaginationCase(
+        'Exclusive start key',
+        {'exclusive_start_key': '1000'},
+        create_items(1001, 2500),
+        KVS_CLIENTS,
+    ),
+    _PaginationCase(
+        'Exclusive start key and limit',
+        {'exclusive_start_key': '1000', 'limit': 500},
+        create_items(1001, 1501),
+        KVS_CLIENTS,
+    ),
+    _PaginationCase(
+        'Cursor',
+        {'cursor': '1000'},
+        create_items(1001, 2500),
+        RQ_CLIENTS,
+    ),
+    _PaginationCase(
+        'Cursor and limit',
+        {'cursor': '1000', 'limit': 500},
+        create_items(1001, 1501),
+        RQ_CLIENTS,
+    ),
+)
+
+
+def _generate_test_params(client_set: Literal['collection', 'dataset', 'kvs', 'rq']) -> list[ParameterSet]:
+    """Build the pytest parameter set for the given client category.
+
+    Each parameter carries the resource-client class name; the test body instantiates
+    the real client against the `httpserver` URL and looks up the factory in
+    `_CLIENT_FACTORIES`.
+    """
+    client_names = _CLIENT_SET_NAMES[client_set]
+    return [
+        pytest.param(test_case.inputs, test_case.expected_items, client_name, id=f'{client_name}:{test_case.id}')
+        for test_case in TEST_CASES
+        for client_name in client_names
+        if client_name in test_case.supported_clients
+    ]
+
+
+@pytest.mark.parametrize(
+    ('inputs', 'expected_items', 'client_name'),
+    _generate_test_params(client_set='collection'),
+)
+def test_client_list_iterable(
+    pagination_server: HTTPServer,
+    client_name: str,
+    inputs: dict,
+    expected_items: list[dict[str, int]],
+) -> None:
+    """Every sync collection client's `list()` return value should iterate across pages."""
+    client: CollectionClient = _CLIENT_FACTORIES[client_name](_make_sync_client(pagination_server))
+    returned_items = list(client.iterate(**inputs))
+    assert len(returned_items) == len(expected_items)
+    assert returned_items == expected_items
+
+
+@pytest.mark.parametrize(
+    ('inputs', 'expected_items', 'client_name'),
+    _generate_test_params(client_set='collection'),
+)
+async def test_client_list_iterable_async(
+    pagination_server: HTTPServer,
+    client_name: str,
+    inputs: dict,
+    expected_items: list[dict[str, int]],
+) -> None:
+    """Every async collection client's `list()` return value should iterate across pages."""
+    client: CollectionClientAsync = _CLIENT_FACTORIES[client_name](_make_async_client(pagination_server))
+    returned_items = [item async for item in client.iterate(**inputs)]
+    assert len(returned_items) == len(expected_items)
+    assert returned_items == expected_items
+
+
+@pytest.mark.parametrize(
+    ('inputs', 'expected_items', 'client_name'),
+    _generate_test_params(client_set='dataset'),
+)
+def test_dataset_items_list_iterable(
+    pagination_server: HTTPServer,
+    client_name: str,
+    inputs: dict,
+    expected_items: list[dict[str, int]],
+) -> None:
+    """The sync dataset client's `iterate_items()` should iterate across pages."""
+    client: DatasetClient = _CLIENT_FACTORIES[client_name](_make_sync_client(pagination_server))
+    returned_items = list(client.iterate_items(**inputs))
+
+    if inputs == {}:
+        list_response = client.list_items(**inputs)
+        assert len(returned_items) == list_response.total
+
+    assert len(returned_items) == len(expected_items)
+    assert returned_items == expected_items
+
+
+@pytest.mark.parametrize(
+    ('inputs', 'expected_items', 'client_name'),
+    _generate_test_params(client_set='dataset'),
+)
+async def test_dataset_items_list_iterable_async(
+    pagination_server: HTTPServer,
+    client_name: str,
+    inputs: dict,
+    expected_items: list[dict[str, int]],
+) -> None:
+    """The async dataset client's `iterate_items()` should iterate across pages."""
+    client: DatasetClientAsync = _CLIENT_FACTORIES[client_name](_make_async_client(pagination_server))
+    returned_items = [item async for item in client.iterate_items(**inputs)]
+
+    if inputs == {}:
+        list_response = await client.list_items(**inputs)
+        assert len(returned_items) == list_response.total
+
+    assert returned_items == expected_items
+
+
+@pytest.mark.parametrize(
+    ('inputs', 'expected_items', 'client_name'),
+    _generate_test_params(client_set='kvs'),
+)
+def test_kvs_list_keys_iterable(
+    pagination_server: HTTPServer,
+    client_name: str,
+    inputs: dict,
+    expected_items: list[dict[str, int]],
+) -> None:
+    """The sync KVS client's `iterate_keys()` should iterate across cursor-paginated pages."""
+    client: KeyValueStoreClient = _CLIENT_FACTORIES[client_name](_make_sync_client(pagination_server))
+    returned_items = [dict(item) for item in client.iterate_keys(**inputs)]
+
+    assert returned_items == expected_items
+
+
+@pytest.mark.parametrize(
+    ('inputs', 'expected_items', 'client_name'),
+    _generate_test_params(client_set='kvs'),
+)
+async def test_kvs_list_keys_iterable_async(
+    pagination_server: HTTPServer,
+    client_name: str,
+    inputs: dict,
+    expected_items: list[dict[str, int]],
+) -> None:
+    """The async KVS client's `iterate_keys()` should iterate across cursor-paginated pages."""
+    client: KeyValueStoreClientAsync = _CLIENT_FACTORIES[client_name](_make_async_client(pagination_server))
+    returned_items = [dict(item) async for item in client.iterate_keys(**inputs)]
+
+    assert returned_items == expected_items
+
+
+@pytest.mark.parametrize(
+    ('inputs', 'expected_items', 'client_name'),
+    _generate_test_params(client_set='rq'),
+)
+def test_rq_list_requests_iterable(
+    pagination_server: HTTPServer,
+    client_name: str,
+    inputs: dict,
+    expected_items: list[dict[str, int]],
+) -> None:
+    """The sync RQ client's `iterate_requests()` should iterate across cursor-paginated pages."""
+    client: RequestQueueClient = _CLIENT_FACTORIES[client_name](_make_sync_client(pagination_server))
+    returned_items = [dict(item) for item in client.iterate_requests(**inputs)]
+    assert returned_items == expected_items
+
+
+@pytest.mark.parametrize(
+    ('inputs', 'expected_items', 'client_name'),
+    _generate_test_params(client_set='rq'),
+)
+async def test_rq_list_requests_iterable_async(
+    pagination_server: HTTPServer,
+    client_name: str,
+    inputs: dict,
+    expected_items: list[dict[str, int]],
+) -> None:
+    """The async RQ client's `iterate_requests()` should iterate across cursor-paginated pages."""
+    client: RequestQueueClientAsync = _CLIENT_FACTORIES[client_name](_make_async_client(pagination_server))
+    returned_items = [dict(item) async for item in client.iterate_requests(**inputs)]
+    assert returned_items == expected_items
+
+
+def test_rq_list_requests_rejects_cursor_and_exclusive_start_id() -> None:
+    """Passing both `cursor` and `exclusive_start_id` is mutually exclusive and must error."""
+    client = ApifyClient(token='').request_queue(ID_PLACEHOLDER)
+    with pytest.raises(ValueError, match='Cannot use both'):
+        client.list_requests(cursor='a', exclusive_start_id='b')
+
+
+async def test_rq_list_requests_rejects_cursor_and_exclusive_start_id_async() -> None:
+    """Async variant of the mutual-exclusion check."""
+    client = ApifyClientAsync(token='').request_queue(ID_PLACEHOLDER)
+    with pytest.raises(ValueError, match='Cannot use both'):
+        await client.list_requests(cursor='a', exclusive_start_id='b')


### PR DESCRIPTION
### Description
Support more convenient iteration through paginated endpoints of collection clients.

- Added iterate methods to following clients(same for async clients):
  - ActorCollectionClient
  - BuildCollectionClient
  - RunCollectionClient
  - ScheduleCollectionClient
  - TaskCollectionClient
  - WebhookCollectionClient
  - WebhookDispatchCollectionClient
  - DatasetCollectionClient
  - KeyValueStoreCollectionClient
  - RequestQueueCollectionClient
  - StoreCollectionClient
  - ActorEnvVarCollectionClient
  - ActorVersionCollectionClient

#### Example usage
```
...
# Sync
datasets_client = ApifyClient(token='...').datasets()

# Same as before
list_page = datasets_client.list(...)

# New functionality
individual_items = [item for item in datasets_client.iterate(...)]

...
# Async
datasets_client = ApifyClientAsync(token='...').datasets()

# Same as before
list_page = await datasets_client.list(...)

# New functionality
individual_items = [item async for item in datasets_client.iterate(...)]
```


### Testing

- Unit tests
- Manual API tests

### Checklist

- [x] CI passed

### Issues

Closes: #539
