### PR TITLE
test: Fix flaky integration tests asserting membership in capped iterate()

### DIFF
--- a/tests/integration/test_dataset.py
+++ b/tests/integration/test_dataset.py
@@ -432,8 +432,7 @@ async def test_dataset_collection_iterate(client: ApifyClient | ApifyClientAsync
         created_ids.append(dataset.id)
 
     try:
-        # Iterate with a small chunk to force multiple API calls
-        iterator = client.datasets().iterate(limit=10, desc=True)
+        iterator = client.datasets().iterate(desc=True)
         collected: list[DatasetListItem] = []
         if is_async:
             assert isinstance(iterator, AsyncIterator)

--- a/tests/integration/test_key_value_store.py
+++ b/tests/integration/test_key_value_store.py
@@ -555,7 +555,7 @@ async def test_key_value_store_collection_iterate(client: ApifyClient | ApifyCli
         created_ids.append(kvs.id)
 
     try:
-        iterator = client.key_value_stores().iterate(limit=10, desc=True)
+        iterator = client.key_value_stores().iterate(desc=True)
         collected: list[KeyValueStore] = []
         if is_async:
             assert isinstance(iterator, AsyncIterator)

--- a/tests/integration/test_request_queue.py
+++ b/tests/integration/test_request_queue.py
@@ -615,7 +615,7 @@ async def test_request_queue_collection_iterate(client: ApifyClient | ApifyClien
         created_ids.append(rq.id)
 
     try:
-        iterator = client.request_queues().iterate(limit=10, desc=True)
+        iterator = client.request_queues().iterate(desc=True)
         collected: list[RequestQueueShort] = []
         if is_async:
             assert isinstance(iterator, AsyncIterator)

--- a/tests/integration/test_schedule.py
+++ b/tests/integration/test_schedule.py
@@ -193,7 +193,7 @@ async def test_schedule_collection_iterate(client: ApifyClient | ApifyClientAsyn
         created_ids.append(schedule.id)
 
     try:
-        iterator = client.schedules().iterate(limit=10)
+        iterator = client.schedules().iterate()
         collected: list[ScheduleShort] = []
         if is_async:
             assert isinstance(iterator, AsyncIterator)

--- a/tests/integration/test_task.py
+++ b/tests/integration/test_task.py
@@ -365,7 +365,7 @@ async def test_task_collection_iterate(client: ApifyClient | ApifyClientAsync, *
         created_ids.append(task.id)
 
     try:
-        iterator = client.tasks().iterate(limit=10, desc=True)
+        iterator = client.tasks().iterate(desc=True)
         collected: list[TaskShort] = []
         if is_async:
             assert isinstance(iterator, AsyncIterator)

--- a/tests/integration/test_webhook.py
+++ b/tests/integration/test_webhook.py
@@ -219,7 +219,7 @@ async def test_webhook_collection_iterate(client: ApifyClient | ApifyClientAsync
     assert len(set(created_ids)) == 3
 
     try:
-        iterator = client.webhooks().iterate(limit=10, desc=True)
+        iterator = client.webhooks().iterate(desc=True)
         collected: list[WebhookShort] = []
         if is_async:
             assert isinstance(iterator, AsyncIterator)


### PR DESCRIPTION
### Summary

Several `*_collection_iterate` integration tests created a few resources, called `iterate(limit=10, desc=True)`, and asserted each just-created ID showed up. `limit` is a *total* cap, not a per-page size — under the parallel suite, other workers creating the same resource type could push the fresh items past the 10-newest window before the assertion ran.

Dropping `limit=10` lets the iterator walk the full collection (server-side pagination still chunks the requests), so the inclusion check runs against the full set instead of a racy window.

### Failing CI runs

- request_queue: https://github.com/apify/apify-client-python/actions/runs/26398397194/job/77704443961
- dataset: https://github.com/apify/apify-client-python/actions/runs/26398508480/job/77704799161