### PR TITLE
docs: align API reference package name with PyPI

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "apify-client-python-website",
+    "name": "apify-client",
     "private": true,
     "scripts": {
         "clean": "rimraf .docusaurus build",

--- a/website/versioned_docs/version-3.0/api-packages.json
+++ b/website/versioned_docs/version-3.0/api-packages.json
@@ -1,1 +1,1 @@
-[{"entryPoints":{"index":{"label":"Index","path":"src/index.ts"}},"packageRoot":".","packagePath":".","packageSlug":".","packageName":"apify-client-python-website"}]
+[{"entryPoints":{"index":{"label":"Index","path":"src/index.ts"}},"packageRoot":".","packagePath":".","packageSlug":".","packageName":"apify-client"}]


### PR DESCRIPTION
The package name is rendered as the label on the docs website API reference pages, so this renames it back from `apify-client-python-website` to `apify-client` (the PyPI package).

@B4nan tagging you as a reviewer since you changed this recently — let me know if there was any reasoning behind it that I'm missing.