### PR TITLE
ci: pass secrets to unit tests reusable workflow

### DIFF
--- a/.github/workflows/_tests.yaml
+++ b/.github/workflows/_tests.yaml
@@ -14,6 +14,7 @@ jobs:
   unit_tests:
     name: Unit tests
     uses: apify/workflows/.github/workflows/python_unit_tests.yaml@main
+    secrets: inherit
     with:
       python_versions: '["3.11", "3.12", "3.13", "3.14"]'
       operating_systems: '["ubuntu-latest", "windows-latest"]'


### PR DESCRIPTION
## Summary

Adds `secrets: inherit` to the `unit_tests` job in `.github/workflows/_tests.yaml` so `CODECOV_TOKEN` is forwarded to the reusable workflow at `apify/workflows/.github/workflows/python_unit_tests.yaml@main`.

## Why

The reusable unit-tests workflow declares `CODECOV_TOKEN` as a `workflow_call` secret and gates its upload step on `if: env.CODECOV_TOKEN != ''`. Without `secrets: inherit` (or an explicit `secrets:` map) on the caller, the secret is empty inside the called workflow, so the upload step is silently skipped on every commit and the `unit` flag is never sent to Codecov — Codecov shows it as carried-forward.

This is why PRs (e.g. #771) only see the `integration` flag in the Codecov comment and patch coverage numbers reflect only integration tests. `secrets: inherit` on the grandparent (`on_pull_request.yaml`) does not auto-propagate through an intermediate caller — it must be set on each `uses:` invocation.

`apify/apify-sdk-python` already has `secrets: inherit` set on the same reusable workflow call.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CNyVuou5LWBKdb4rdo1wJK)_