### PR TITLE
test: raise default poll_until_condition timeout to deflake integration tests

### DIFF
--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -134,7 +134,7 @@ async def poll_until_condition(
     fn: Callable[[], Awaitable[T] | T],
     condition: Callable[[T], bool] = bool,
     *,
-    timeout: float = 5,
+    timeout: float = 30,
     poll_interval: float = 1,
     backoff_factor: float = 1,
 ) -> T:

--- a/tests/integration/test_request_queue.py
+++ b/tests/integration/test_request_queue.py
@@ -526,7 +526,7 @@ async def test_request_queue_unlock_requests(client: ApifyClient | ApifyClientAs
             assert isinstance(head, RequestQueueHead)
             return locked_ids.isdisjoint(item.id for item in head.items)
 
-        await poll_until_condition(all_locks_visible, timeout=30, poll_interval=1)
+        await poll_until_condition(all_locks_visible)
 
         # Unlock all requests
         unlock_response = await maybe_await(rq_client.unlock_requests())

--- a/tests/integration/test_run.py
+++ b/tests/integration/test_run.py
@@ -295,7 +295,7 @@ async def test_run_metamorph(client: ApifyClient | ApifyClientAsync) -> None:
             return await maybe_await(run_client.get())
 
         await poll_until_condition(
-            get_run, lambda run: isinstance(run, Run) and run.status != 'READY', timeout=30, backoff_factor=2
+            get_run, lambda run: isinstance(run, Run) and run.status != 'READY', backoff_factor=2
         )
 
         # Metamorph the run into the same actor (allowed) with new input
@@ -339,7 +339,7 @@ async def test_run_reboot(client: ApifyClient | ApifyClientAsync) -> None:
             return await maybe_await(run_client.get())
 
         current_run = await poll_until_condition(
-            get_run, lambda run: isinstance(run, Run) and run.status != 'READY', timeout=30, backoff_factor=2
+            get_run, lambda run: isinstance(run, Run) and run.status != 'READY', backoff_factor=2
         )
 
         # Only try to reboot if the run is still running


### PR DESCRIPTION
The `test_request_queue_list_and_lock_head` integration test flaked on a loaded Python 3.14 CI runner: after adding 5 requests, the queue head stayed empty past the 5s poll ceiling (`assert 0 == 5`). The Apify platform's listing endpoints are eventually consistent, so the 5s default in `poll_until_condition` was too tight under parallel load.

Raise the default timeout from 5s to 30s, and drop the now-redundant explicit `timeout=30` overrides in the request-queue and run tests. The timeout is only a ceiling, so happy paths are unaffected.

Failing CI run: https://github.com/apify/apify-client-python/actions/runs/27765226958/job/82149997276