### PR TITLE
chore: Update actions from `apify/actions` [internal]

### DIFF
--- a/.github/workflows/manual_release_beta.yaml
+++ b/.github/workflows/manual_release_beta.yaml
@@ -23,7 +23,7 @@ jobs:
       version_number: ${{ steps.release_prepare.outputs.version_number }}
       changelog: ${{ steps.release_prepare.outputs.changelog }}
     steps:
-      - uses: apify/actions/git-cliff-release@v1.1.1
+      - uses: apify/actions/git-cliff-release@v1.1.2
         id: release_prepare
         name: Release prepare
         with:
@@ -53,7 +53,7 @@ jobs:
       url: https://pypi.org/project/apify-client
     steps:
       - name: Prepare distribution
-        uses: apify/actions/prepare-pypi-distribution@v1.1.1
+        uses: apify/actions/prepare-pypi-distribution@v1.1.2
         with:
           package_name: apify-client
           is_prerelease: "yes"

--- a/.github/workflows/manual_release_beta.yaml
+++ b/.github/workflows/manual_release_beta.yaml
@@ -23,7 +23,7 @@ jobs:
       version_number: ${{ steps.release_prepare.outputs.version_number }}
       changelog: ${{ steps.release_prepare.outputs.changelog }}
     steps:
-      - uses: apify/actions/git-cliff-release@v1.1.0
+      - uses: apify/actions/git-cliff-release@v1.1.1
         id: release_prepare
         name: Release prepare
         with:
@@ -53,7 +53,7 @@ jobs:
       url: https://pypi.org/project/apify-client
     steps:
       - name: Prepare distribution
-        uses: apify/actions/prepare-pypi-distribution@v1.1.0
+        uses: apify/actions/prepare-pypi-distribution@v1.1.1
         with:
           package_name: apify-client
           is_prerelease: "yes"

--- a/.github/workflows/manual_release_beta.yaml
+++ b/.github/workflows/manual_release_beta.yaml
@@ -23,7 +23,7 @@ jobs:
       version_number: ${{ steps.release_prepare.outputs.version_number }}
       changelog: ${{ steps.release_prepare.outputs.changelog }}
     steps:
-      - uses: apify/actions/git-cliff-release@v1.0.0
+      - uses: apify/actions/git-cliff-release@v1.1.0
         id: release_prepare
         name: Release prepare
         with:
@@ -53,7 +53,7 @@ jobs:
       url: https://pypi.org/project/apify-client
     steps:
       - name: Prepare distribution
-        uses: apify/actions/prepare-pypi-distribution@v1.0.0
+        uses: apify/actions/prepare-pypi-distribution@v1.1.0
         with:
           package_name: apify-client
           is_prerelease: "yes"

--- a/.github/workflows/manual_release_docs.yaml
+++ b/.github/workflows/manual_release_docs.yaml
@@ -50,7 +50,7 @@ jobs:
         run: uv run poe install-dev
 
       - name: Install pnpm and website dependencies
-        uses: apify/actions/pnpm-install@v1.1.0
+        uses: apify/actions/pnpm-install@v1.1.1
         with:
           working-directory: website
 

--- a/.github/workflows/manual_release_docs.yaml
+++ b/.github/workflows/manual_release_docs.yaml
@@ -50,7 +50,7 @@ jobs:
         run: uv run poe install-dev
 
       - name: Install pnpm and website dependencies
-        uses: apify/actions/pnpm-install@v1.1.1
+        uses: apify/actions/pnpm-install@v1.1.2
         with:
           working-directory: website
 

--- a/.github/workflows/manual_release_docs.yaml
+++ b/.github/workflows/manual_release_docs.yaml
@@ -50,7 +50,7 @@ jobs:
         run: uv run poe install-dev
 
       - name: Install pnpm and website dependencies
-        uses: apify/actions/pnpm-install@v1.0.0
+        uses: apify/actions/pnpm-install@v1.1.0
         with:
           working-directory: website
 

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -43,7 +43,7 @@ jobs:
       changelog: ${{ steps.release_prepare.outputs.changelog }}
       release_notes: ${{ steps.release_prepare.outputs.release_notes }}
     steps:
-      - uses: apify/actions/git-cliff-release@v1.1.1
+      - uses: apify/actions/git-cliff-release@v1.1.2
         name: Release prepare
         id: release_prepare
         with:
@@ -91,7 +91,7 @@ jobs:
       url: https://pypi.org/project/apify-client
     steps:
       - name: Prepare distribution
-        uses: apify/actions/prepare-pypi-distribution@v1.1.1
+        uses: apify/actions/prepare-pypi-distribution@v1.1.2
         with:
           package_name: apify-client
           is_prerelease: ""

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -43,7 +43,7 @@ jobs:
       changelog: ${{ steps.release_prepare.outputs.changelog }}
       release_notes: ${{ steps.release_prepare.outputs.release_notes }}
     steps:
-      - uses: apify/actions/git-cliff-release@v1.0.0
+      - uses: apify/actions/git-cliff-release@v1.1.0
         name: Release prepare
         id: release_prepare
         with:
@@ -91,7 +91,7 @@ jobs:
       url: https://pypi.org/project/apify-client
     steps:
       - name: Prepare distribution
-        uses: apify/actions/prepare-pypi-distribution@v1.0.0
+        uses: apify/actions/prepare-pypi-distribution@v1.1.0
         with:
           package_name: apify-client
           is_prerelease: ""

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -43,7 +43,7 @@ jobs:
       changelog: ${{ steps.release_prepare.outputs.changelog }}
       release_notes: ${{ steps.release_prepare.outputs.release_notes }}
     steps:
-      - uses: apify/actions/git-cliff-release@v1.1.0
+      - uses: apify/actions/git-cliff-release@v1.1.1
         name: Release prepare
         id: release_prepare
         with:
@@ -91,7 +91,7 @@ jobs:
       url: https://pypi.org/project/apify-client
     steps:
       - name: Prepare distribution
-        uses: apify/actions/prepare-pypi-distribution@v1.1.0
+        uses: apify/actions/prepare-pypi-distribution@v1.1.1
         with:
           package_name: apify-client
           is_prerelease: ""

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -50,7 +50,7 @@ jobs:
         run: uv run poe install-dev
 
       - name: Install pnpm and website dependencies
-        uses: apify/actions/pnpm-install@v1.1.0
+        uses: apify/actions/pnpm-install@v1.1.1
         with:
           working-directory: website
 

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -50,7 +50,7 @@ jobs:
         run: uv run poe install-dev
 
       - name: Install pnpm and website dependencies
-        uses: apify/actions/pnpm-install@v1.1.1
+        uses: apify/actions/pnpm-install@v1.1.2
         with:
           working-directory: website
 

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -50,7 +50,7 @@ jobs:
         run: uv run poe install-dev
 
       - name: Install pnpm and website dependencies
-        uses: apify/actions/pnpm-install@v1.0.0
+        uses: apify/actions/pnpm-install@v1.1.0
         with:
           working-directory: website
 

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -60,6 +60,6 @@ jobs:
       actions: write # Required by execute-workflow.
     steps:
       - name: Dispatch beta release workflow
-        uses: apify/actions/execute-workflow@v1.1.0
+        uses: apify/actions/execute-workflow@v1.1.1
         with:
           workflow: manual_release_beta.yaml

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -60,6 +60,6 @@ jobs:
       actions: write # Required by execute-workflow.
     steps:
       - name: Dispatch beta release workflow
-        uses: apify/actions/execute-workflow@v1.0.0
+        uses: apify/actions/execute-workflow@v1.1.0
         with:
           workflow: manual_release_beta.yaml

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -60,6 +60,6 @@ jobs:
       actions: write # Required by execute-workflow.
     steps:
       - name: Dispatch beta release workflow
-        uses: apify/actions/execute-workflow@v1.1.1
+        uses: apify/actions/execute-workflow@v1.1.2
         with:
           workflow: manual_release_beta.yaml


### PR DESCRIPTION
There was an issue with the `v1.0.0` version of some of the actions from `apify/actions` (a NPM dependency was not present), I've released an updated version which fixes it.