### PR TITLE
chore: switch Renovate lock-file maintenance & dev-deps to PR automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
     "lockFileMaintenance": {
         "enabled": true,
         "automerge": true,
-        "automergeType": "branch"
+        "automergeType": "pr"
     },
     "packageRules": [
         {
@@ -18,7 +18,7 @@
             "groupName": "major/minor dev dependencies",
             "groupSlug": "dev-dependencies",
             "automerge": true,
-            "automergeType": "branch"
+            "automergeType": "pr"
         },
         {
             "matchPackageNames": ["@apify/*", "@crawlee/*", "apify", "apify-client", "apify-shared", "apify-fingerprint-datapoints", "crawlee", "got-scraping"],


### PR DESCRIPTION
`lockFileMaintenance` and the "major/minor dev dependencies" rule used `automergeType: "branch"`, which never opens a PR and relies on branch automerge merging directly into `master` once branch status checks pass. But CI only runs on `pull_request` and pushes to `master`, so no checks ever run on `renovate/*` branches and the branch can never go green. The update (including `uv.lock`) just piled up on the branch with no PR and no merge.

Switch both rules to `automergeType: "pr"` so Renovate opens a PR (which triggers the existing pull_request CI) and auto-merges it once green, consistent with every other update in this repo.
