### PR TITLE
docs: Adopt `@apify/docusaurus-plugin-typedoc-api` 5.1.7

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@apify/docs-theme": "^1.0.251",
-        "@apify/docusaurus-plugin-typedoc-api": "^5.1.6",
+        "@apify/docusaurus-plugin-typedoc-api": "^5.1.7",
         "@docusaurus/core": "^3.8.1",
         "@docusaurus/faster": "^3.8.1",
         "@docusaurus/plugin-client-redirects": "^3.8.1",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.0.251
         version: 1.0.251(@algolia/client-search@5.50.1)(@babel/core@7.29.0)(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.24)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.2))(@rspack/core@1.7.11)(@swc/core@1.15.24)(@types/react@19.2.14)(clsx@2.1.1)(postcss@8.5.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(search-insights@2.17.3)(styled-components@5.3.11(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5))(webpack@5.106.1(@swc/core@1.15.24))
       '@apify/docusaurus-plugin-typedoc-api':
-        specifier: ^5.1.6
-        version: 5.1.6(b5d850f32c50aa67ed4d2687a57dffc8)
+        specifier: ^5.1.7
+        version: 5.1.7(b5d850f32c50aa67ed4d2687a57dffc8)
       '@docusaurus/core':
         specifier: ^3.8.1
         version: 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.24)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
@@ -250,8 +250,8 @@ packages:
       react: '*'
       react-dom: '*'
 
-  '@apify/docusaurus-plugin-typedoc-api@5.1.6':
-    resolution: {integrity: sha512-qBjozPWltxMNyrH8GSM6V7KNTNc17KGcAOn8Z9RZftRH5SRhn/PKn/ENRAwjW8kpxT+0vEQAf+n32W/G7diZ8A==}
+  '@apify/docusaurus-plugin-typedoc-api@5.1.7':
+    resolution: {integrity: sha512-W70ZTzwDxcY1PUu6jRF+OfHG4zk3lgBsXjjMm9+2SS9tZH8Ajj/musVq/+4DQdFrWXBNvtq3vqkZnA4B1Idd3Q==}
     engines: {node: '>=16.12.0'}
     peerDependencies:
       '@docusaurus/core': ^3.8.1
@@ -7936,7 +7936,7 @@ snapshots:
       - webpack
       - webpack-cli
 
-  '@apify/docusaurus-plugin-typedoc-api@5.1.6(b5d850f32c50aa67ed4d2687a57dffc8)':
+  '@apify/docusaurus-plugin-typedoc-api@5.1.7(b5d850f32c50aa67ed4d2687a57dffc8)':
     dependencies:
       '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.24)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
       '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)


### PR DESCRIPTION
## Summary

Bump `@apify/docusaurus-plugin-typedoc-api` from `^5.1.6` to `^5.1.7` in `website/` to pick up the latest fixes and improvements from upstream.