### PR TITLE
ci: Approve pnpm build scripts for docs build

### DIFF
--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -11,4 +11,5 @@ publicHoistPattern:
 allowBuilds:
   '@apify/ui-icons': true
   '@swc/core': true
+  core-js: false
   unrs-resolver: true

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -11,5 +11,4 @@ publicHoistPattern:
 allowBuilds:
   '@apify/ui-icons': true
   '@swc/core': true
-  core-js: true
   unrs-resolver: true

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -8,3 +8,8 @@ linkWorkspacePackages: true
 preferWorkspacePackages: true
 publicHoistPattern:
     - "*"
+allowBuilds:
+  '@apify/ui-icons': true
+  '@swc/core': true
+  core-js: true
+  unrs-resolver: true


### PR DESCRIPTION
The recent bump to pnpm v11 (#841) turned ignored package build scripts into a hard error, breaking the docs check:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @apify/ui-icons, @swc/core, core-js, unrs-resolver
```

This explicitly approves those packages' build scripts via an `allowBuilds` section in `website/pnpm-workspace.yaml` (pnpm 11's mechanism for opting dependencies into running install scripts).

Verified locally that `pnpm install` and `uv run poe build-docs` both succeed.