### PR TITLE
refactor: Use canonical /v2/actors/ path instead of legacy /v2/acts/ alias

### DIFF
--- a/src/apify_client/_resource_clients/actor.py
+++ b/src/apify_client/_resource_clients/actor.py
@@ -75,7 +75,7 @@ class ActorClient(ResourceClient):
         self,
         *,
         resource_id: str,
-        resource_path: str = 'acts',
+        resource_path: str = 'actors',
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -571,7 +571,7 @@ class ActorClientAsync(ResourceClientAsync):
         self,
         *,
         resource_id: str,
-        resource_path: str = 'acts',
+        resource_path: str = 'actors',
         **kwargs: Any,
     ) -> None:
         super().__init__(

--- a/src/apify_client/_resource_clients/actor_collection.py
+++ b/src/apify_client/_resource_clients/actor_collection.py
@@ -36,7 +36,7 @@ class ActorCollectionClient(ResourceClient):
     def __init__(
         self,
         *,
-        resource_path: str = 'acts',
+        resource_path: str = 'actors',
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -215,7 +215,7 @@ class ActorCollectionClientAsync(ResourceClientAsync):
     def __init__(
         self,
         *,
-        resource_path: str = 'acts',
+        resource_path: str = 'actors',
         **kwargs: Any,
     ) -> None:
         super().__init__(

--- a/tests/unit/test_actor_start_params.py
+++ b/tests/unit/test_actor_start_params.py
@@ -64,7 +64,7 @@ def test_actor_start_passes_timeout_param_sync(httpserver: HTTPServer) -> None:
         )
 
     httpserver.expect_request(
-        f'/v2/acts/{_MOCKED_ACTOR_ID}/runs',
+        f'/v2/actors/{_MOCKED_ACTOR_ID}/runs',
         method='POST',
     ).respond_with_handler(capture_request)
 
@@ -97,7 +97,7 @@ async def test_actor_start_passes_timeout_param_async(httpserver: HTTPServer) ->
         )
 
     httpserver.expect_request(
-        f'/v2/acts/{_MOCKED_ACTOR_ID}/runs',
+        f'/v2/actors/{_MOCKED_ACTOR_ID}/runs',
         method='POST',
     ).respond_with_handler(capture_request)
 
@@ -130,7 +130,7 @@ def test_actor_start_timeout_not_passed_when_none_sync(httpserver: HTTPServer) -
         )
 
     httpserver.expect_request(
-        f'/v2/acts/{_MOCKED_ACTOR_ID}/runs',
+        f'/v2/actors/{_MOCKED_ACTOR_ID}/runs',
         method='POST',
     ).respond_with_handler(capture_request)
 
@@ -160,7 +160,7 @@ async def test_actor_start_timeout_not_passed_when_none_async(httpserver: HTTPSe
         )
 
     httpserver.expect_request(
-        f'/v2/acts/{_MOCKED_ACTOR_ID}/runs',
+        f'/v2/actors/{_MOCKED_ACTOR_ID}/runs',
         method='POST',
     ).respond_with_handler(capture_request)
 
@@ -191,7 +191,7 @@ def test_actor_start_various_timeout_values_sync(httpserver: HTTPServer, timeout
         )
 
     httpserver.expect_request(
-        f'/v2/acts/{_MOCKED_ACTOR_ID}/runs',
+        f'/v2/actors/{_MOCKED_ACTOR_ID}/runs',
         method='POST',
     ).respond_with_handler(capture_request)
 
@@ -218,7 +218,7 @@ async def test_actor_start_various_timeout_values_async(httpserver: HTTPServer, 
         )
 
     httpserver.expect_request(
-        f'/v2/acts/{_MOCKED_ACTOR_ID}/runs',
+        f'/v2/actors/{_MOCKED_ACTOR_ID}/runs',
         method='POST',
     ).respond_with_handler(capture_request)
 

--- a/tests/unit/test_client_errors.py
+++ b/tests/unit/test_client_errors.py
@@ -281,7 +281,7 @@ def test_actor_last_run_dataset_get_raises_on_404(httpserver: HTTPServer, sync_c
     """404 covers missing actor, missing last_run, or missing dataset — all three are indistinguishable from the single
     HTTP response (the client only hits the final URL), so `NotFoundError` propagates uniformly.
     """
-    httpserver.expect_request('/v2/acts/actor-id/runs/last/dataset').respond_with_json(_not_found_body(), status=404)
+    httpserver.expect_request('/v2/actors/actor-id/runs/last/dataset').respond_with_json(_not_found_body(), status=404)
     with pytest.raises(NotFoundError):
         sync_client.actor('actor-id').last_run().dataset().get()
 
@@ -289,13 +289,13 @@ def test_actor_last_run_dataset_get_raises_on_404(httpserver: HTTPServer, sync_c
 async def test_actor_last_run_dataset_get_raises_on_404_async(
     httpserver: HTTPServer, async_client: ApifyClientAsync
 ) -> None:
-    httpserver.expect_request('/v2/acts/actor-id/runs/last/dataset').respond_with_json(_not_found_body(), status=404)
+    httpserver.expect_request('/v2/actors/actor-id/runs/last/dataset').respond_with_json(_not_found_body(), status=404)
     with pytest.raises(NotFoundError):
         await async_client.actor('actor-id').last_run().dataset().get()
 
 
 def test_actor_last_run_dataset_get_returns_dataset(httpserver: HTTPServer, sync_client: ApifyClient) -> None:
-    httpserver.expect_request('/v2/acts/actor-id/runs/last/dataset').respond_with_json({'data': _DATASET_FIXTURE})
+    httpserver.expect_request('/v2/actors/actor-id/runs/last/dataset').respond_with_json({'data': _DATASET_FIXTURE})
     dataset = sync_client.actor('actor-id').last_run().dataset().get()
     assert dataset is not None
     assert dataset.id == 'ds-1'
@@ -304,7 +304,7 @@ def test_actor_last_run_dataset_get_returns_dataset(httpserver: HTTPServer, sync
 async def test_actor_last_run_dataset_get_returns_dataset_async(
     httpserver: HTTPServer, async_client: ApifyClientAsync
 ) -> None:
-    httpserver.expect_request('/v2/acts/actor-id/runs/last/dataset').respond_with_json({'data': _DATASET_FIXTURE})
+    httpserver.expect_request('/v2/actors/actor-id/runs/last/dataset').respond_with_json({'data': _DATASET_FIXTURE})
     dataset = await async_client.actor('actor-id').last_run().dataset().get()
     assert dataset is not None
     assert dataset.id == 'ds-1'

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -171,7 +171,7 @@ def mock_api(httpserver: HTTPServer) -> None:
     )
 
     # Add actor info endpoint
-    httpserver.expect_request(f'/v2/acts/{_MOCKED_ACTOR_ID}', method='GET').respond_with_json(
+    httpserver.expect_request(f'/v2/actors/{_MOCKED_ACTOR_ID}', method='GET').respond_with_json(
         {
             'data': {
                 'id': _MOCKED_ACTOR_ID,
@@ -203,7 +203,7 @@ def mock_api(httpserver: HTTPServer) -> None:
     )
 
     # Add actor run creation endpoint
-    httpserver.expect_request(f'/v2/acts/{_MOCKED_ACTOR_ID}/runs', method='POST').respond_with_json(
+    httpserver.expect_request(f'/v2/actors/{_MOCKED_ACTOR_ID}/runs', method='POST').respond_with_json(
         {
             'data': status_generator._create_minimal_run_data('Initial message', 'RUNNING', is_terminal=False),
         }
@@ -520,7 +520,7 @@ async def test_streamed_log_async_restart_after_normal_completion(httpserver: HT
     )
 
     # Set up actor info endpoint
-    httpserver.expect_request(f'/v2/acts/{_MOCKED_ACTOR_ID}', method='GET').respond_with_json(
+    httpserver.expect_request(f'/v2/actors/{_MOCKED_ACTOR_ID}', method='GET').respond_with_json(
         {
             'data': {
                 'id': _MOCKED_ACTOR_ID,
@@ -608,7 +608,7 @@ async def test_status_message_watcher_async_restart_after_normal_completion(http
     )
 
     # Set up actor info endpoint (needed for get_status_message_watcher)
-    httpserver.expect_request(f'/v2/acts/{_MOCKED_ACTOR_ID}', method='GET').respond_with_json(
+    httpserver.expect_request(f'/v2/actors/{_MOCKED_ACTOR_ID}', method='GET').respond_with_json(
         {
             'data': {
                 'id': _MOCKED_ACTOR_ID,
@@ -749,7 +749,7 @@ def _register_run_and_actor_endpoints(httpserver: HTTPServer) -> None:
             }
         }
     )
-    httpserver.expect_request(f'/v2/acts/{_MOCKED_ACTOR_ID}', method='GET').respond_with_json(
+    httpserver.expect_request(f'/v2/actors/{_MOCKED_ACTOR_ID}', method='GET').respond_with_json(
         {
             'data': {
                 'id': _MOCKED_ACTOR_ID,


### PR DESCRIPTION
Switches the actor resource client URLs from the legacy `/v2/acts/...` alias to the canonical `/v2/actors/...` family.

Follow-up to [apify/apify-docs#2522](https://github.com/apify/apify-docs/pull/2522) (and [apify/apify-core#27780](https://github.com/apify/apify-core/pull/27780)), which made `/v2/actors/...` the documented canonical path while keeping `/v2/acts/...` as an undocumented alias. Non-breaking — the server still accepts the legacy alias, but the client should hit the canonical path.