### PR TITLE
fix: Use DeprecationWarning for deprecated methods and arguments

### DIFF
--- a/src/apify_client/clients/resource_clients/request_queue.py
+++ b/src/apify_client/clients/resource_clients/request_queue.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 import math
+import warnings
 from collections.abc import Iterable
 from queue import Queue
 from typing import TYPE_CHECKING, Any, TypedDict
@@ -22,8 +22,6 @@ if TYPE_CHECKING:
     from datetime import timedelta
 
     from apify_shared.consts import StorageGeneralAccess
-
-logger = logging.getLogger(__name__)
 
 _RQ_MAX_REQUESTS_PER_BATCH = 25
 _MAX_PAYLOAD_SIZE_BYTES = 9 * 1024 * 1024  # 9 MB
@@ -311,9 +309,17 @@ class RequestQueueClient(ResourceClient):
             Result containing lists of processed and unprocessed requests.
         """
         if max_unprocessed_requests_retries:
-            logger.warning('`max_unprocessed_requests_retries` is deprecated and not used anymore.')
+            warnings.warn(
+                '`max_unprocessed_requests_retries` is deprecated and not used anymore.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
         if min_delay_between_unprocessed_requests_retries:
-            logger.warning('`min_delay_between_unprocessed_requests_retries` is deprecated and not used anymore.')
+            warnings.warn(
+                '`min_delay_between_unprocessed_requests_retries` is deprecated and not used anymore.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         if max_parallel != 1:
             raise NotImplementedError('max_parallel is only supported in async client')
@@ -393,8 +399,15 @@ class RequestQueueClient(ResourceClient):
 
         Args:
             limit: How many requests to retrieve.
-            exclusive_start_id: All requests up to this one (including) are skipped from the result.
+            exclusive_start_id: Deprecated argument. Will be removed in next major release.
         """
+        if exclusive_start_id is not None:
+            warnings.warn(
+                '`exclusive_start_id` is deprecated for paginating requests.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         request_params = self._params(limit=limit, exclusiveStartId=exclusive_start_id, clientKey=self.client_key)
 
         response = self.http_client.call(
@@ -738,9 +751,17 @@ class RequestQueueClientAsync(ResourceClientAsync):
             Result containing lists of processed and unprocessed requests.
         """
         if max_unprocessed_requests_retries:
-            logger.warning('`max_unprocessed_requests_retries` is deprecated and not used anymore.')
+            warnings.warn(
+                '`max_unprocessed_requests_retries` is deprecated and not used anymore.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
         if min_delay_between_unprocessed_requests_retries:
-            logger.warning('`min_delay_between_unprocessed_requests_retries` is deprecated and not used anymore.')
+            warnings.warn(
+                '`min_delay_between_unprocessed_requests_retries` is deprecated and not used anymore.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         tasks = set[asyncio.Task]()
         queue: asyncio.Queue[Iterable[dict]] = asyncio.Queue()
@@ -821,8 +842,15 @@ class RequestQueueClientAsync(ResourceClientAsync):
 
         Args:
             limit: How many requests to retrieve.
-            exclusive_start_id: All requests up to this one (including) are skipped from the result.
+            exclusive_start_id: Deprecated argument. Will be removed in next major release.
         """
+        if exclusive_start_id is not None:
+            warnings.warn(
+                '`exclusive_start_id` is deprecated for paginating requests.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         request_params = self._params(limit=limit, exclusiveStartId=exclusive_start_id, clientKey=self.client_key)
 
         response = await self.http_client.call(

--- a/src/apify_client/clients/resource_clients/request_queue.py
+++ b/src/apify_client/clients/resource_clients/request_queue.py
@@ -302,21 +302,22 @@ class RequestQueueClient(ResourceClient):
             max_parallel: Specifies the maximum number of parallel tasks for API calls. This is only applicable
                 to the async client. For the sync client, this value must be set to 1, as parallel execution
                 is not supported.
-            max_unprocessed_requests_retries: Deprecated argument. Will be removed in next major release.
-            min_delay_between_unprocessed_requests_retries: Deprecated argument. Will be removed in next major release.
+            max_unprocessed_requests_retries: Deprecated argument. Will be removed in v3.0.0.
+            min_delay_between_unprocessed_requests_retries: Deprecated argument. Will be removed in v3.0.0.
 
         Returns:
             Result containing lists of processed and unprocessed requests.
         """
         if max_unprocessed_requests_retries:
             warnings.warn(
-                '`max_unprocessed_requests_retries` is deprecated and not used anymore.',
+                'The `max_unprocessed_requests_retries` argument is deprecated and will be removed in v3.0.0.',
                 DeprecationWarning,
                 stacklevel=2,
             )
         if min_delay_between_unprocessed_requests_retries:
             warnings.warn(
-                '`min_delay_between_unprocessed_requests_retries` is deprecated and not used anymore.',
+                'The `min_delay_between_unprocessed_requests_retries` argument is deprecated and will be removed '
+                'in v3.0.0.',
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -399,11 +400,11 @@ class RequestQueueClient(ResourceClient):
 
         Args:
             limit: How many requests to retrieve.
-            exclusive_start_id: Deprecated argument. Will be removed in next major release.
+            exclusive_start_id: Deprecated argument. Will be removed in v3.0.0.
         """
         if exclusive_start_id is not None:
             warnings.warn(
-                '`exclusive_start_id` is deprecated for paginating requests.',
+                'The `exclusive_start_id` argument is deprecated and will be removed in v3.0.0.',
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -744,21 +745,22 @@ class RequestQueueClientAsync(ResourceClientAsync):
             max_parallel: Specifies the maximum number of parallel tasks for API calls. This is only applicable
                 to the async client. For the sync client, this value must be set to 1, as parallel execution
                 is not supported.
-            max_unprocessed_requests_retries: Deprecated argument. Will be removed in next major release.
-            min_delay_between_unprocessed_requests_retries: Deprecated argument. Will be removed in next major release.
+            max_unprocessed_requests_retries: Deprecated argument. Will be removed in v3.0.0.
+            min_delay_between_unprocessed_requests_retries: Deprecated argument. Will be removed in v3.0.0.
 
         Returns:
             Result containing lists of processed and unprocessed requests.
         """
         if max_unprocessed_requests_retries:
             warnings.warn(
-                '`max_unprocessed_requests_retries` is deprecated and not used anymore.',
+                'The `max_unprocessed_requests_retries` argument is deprecated and will be removed in v3.0.0.',
                 DeprecationWarning,
                 stacklevel=2,
             )
         if min_delay_between_unprocessed_requests_retries:
             warnings.warn(
-                '`min_delay_between_unprocessed_requests_retries` is deprecated and not used anymore.',
+                'The `min_delay_between_unprocessed_requests_retries` argument is deprecated and will be removed '
+                'in v3.0.0.',
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -842,11 +844,11 @@ class RequestQueueClientAsync(ResourceClientAsync):
 
         Args:
             limit: How many requests to retrieve.
-            exclusive_start_id: Deprecated argument. Will be removed in next major release.
+            exclusive_start_id: Deprecated argument. Will be removed in v3.0.0.
         """
         if exclusive_start_id is not None:
             warnings.warn(
-                '`exclusive_start_id` is deprecated for paginating requests.',
+                'The `exclusive_start_id` argument is deprecated and will be removed in v3.0.0.',
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/src/apify_client/clients/resource_clients/request_queue.py
+++ b/src/apify_client/clients/resource_clients/request_queue.py
@@ -302,22 +302,22 @@ class RequestQueueClient(ResourceClient):
             max_parallel: Specifies the maximum number of parallel tasks for API calls. This is only applicable
                 to the async client. For the sync client, this value must be set to 1, as parallel execution
                 is not supported.
-            max_unprocessed_requests_retries: Deprecated argument. Will be removed in v3.0.0.
-            min_delay_between_unprocessed_requests_retries: Deprecated argument. Will be removed in v3.0.0.
+            max_unprocessed_requests_retries: Deprecated argument. Will be removed in v3.
+            min_delay_between_unprocessed_requests_retries: Deprecated argument. Will be removed in v3.
 
         Returns:
             Result containing lists of processed and unprocessed requests.
         """
         if max_unprocessed_requests_retries:
             warnings.warn(
-                'The `max_unprocessed_requests_retries` argument is deprecated and will be removed in v3.0.0.',
+                'The `max_unprocessed_requests_retries` argument is deprecated and will be removed in v3.',
                 DeprecationWarning,
                 stacklevel=2,
             )
         if min_delay_between_unprocessed_requests_retries:
             warnings.warn(
                 'The `min_delay_between_unprocessed_requests_retries` argument is deprecated and will be removed '
-                'in v3.0.0.',
+                'in v3.',
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -400,11 +400,11 @@ class RequestQueueClient(ResourceClient):
 
         Args:
             limit: How many requests to retrieve.
-            exclusive_start_id: Deprecated argument. Will be removed in v3.0.0.
+            exclusive_start_id: Deprecated argument. Will be removed in v3.
         """
         if exclusive_start_id is not None:
             warnings.warn(
-                'The `exclusive_start_id` argument is deprecated and will be removed in v3.0.0.',
+                'The `exclusive_start_id` argument is deprecated and will be removed in v3.',
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -745,22 +745,22 @@ class RequestQueueClientAsync(ResourceClientAsync):
             max_parallel: Specifies the maximum number of parallel tasks for API calls. This is only applicable
                 to the async client. For the sync client, this value must be set to 1, as parallel execution
                 is not supported.
-            max_unprocessed_requests_retries: Deprecated argument. Will be removed in v3.0.0.
-            min_delay_between_unprocessed_requests_retries: Deprecated argument. Will be removed in v3.0.0.
+            max_unprocessed_requests_retries: Deprecated argument. Will be removed in v3.
+            min_delay_between_unprocessed_requests_retries: Deprecated argument. Will be removed in v3.
 
         Returns:
             Result containing lists of processed and unprocessed requests.
         """
         if max_unprocessed_requests_retries:
             warnings.warn(
-                'The `max_unprocessed_requests_retries` argument is deprecated and will be removed in v3.0.0.',
+                'The `max_unprocessed_requests_retries` argument is deprecated and will be removed in v3.',
                 DeprecationWarning,
                 stacklevel=2,
             )
         if min_delay_between_unprocessed_requests_retries:
             warnings.warn(
                 'The `min_delay_between_unprocessed_requests_retries` argument is deprecated and will be removed '
-                'in v3.0.0.',
+                'in v3.',
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -844,11 +844,11 @@ class RequestQueueClientAsync(ResourceClientAsync):
 
         Args:
             limit: How many requests to retrieve.
-            exclusive_start_id: Deprecated argument. Will be removed in v3.0.0.
+            exclusive_start_id: Deprecated argument. Will be removed in v3.
         """
         if exclusive_start_id is not None:
             warnings.warn(
-                'The `exclusive_start_id` argument is deprecated and will be removed in v3.0.0.',
+                'The `exclusive_start_id` argument is deprecated and will be removed in v3.',
                 DeprecationWarning,
                 stacklevel=2,
             )


### PR DESCRIPTION
Replace `logger.warning(...)` calls with `warnings.warn(..., DeprecationWarning)` for deprecated request queue client arguments (`max_unprocessed_requests_retries`, `min_delay_between_unprocessed_requests_retries`), and also emit a `DeprecationWarning` when `exclusive_start_id` is passed to `list_requests`. Using the `warnings` machinery makes deprecations discoverable by tooling and matches Python conventions.

I'll release this as v2.5.1, the last patch before the next major.