### PR TITLE
fix: include all supported fields for ad-hoc webhooks

### DIFF
--- a/src/apify_client/_models.py
+++ b/src/apify_client/_models.py
@@ -3766,6 +3766,18 @@ class WebhookRepresentation(BaseModel):
     """
     Optional template for the HTTP headers sent by the webhook.
     """
+    idempotency_key: Annotated[str | None, Field(alias='idempotencyKey', examples=['fdSJmdP3nfs7sfk3y'])] = None
+    """
+    Optional key that prevents creating duplicate webhooks, e.g. when the run-starting request is retried.
+    """
+    ignore_ssl_errors: Annotated[bool | None, Field(alias='ignoreSslErrors', examples=[False])] = None
+    """
+    Optional flag to ignore SSL errors when the webhook sends the request.
+    """
+    do_not_retry: Annotated[bool | None, Field(alias='doNotRetry', examples=[False])] = None
+    """
+    Optional flag to skip retrying the webhook request on failure.
+    """
 
 
 @docs_group('Models')

--- a/src/apify_client/_models.py
+++ b/src/apify_client/_models.py
@@ -3766,17 +3766,21 @@ class WebhookRepresentation(BaseModel):
     """
     Optional template for the HTTP headers sent by the webhook.
     """
+    should_interpolate_strings: Annotated[bool | None, Field(alias='shouldInterpolateStrings', examples=[False])] = None
+    """
+    Flag to also interpolate `{{...}}` variables inside string values of the payload and headers templates.
+    """
     idempotency_key: Annotated[str | None, Field(alias='idempotencyKey', examples=['fdSJmdP3nfs7sfk3y'])] = None
     """
-    Optional key that prevents creating duplicate webhooks, e.g. when the run-starting request is retried.
+    Key that prevents creating duplicate webhooks, e.g. when the run-starting request is retried.
     """
     ignore_ssl_errors: Annotated[bool | None, Field(alias='ignoreSslErrors', examples=[False])] = None
     """
-    Optional flag to ignore SSL errors when the webhook sends the request.
+    Flag to ignore SSL errors when the webhook sends the request.
     """
     do_not_retry: Annotated[bool | None, Field(alias='doNotRetry', examples=[False])] = None
     """
-    Optional flag to skip retrying the webhook request on failure.
+    Flag to skip retrying the webhook request on failure.
     """
 
 

--- a/src/apify_client/_typeddicts.py
+++ b/src/apify_client/_typeddicts.py
@@ -336,17 +336,21 @@ class WebhookRepresentationDict(TypedDict):
     """
     Optional template for the HTTP headers sent by the webhook.
     """
+    should_interpolate_strings: NotRequired[bool | None]
+    """
+    Flag to also interpolate `{{...}}` variables inside string values of the payload and headers templates.
+    """
     idempotency_key: NotRequired[str | None]
     """
-    Optional key that prevents creating duplicate webhooks, e.g. when the run-starting request is retried.
+    Key that prevents creating duplicate webhooks, e.g. when the run-starting request is retried.
     """
     ignore_ssl_errors: NotRequired[bool | None]
     """
-    Optional flag to ignore SSL errors when the webhook sends the request.
+    Flag to ignore SSL errors when the webhook sends the request.
     """
     do_not_retry: NotRequired[bool | None]
     """
-    Optional flag to skip retrying the webhook request on failure.
+    Flag to skip retrying the webhook request on failure.
     """
 
 
@@ -386,15 +390,19 @@ class WebhookRepresentationCamelDict(TypedDict):
     """
     Optional template for the HTTP headers sent by the webhook.
     """
+    shouldInterpolateStrings: NotRequired[bool | None]
+    """
+    Flag to also interpolate `{{...}}` variables inside string values of the payload and headers templates.
+    """
     idempotencyKey: NotRequired[str | None]
     """
-    Optional key that prevents creating duplicate webhooks, e.g. when the run-starting request is retried.
+    Key that prevents creating duplicate webhooks, e.g. when the run-starting request is retried.
     """
     ignoreSslErrors: NotRequired[bool | None]
     """
-    Optional flag to ignore SSL errors when the webhook sends the request.
+    Flag to ignore SSL errors when the webhook sends the request.
     """
     doNotRetry: NotRequired[bool | None]
     """
-    Optional flag to skip retrying the webhook request on failure.
+    Flag to skip retrying the webhook request on failure.
     """

--- a/src/apify_client/_typeddicts.py
+++ b/src/apify_client/_typeddicts.py
@@ -336,6 +336,18 @@ class WebhookRepresentationDict(TypedDict):
     """
     Optional template for the HTTP headers sent by the webhook.
     """
+    idempotency_key: NotRequired[str | None]
+    """
+    Optional key that prevents creating duplicate webhooks, e.g. when the run-starting request is retried.
+    """
+    ignore_ssl_errors: NotRequired[bool | None]
+    """
+    Optional flag to ignore SSL errors when the webhook sends the request.
+    """
+    do_not_retry: NotRequired[bool | None]
+    """
+    Optional flag to skip retrying the webhook request on failure.
+    """
 
 
 @docs_group('Typed dicts')
@@ -373,4 +385,16 @@ class WebhookRepresentationCamelDict(TypedDict):
     headersTemplate: NotRequired[str | None]
     """
     Optional template for the HTTP headers sent by the webhook.
+    """
+    idempotencyKey: NotRequired[str | None]
+    """
+    Optional key that prevents creating duplicate webhooks, e.g. when the run-starting request is retried.
+    """
+    ignoreSslErrors: NotRequired[bool | None]
+    """
+    Optional flag to ignore SSL errors when the webhook sends the request.
+    """
+    doNotRetry: NotRequired[bool | None]
+    """
+    Optional flag to skip retrying the webhook request on failure.
     """

--- a/src/apify_client/_utils.py
+++ b/src/apify_client/_utils.py
@@ -288,31 +288,25 @@ def encode_webhooks_to_base64(webhooks: WebhooksList | None) -> str | None:
 
     Returns `None` for `None` or an empty list, so the query parameter is omitted.
 
-    See `WebhooksList` for the accepted shapes. `WebhookRepresentation` instances are used as-is; `WebhookCreate`
-    instances are projected onto the `WebhookRepresentation` fields, dropping persistent-only fields like `condition`.
-    Dict shapes are validated into `WebhookRepresentation` and only fields it declares are kept.
+    See `WebhooksList` for the accepted shapes. `WebhookRepresentation` instances are used as-is. `WebhookCreate`
+    instances and dict shapes are projected onto the fields `WebhookRepresentation` declares, dropping anything else
+    (e.g. persistent-only fields like `condition`). Filtering by the declared field names and aliases means new
+    ad-hoc fields added to `WebhookRepresentation` flow through automatically, without touching this function.
     """
     if not webhooks:
         return None
 
     representations = list[WebhookRepresentation]()
+    allowed = _webhook_representation_keys()
 
     for webhook in webhooks:
         if isinstance(webhook, WebhookRepresentation):
             representations.append(webhook)
-        elif isinstance(webhook, WebhookCreate):
-            representations.append(
-                WebhookRepresentation(
-                    event_types=webhook.event_types,
-                    request_url=webhook.request_url,
-                    payload_template=webhook.payload_template,
-                    headers_template=webhook.headers_template,
-                )
-            )
-        else:
-            allowed = _webhook_representation_keys()
-            filtered = {k: v for k, v in webhook.items() if k in allowed}
-            representations.append(WebhookRepresentation.model_validate(filtered))
+            continue
+
+        data = webhook.model_dump(by_alias=True) if isinstance(webhook, WebhookCreate) else dict(webhook)
+        filtered = {key: value for key, value in data.items() if key in allowed}
+        representations.append(WebhookRepresentation.model_validate(filtered))
 
     data = [r.model_dump(by_alias=True, exclude_none=True) for r in representations]
     json_string = json.dumps(data).encode(encoding='utf-8')

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import io
+import json
+from base64 import b64decode
 from datetime import timedelta
 from http import HTTPStatus
 from typing import TYPE_CHECKING
@@ -27,6 +29,7 @@ from apify_client.errors import ApifyApiError, InvalidResponseBodyError
 
 if TYPE_CHECKING:
     from apify_client._typeddicts import WebhookRepresentationDict
+    from apify_client.types import WebhooksList
 
 
 def test_to_safe_id() -> None:
@@ -56,6 +59,64 @@ def test_encode_webhooks_to_base64() -> None:
         )
         == 'W3siZXZlbnRUeXBlcyI6IFsiQUNUT1IuUlVOLkNSRUFURUQiXSwgInJlcXVlc3RVcmwiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9ydW4tY3JlYXRlZCJ9LCB7ImV2ZW50VHlwZXMiOiBbIkFDVE9SLlJVTi5TVUNDRUVERUQiXSwgInJlcXVlc3RVcmwiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9ydW4tc3VjY2VlZGVkIiwgInBheWxvYWRUZW1wbGF0ZSI6ICJ7XCJoZWxsb1wiOiBcIndvcmxkXCIsIFwicmVzb3VyY2VcIjp7e3Jlc291cmNlfX19In1d'  # noqa: E501
     )
+
+
+@pytest.mark.parametrize(
+    'webhooks',
+    [
+        pytest.param(
+            [
+                WebhookCreate(
+                    event_types=['ACTOR.RUN.SUCCEEDED'],
+                    condition=WebhookCondition(),
+                    request_url='https://example.com/run-succeeded',
+                    idempotency_key='some-key',
+                    ignore_ssl_errors=True,
+                    do_not_retry=True,
+                ),
+            ],
+            id='webhook-create-model',
+        ),
+        pytest.param(
+            [
+                {
+                    'event_types': ['ACTOR.RUN.SUCCEEDED'],
+                    'request_url': 'https://example.com/run-succeeded',
+                    'idempotency_key': 'some-key',
+                    'ignore_ssl_errors': True,
+                    'do_not_retry': True,
+                },
+            ],
+            id='snake-case-dict',
+        ),
+        pytest.param(
+            [
+                {
+                    'eventTypes': ['ACTOR.RUN.SUCCEEDED'],
+                    'requestUrl': 'https://example.com/run-succeeded',
+                    'idempotencyKey': 'some-key',
+                    'ignoreSslErrors': True,
+                    'doNotRetry': True,
+                },
+            ],
+            id='camel-case-dict',
+        ),
+    ],
+)
+def test_encode_webhooks_to_base64_keeps_adhoc_fields(webhooks: WebhooksList) -> None:
+    """Test that the idempotency key and the SSL/retry flags survive the projection for every accepted shape."""
+    result = encode_webhooks_to_base64(webhooks)
+
+    assert result is not None
+    assert json.loads(b64decode(result)) == [
+        {
+            'eventTypes': ['ACTOR.RUN.SUCCEEDED'],
+            'requestUrl': 'https://example.com/run-succeeded',
+            'idempotencyKey': 'some-key',
+            'ignoreSslErrors': True,
+            'doNotRetry': True,
+        }
+    ]
 
 
 def test_encode_webhooks_to_base64_from_dicts() -> None:


### PR DESCRIPTION
This PR updates the auto-generated Pydantic models and TypedDicts based on OpenAPI specification changes in [apify-docs PR #2640](https://github.com/apify/apify-docs/pull/2640).

On top of the regenerated models, it fixes a related bug: ad-hoc webhooks passed to `start()` / `call()` silently dropped `idempotency_key`, `ignore_ssl_errors` and `do_not_retry`. `WebhookRepresentation` declared only the four templating fields, and `encode_webhooks_to_base64` keeps only declared fields, so these three never reached the platform. The platform accepts and honors all three for ad-hoc webhooks (verified in apify-core: the run-start handler feeds them into the same webhook-creation path as the create-webhook endpoint, including the `idempotencyKey` dedup).

What changed:

- The regenerated models add the three fields to `WebhookRepresentation` and both webhook-representation typed dicts (snake_case + camelCase).
- Reworks the `WebhookCreate` / dict projection in `encode_webhooks_to_base64` to filter by the fields `WebhookRepresentation` declares, instead of hand-listing them. New ad-hoc fields now flow through automatically, so this class of silent-drop bug cannot recur.

Supersedes #854 (a manual version of the same fix).

Unblocks apify/apify-sdk-python#963, which forwards these fields from the SDK `Webhook` dataclass.
