### PR TITLE
chore(docs): fix codeowner pattern

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Documentation codeowner
 
-/docs/*.md @szaganek
-/docs/*.mdx @szaganek
+/docs/**/*.md @szaganek
+/docs/**/*.mdx @szaganek


### PR DESCRIPTION
Current pattern doesn't cover the whole docs tree.