### PR TITLE
ci: add manually triggerable beta release workflow

### DIFF
--- a/.github/workflows/manual_release_beta.yaml
+++ b/.github/workflows/manual_release_beta.yaml
@@ -1,0 +1,74 @@
+name: Beta release
+
+on:
+  # Runs when manually triggered from the GitHub UI.
+  workflow_dispatch:
+
+  # Runs when invoked by another workflow.
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  release_prepare:
+    name: Release prepare
+    runs-on: ubuntu-latest
+    outputs:
+      version_number: ${{ steps.release_prepare.outputs.version_number }}
+      tag_name: ${{ steps.release_prepare.outputs.tag_name }}
+      changelog: ${{ steps.release_prepare.outputs.changelog }}
+    steps:
+      - uses: apify/workflows/git-cliff-release@main
+        id: release_prepare
+        name: Release prepare
+        with:
+          release_type: prerelease
+          existing_changelog_path: CHANGELOG.md
+
+  changelog_update:
+    name: Changelog update
+    needs: [release_prepare]
+    permissions:
+      contents: write
+    uses: apify/workflows/.github/workflows/python_bump_and_update_changelog.yaml@main
+    with:
+      version_number: ${{ needs.release_prepare.outputs.version_number }}
+      changelog: ${{ needs.release_prepare.outputs.changelog }}
+    secrets: inherit
+
+  pypi_publish:
+    name: PyPI publish
+    needs: [release_prepare, changelog_update]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write # Required for OIDC authentication.
+    environment:
+      name: pypi
+      url: https://pypi.org/project/apify-client
+    steps:
+      - name: Prepare distribution
+        uses: apify/workflows/prepare-pypi-distribution@main
+        with:
+          package_name: apify-client
+          is_prerelease: "yes"
+          version_number: ${{ needs.release_prepare.outputs.version_number }}
+          ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
+
+      # Publish the package to PyPI using PyPA official GitHub action with OIDC authentication.
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  doc_release_post_publish:
+    name: Doc release post publish
+    needs: [changelog_update, pypi_publish]
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/manual_release_docs.yaml
+    with:
+      # Use the ref from the changelog update to include the updated changelog.
+      ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
+    secrets: inherit

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -49,7 +49,7 @@ jobs:
     uses: ./.github/workflows/_tests.yaml
     secrets: inherit
 
-  release_prepare:
+  beta_release:
     # Run this only for "feat", "fix", "perf", "refactor" and "style" commits.
     if: >-
       startsWith(github.event.head_commit.message, 'feat') ||
@@ -57,63 +57,11 @@ jobs:
       startsWith(github.event.head_commit.message, 'perf') ||
       startsWith(github.event.head_commit.message, 'refactor') ||
       startsWith(github.event.head_commit.message, 'style')
-    name: Release prepare
+    name: Beta release
     needs: [code_checks, docstrings_checks, tests]
-    runs-on: ubuntu-latest
-    outputs:
-      version_number: ${{ steps.release_prepare.outputs.version_number }}
-      tag_name: ${{ steps.release_prepare.outputs.tag_name }}
-      changelog: ${{ steps.release_prepare.outputs.changelog }}
-    steps:
-      - uses: apify/workflows/git-cliff-release@main
-        id: release_prepare
-        name: Release prepare
-        with:
-          release_type: prerelease
-          existing_changelog_path: CHANGELOG.md
-
-  changelog_update:
-    name: Changelog update
-    needs: [release_prepare]
     permissions:
       contents: write
-    uses: apify/workflows/.github/workflows/python_bump_and_update_changelog.yaml@main
-    with:
-      version_number: ${{ needs.release_prepare.outputs.version_number }}
-      changelog: ${{ needs.release_prepare.outputs.changelog }}
-    secrets: inherit
-
-  pypi_publish:
-    name: PyPI publish
-    needs: [release_prepare, changelog_update]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write # Required for OIDC authentication.
-    environment:
-      name: pypi
-      url: https://pypi.org/project/apify-client
-    steps:
-      - name: Prepare distribution
-        uses: apify/workflows/prepare-pypi-distribution@main
-        with:
-          package_name: apify-client
-          is_prerelease: "yes"
-          version_number: ${{ needs.release_prepare.outputs.version_number }}
-          ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
-
-      - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-
-  doc_release_post_publish:
-    name: Doc release post publish
-    needs: [changelog_update, pypi_publish]
-    permissions:
-      contents: write
-      pages: write
       id-token: write
-    uses: ./.github/workflows/manual_release_docs.yaml
-    with:
-      # Use the ref from the changelog update to include the updated changelog.
-      ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
+      pages: write
+    uses: ./.github/workflows/manual_release_beta.yaml
     secrets: inherit


### PR DESCRIPTION
## Summary

- Extract the beta release pipeline (`release_prepare` → `changelog_update` → `pypi_publish` → `doc_release_post_publish`) from `on_master.yaml` into a new `manual_release_beta.yaml` reusable workflow.
- The new workflow exposes both `workflow_dispatch` (manual trigger from the GitHub UI) and `workflow_call` (so `on_master` can keep auto-publishing betas after master pushes).
- `on_master.yaml` now has a single `beta_release` job that calls the new workflow, gated on the same `feat|fix|perf|refactor|style:` commit prefixes and on `code_checks` + `docstrings_checks` + `tests` passing.

## Why

We previously had no way to cut a beta without pushing a release-triggering commit to master. With this change, a beta can be released on demand from the Actions tab, while the existing automatic flow on master is preserved.

Mirrors apify/apify-sdk-python#886.