### PR TITLE
test: fix flaky webhook dispatch pagination test

### DIFF
--- a/tests/integration/test_webhook_dispatch.py
+++ b/tests/integration/test_webhook_dispatch.py
@@ -69,10 +69,15 @@ async def test_webhook_dispatch_list_pagination(client: ApifyClient | ApifyClien
     # `desc=True` must return dispatches in non-increasing `created_at` order.
     created_ats = [d.created_at for d in page.items if d.created_at is not None]
     assert created_ats == sorted(created_ats, reverse=True)
-    # `offset` must move the window — second page must not start with the same id as the first
-    # (only meaningful when the first page is full, i.e. at least 5 items exist).
-    if len(page.items) == 5:
-        next_page = await maybe_await(client.webhook_dispatches().list(limit=5, offset=5, desc=True))
+    # `offset` must move the window — the second page must not start with the same id as the first.
+    # Query in ascending order so the window is anchored to the oldest dispatches: with `desc=True`,
+    # dispatches created by other tests running in parallel land at the head and can shift the first
+    # page down into the second between the two calls, making both pages start with the same id.
+    asc_page = await maybe_await(client.webhook_dispatches().list(limit=5, offset=0, desc=False))
+    assert isinstance(asc_page, ListOfWebhookDispatches)
+    # Only meaningful when the first page is full, i.e. at least 5 dispatches exist.
+    if len(asc_page.items) == 5:
+        next_page = await maybe_await(client.webhook_dispatches().list(limit=5, offset=5, desc=False))
         assert isinstance(next_page, ListOfWebhookDispatches)
         if next_page.items:
-            assert page.items[0].id != next_page.items[0].id
+            assert asc_page.items[0].id != next_page.items[0].id

--- a/tests/integration/test_webhook_dispatch.py
+++ b/tests/integration/test_webhook_dispatch.py
@@ -70,12 +70,10 @@ async def test_webhook_dispatch_list_pagination(client: ApifyClient | ApifyClien
     created_ats = [d.created_at for d in page.items if d.created_at is not None]
     assert created_ats == sorted(created_ats, reverse=True)
     # `offset` must move the window — the second page must not start with the same id as the first.
-    # Query in ascending order so the window is anchored to the oldest dispatches: with `desc=True`,
-    # dispatches created by other tests running in parallel land at the head and can shift the first
-    # page down into the second between the two calls, making both pages start with the same id.
+    # Use ascending order so dispatches created by parallel tests can't shift the pages between calls.
     asc_page = await maybe_await(client.webhook_dispatches().list(limit=5, offset=0, desc=False))
     assert isinstance(asc_page, ListOfWebhookDispatches)
-    # Only meaningful when the first page is full, i.e. at least 5 dispatches exist.
+    # Only meaningful when the first page is full.
     if len(asc_page.items) == 5:
         next_page = await maybe_await(client.webhook_dispatches().list(limit=5, offset=5, desc=False))
         assert isinstance(next_page, ListOfWebhookDispatches)


### PR DESCRIPTION
## What & why

`test_webhook_dispatch_list_pagination` was flaky on CI ([failing run](https://github.com/apify/apify-client-python/actions/runs/26631332682/job/78480663231)).

The offset check fetched two `desc=True` (newest-first) pages and asserted they start with different ids. But webhook dispatches created by other tests running in parallel land at the **head** of the desc-ordered list, shifting the window between the two calls. When ≥5 new dispatches appeared between the calls, page 1's first item slid to offset 5 — so both pages started with the same id and the assertion failed.

## Fix

Query the offset window in **ascending** order (`desc=False`) so it's anchored to the oldest dispatches. New dispatches append at the tail, leaving the front window stable, and the global-oldest item can never reach offset 5. This is race-free while still exercising the `offset` parameter. The `desc=True` ordering assertion is kept unchanged.