### PR TITLE
test: fix flaky `test_request_queue_unlock_requests`

### DIFF
--- a/tests/integration/test_request_queue.py
+++ b/tests/integration/test_request_queue.py
@@ -22,7 +22,32 @@ from apify_client._models import (
 
 if TYPE_CHECKING:
     from apify_client import ApifyClient, ApifyClientAsync
+    from apify_client._resource_clients.request_queue import RequestQueueClient, RequestQueueClientAsync
     from apify_client._typeddicts import RequestDict, RequestDraftDeleteDict, RequestDraftDict
+
+
+async def ensure_queue_is_populated(
+    rq_client: RequestQueueClient | RequestQueueClientAsync,
+    *,
+    expected_count: int,
+    is_async: bool,
+) -> None:
+    """Poll the queue until `expected_count` requests are visible.
+
+    Uses `list_head` (without side effects) so polling does not lock items, which would otherwise
+    lead to an ambiguous count of actually-locked requests in tests that exercise locking.
+    """
+    head_response: RequestQueueHead | None = None
+    for _ in range(5):
+        await maybe_sleep(1, is_async=is_async)
+        result = await maybe_await(rq_client.list_head(limit=expected_count))
+        assert isinstance(result, RequestQueueHead)
+        head_response = result
+        if len(head_response.items) == expected_count:
+            break
+
+    assert head_response is not None
+    assert len(head_response.items) == expected_count
 
 
 async def test_request_queue_collection_list(client: ApifyClient | ApifyClientAsync) -> None:
@@ -411,19 +436,7 @@ async def test_request_queue_list_and_lock_head(client: ApifyClient | ApifyClien
                 rq_client.add_request({'url': f'https://example.com/lock-{i}', 'unique_key': f'lock-{i}'})
             )
 
-        # Poll (without side effects) until all requests are visible. Using `list_and_lock_head` for polling
-        # would lock items across iterations, leading to an ambiguous count of actually-locked requests.
-        head_response: RequestQueueHead | None = None
-        for _ in range(5):
-            await maybe_sleep(1, is_async=is_async)
-            result = await maybe_await(rq_client.list_head(limit=5))
-            assert isinstance(result, RequestQueueHead)
-            head_response = result
-            if len(head_response.items) == 5:
-                break
-
-        assert head_response is not None
-        assert len(head_response.items) == 5
+        await ensure_queue_is_populated(rq_client, expected_count=5, is_async=is_async)
 
         result = await maybe_await(rq_client.list_and_lock_head(limit=3, lock_duration=timedelta(seconds=60)))
         assert isinstance(result, LockedRequestQueueHead)
@@ -528,19 +541,7 @@ async def test_request_queue_unlock_requests(client: ApifyClient | ApifyClientAs
                 rq_client.add_request({'url': f'https://example.com/unlock-{i}', 'unique_key': f'unlock-{i}'})
             )
 
-        # Poll (without side effects) until all requests are visible. Using `list_and_lock_head` for polling
-        # would lock items across iterations, leading to an ambiguous count of actually-locked requests.
-        head_response: RequestQueueHead | None = None
-        for _ in range(5):
-            await maybe_sleep(1, is_async=is_async)
-            result = await maybe_await(rq_client.list_head(limit=5))
-            assert isinstance(result, RequestQueueHead)
-            head_response = result
-            if len(head_response.items) == 5:
-                break
-
-        assert head_response is not None
-        assert len(head_response.items) == 5
+        await ensure_queue_is_populated(rq_client, expected_count=5, is_async=is_async)
 
         result = await maybe_await(rq_client.list_and_lock_head(limit=3, lock_duration=timedelta(seconds=60)))
         assert isinstance(result, LockedRequestQueueHead)

--- a/tests/integration/test_request_queue.py
+++ b/tests/integration/test_request_queue.py
@@ -411,17 +411,23 @@ async def test_request_queue_list_and_lock_head(client: ApifyClient | ApifyClien
                 rq_client.add_request({'url': f'https://example.com/lock-{i}', 'unique_key': f'lock-{i}'})
             )
 
-        # Poll until requests are available for locking (eventual consistency)
-        lock_response: LockedRequestQueueHead | None = None
+        # Poll (without side effects) until all requests are visible. Using `list_and_lock_head` for polling
+        # would lock items across iterations, leading to an ambiguous count of actually-locked requests.
+        head_response: RequestQueueHead | None = None
         for _ in range(5):
             await maybe_sleep(1, is_async=is_async)
-            result = await maybe_await(rq_client.list_and_lock_head(limit=3, lock_duration=timedelta(seconds=60)))
-            assert isinstance(result, LockedRequestQueueHead)
-            lock_response = result
-            if len(lock_response.items) == 3:
+            result = await maybe_await(rq_client.list_head(limit=5))
+            assert isinstance(result, RequestQueueHead)
+            head_response = result
+            if len(head_response.items) == 5:
                 break
 
-        assert lock_response is not None
+        assert head_response is not None
+        assert len(head_response.items) == 5
+
+        result = await maybe_await(rq_client.list_and_lock_head(limit=3, lock_duration=timedelta(seconds=60)))
+        assert isinstance(result, LockedRequestQueueHead)
+        lock_response = result
         assert len(lock_response.items) == 3
 
         # Verify requests are locked
@@ -522,17 +528,23 @@ async def test_request_queue_unlock_requests(client: ApifyClient | ApifyClientAs
                 rq_client.add_request({'url': f'https://example.com/unlock-{i}', 'unique_key': f'unlock-{i}'})
             )
 
-        # Poll until requests are available for locking (eventual consistency)
-        lock_response: LockedRequestQueueHead | None = None
+        # Poll (without side effects) until all requests are visible. Using `list_and_lock_head` for polling
+        # would lock items across iterations, leading to an ambiguous count of actually-locked requests.
+        head_response: RequestQueueHead | None = None
         for _ in range(5):
             await maybe_sleep(1, is_async=is_async)
-            result = await maybe_await(rq_client.list_and_lock_head(limit=3, lock_duration=timedelta(seconds=60)))
-            assert isinstance(result, LockedRequestQueueHead)
-            lock_response = result
-            if len(lock_response.items) == 3:
+            result = await maybe_await(rq_client.list_head(limit=5))
+            assert isinstance(result, RequestQueueHead)
+            head_response = result
+            if len(head_response.items) == 5:
                 break
 
-        assert lock_response is not None
+        assert head_response is not None
+        assert len(head_response.items) == 5
+
+        result = await maybe_await(rq_client.list_and_lock_head(limit=3, lock_duration=timedelta(seconds=60)))
+        assert isinstance(result, LockedRequestQueueHead)
+        lock_response = result
         assert len(lock_response.items) == 3
 
         # Unlock all requests


### PR DESCRIPTION
## Summary

Fix [this flaky CI run](https://github.com/apify/apify-client-python/actions/runs/25495772865/job/74814967391?pr=742) of `test_request_queue_unlock_requests[sync]`, which failed with `assert 2 == 3` on `unlock_response.unlocked_count`.

**Root cause:** the polling loop called `list_and_lock_head` repeatedly, which has the side effect of locking items. Across multiple iterations (due to eventual consistency on `add_request`) the total set of actually-locked requests no longer matched the last response's `items` count, so `unlock_requests` could report a different count than the test expected.

**Fix:** separate the two concerns — poll the read-only `list_head` until all 5 added requests are visible, then call `list_and_lock_head(limit=3)` exactly once. This removes the cross-iteration locking ambiguity.

Applied the same treatment to `test_request_queue_list_and_lock_head`, which shared the same racy polling pattern.