### PR TITLE
ci: build release docs from the branch tip, not the dispatch ref

### DIFF
--- a/.github/workflows/manual_release_docs.yaml
+++ b/.github/workflows/manual_release_docs.yaml
@@ -3,9 +3,21 @@ name: Release docs
 on:
   # Runs when manually triggered from the GitHub UI.
   workflow_dispatch:
+    inputs:
+      ref:
+        description: Commit SHA or ref to build the docs from. If empty, the triggering ref is used.
+        required: false
+        type: string
+        default: ""
 
   # Runs when invoked by another workflow.
   workflow_call:
+    inputs:
+      ref:
+        description: Commit SHA or ref to build the docs from. If empty, the triggering ref is used.
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -39,6 +51,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.ref }}
           token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
       - name: Set up Node

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -144,4 +144,10 @@ jobs:
       id-token: write
       checks: read
     uses: ./.github/workflows/manual_release_docs.yaml
+    with:
+      # Build from the up-to-date branch tip, not the workflow-dispatch ref. The default checkout
+      # pins to the dispatch commit (pre-bump), which predates the changelog finalization and the
+      # version snapshot pushed earlier in this run — so the docs would be redeployed from stale
+      # content (e.g. the changelog stuck at "not yet released").
+      ref: ${{ github.ref_name }}
     secrets: inherit


### PR DESCRIPTION
Aligns the release docs deploy with apify/crawlee-python#1946, so all three Python repos build and deploy docs the same way.

In the stable release the docs build checked out the workflow-dispatch ref (the pre-bump commit), which predates the changelog finalization and the version snapshot pushed earlier in the run. This repo wasn't visibly affected — the `Update docs theme` step's `git pull --rebase` already moves the build to the latest master — but that reliance was implicit. The build now checks out the up-to-date branch tip (`github.ref_name`) explicitly, via a new optional `ref` input on `manual_release_docs.yaml`. Other entry points (on-master docs deploys, manual dispatches) are unaffected because `ref` defaults to the triggering ref.

Unlike here, crawlee-python lacks the theme-update step, so there the stale ref actually broke the deployed changelog (stuck at "not yet released") — see apify/crawlee-python#1946 for the full diagnosis.
