### PR TITLE
ci: avoid branch clash in regenerate-models workflow

### DIFF
--- a/.github/workflows/manual_regenerate_models.yaml
+++ b/.github/workflows/manual_regenerate_models.yaml
@@ -63,15 +63,20 @@ jobs:
         with:
           token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
-      # If the branch already exists on the remote (e.g. from a previous run, possibly with reviewer commits),
-      # check it out to build on top of it instead of starting fresh.
-      - name: Switch to existing branch or create a new one
+      # If the branch already exists on the remote (e.g. from a previous run, possibly with reviewer
+      # commits), check it out so regeneration builds on top of it. Otherwise stay on the default
+      # branch and let the signed-commit step below create the remote branch — its create-branch
+      # flow does `git fetch ... $BRANCH:refs/heads/$BRANCH` which fails if $BRANCH is already
+      # checked out locally.
+      - name: Set up branch
+        id: branch-setup
         run: |
           if git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null 2>&1; then
-            git fetch origin "$BRANCH"
+            git fetch origin "$BRANCH":"$BRANCH"
             git switch "$BRANCH"
+            echo "create_branch=false" >> "$GITHUB_OUTPUT"
           else
-            git switch -c "$BRANCH"
+            echo "create_branch=true" >> "$GITHUB_OUTPUT"
           fi
 
       # Download the pre-built OpenAPI spec artifact from the apify-docs workflow run.
@@ -112,7 +117,7 @@ jobs:
           add: 'src/apify_client/_models.py src/apify_client/_typeddicts.py src/apify_client/_literals.py'
           github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
           branch: ${{ env.BRANCH }}
-          create-branch: 'true'
+          create-branch: ${{ steps.branch-setup.outputs.create_branch }}
 
       - name: Create or update PR
         if: steps.commit.outputs.committed == 'true'


### PR DESCRIPTION
## Summary

Fixes the branch-clash bug in `.github/workflows/manual_regenerate_models.yaml` that was flagged as a follow-up in #809. The recent manual run ([failing CI](https://github.com/apify/apify-client-python/actions/runs/26239209577/job/77220728000)) failed at the `Commit model changes` step with:

```
fatal: refusing to fetch into branch 'refs/heads/update-models-manual' checked out at '...'
```

### Cause

The local `git switch -c "$BRANCH"` step pre-created the branch unconditionally. `apify/actions/signed-commit@v1.0.0` with `create-branch: 'true'` then ran `git fetch --depth=1 origin "$BRANCH:refs/heads/$BRANCH"`, which refuses to fetch into a checked-out branch.

### Fix

- When the remote branch already exists: fetch + check it out locally, and tell signed-commit `create-branch: false`.
- When it doesn't exist: stay on the default branch and let signed-commit create the remote branch with `create-branch: true`.

The `create_branch` decision is exported from the renamed `Set up branch` step and consumed by the signed-commit step.