### PR TITLE
ci: Repair regenerate-models workflow stale add glob

### DIFF
--- a/.github/workflows/manual_regenerate_models.yaml
+++ b/.github/workflows/manual_regenerate_models.yaml
@@ -63,20 +63,15 @@ jobs:
         with:
           token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
-      # If the branch already exists on the remote (e.g. from a previous run, possibly with reviewer
-      # commits), check it out so regeneration builds on top of it. Otherwise stay on the default
-      # branch and let the signed-commit step below create the remote branch — its create-branch
-      # flow does `git fetch ... $BRANCH:refs/heads/$BRANCH` which fails if $BRANCH is already
-      # checked out locally.
-      - name: Set up branch
-        id: branch-setup
+      # If the branch already exists on the remote (e.g. from a previous run, possibly with reviewer commits),
+      # check it out to build on top of it instead of starting fresh.
+      - name: Switch to existing branch or create a new one
         run: |
           if git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null 2>&1; then
-            git fetch origin "$BRANCH":"$BRANCH"
+            git fetch origin "$BRANCH"
             git switch "$BRANCH"
-            echo "create_branch=false" >> "$GITHUB_OUTPUT"
           else
-            echo "create_branch=true" >> "$GITHUB_OUTPUT"
+            git switch -c "$BRANCH"
           fi
 
       # Download the pre-built OpenAPI spec artifact from the apify-docs workflow run.
@@ -117,7 +112,7 @@ jobs:
           add: 'src/apify_client/_models.py src/apify_client/_typeddicts.py src/apify_client/_literals.py'
           github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
           branch: ${{ env.BRANCH }}
-          create-branch: ${{ steps.branch-setup.outputs.create_branch }}
+          create-branch: 'true'
 
       - name: Create or update PR
         if: steps.commit.outputs.committed == 'true'

--- a/.github/workflows/manual_regenerate_models.yaml
+++ b/.github/workflows/manual_regenerate_models.yaml
@@ -1,4 +1,4 @@
-# This workflow regenerates Pydantic models and TypedDicts (src/apify_client/_{models,typeddicts}_generated.py) from the OpenAPI spec.
+# This workflow regenerates Pydantic models, TypedDicts, and Literal aliases (src/apify_client/_{models,typeddicts,literals}.py) from the OpenAPI spec.
 #
 # It can be triggered in two ways:
 #   1. Automatically via workflow_dispatch from the apify-docs CI pipeline.
@@ -63,15 +63,20 @@ jobs:
         with:
           token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
-      # If the branch already exists on the remote (e.g. from a previous run, possibly with reviewer commits),
-      # check it out to build on top of it instead of starting fresh.
-      - name: Switch to existing branch or create a new one
+      # If the branch already exists on the remote (e.g. from a previous run, possibly with reviewer
+      # commits), check it out so regeneration builds on top of it. Otherwise stay on the default
+      # branch and let the signed-commit step below create the remote branch — its create-branch
+      # flow does `git fetch ... $BRANCH:refs/heads/$BRANCH` which fails if $BRANCH is already
+      # checked out locally.
+      - name: Set up branch
+        id: branch-setup
         run: |
           if git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null 2>&1; then
-            git fetch origin "$BRANCH"
+            git fetch origin "$BRANCH":"$BRANCH"
             git switch "$BRANCH"
+            echo "create_branch=false" >> "$GITHUB_OUTPUT"
           else
-            git switch -c "$BRANCH"
+            echo "create_branch=true" >> "$GITHUB_OUTPUT"
           fi
 
       # Download the pre-built OpenAPI spec artifact from the apify-docs workflow run.
@@ -109,10 +114,10 @@ jobs:
         uses: apify/actions/signed-commit@v1.0.0
         with:
           message: ${{ env.TITLE }}
-          add: 'src/apify_client/_*_generated.py'
+          add: 'src/apify_client/_models.py src/apify_client/_typeddicts.py src/apify_client/_literals.py'
           github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
           branch: ${{ env.BRANCH }}
-          create-branch: 'true'
+          create-branch: ${{ steps.branch-setup.outputs.create_branch }}
 
       - name: Create or update PR
         if: steps.commit.outputs.committed == 'true'


### PR DESCRIPTION
## Summary

Fixes a bug in `.github/workflows/manual_regenerate_models.yaml` that's been silently breaking model regeneration since 2026-04-29.

### Bug — stale `add:` glob

`add: 'src/apify_client/_*_generated.py'` matches nothing. PR #765 renamed the generated files from `_models_generated.py` / `_typeddicts_generated.py` to `_models.py`, `_typeddicts.py`, `_literals.py`, but the workflow's pathspec and header comment weren't updated. Under `apify/actions/signed-commit@v1.0.0` this produces `committed: false` with no error — so the workflow has been exiting green while doing nothing for ~3 weeks.

## Changes

- Header comment: `_{models,typeddicts}_generated.py` → `_{models,typeddicts,literals}.py`.
- `add:` enumerates the actually-generated files.

## Follow-up

A separate bug in the workflow — `create-branch: 'true'` colliding with the local `git switch -c "$BRANCH"` in the new-branch path, causing `apify/actions/signed-commit` to fail with `fatal: refusing to fetch into branch ... checked out at ...` — also leaves dangling remote branches without PRs (e.g. [`update-models-docs-pr-2546`](https://github.com/apify/apify-client-python/tree/update-models-docs-pr-2546), [`update-models-docs-pr-2548`](https://github.com/apify/apify-client-python/tree/update-models-docs-pr-2548)). Will be addressed in a follow-up PR.