### PR TITLE
ci: add missing top level contents permission

### DIFF
--- a/.github/workflows/manual_release_docs.yaml
+++ b/.github/workflows/manual_release_docs.yaml
@@ -12,6 +12,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: 22
   PYTHON_VERSION: 3.14

--- a/.github/workflows/on_issue.yaml
+++ b/.github/workflows/on_issue.yaml
@@ -6,6 +6,9 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+
 jobs:
   label_issues:
     name: Add labels


### PR DESCRIPTION
### Description

Two workflows in this repo were missing a top-level `permissions: contents: read` block:

- `.github/workflows/manual_release_docs.yaml`
- `.github/workflows/on_issue.yaml`

The other workflows here, as well as the equivalents in `apify-sdk-python` and `crawlee-python`, all set this default at the file level. This applies the principle of least privilege: jobs that need to escalate (e.g. `contents: write`, `pages: write`, `issues: write`) still do so via job-level overrides.

### Changes

- Add `permissions: contents: read` at the top level of both workflow files.