### PR TITLE
chore(ci): Update renovate schedules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
         "enabled": true,
         "automerge": true,
         "automergeType": "pr",
-        "schedule": ["* 1-3 * * 1"]
+        "schedule": ["* 1-2 * * 1"]
     },
     "packageRules": [
         {
@@ -32,6 +32,6 @@
     ],
     "minimumReleaseAge": "1 day",
     "internalChecksFilter": "strict",
-    "schedule": ["* 4-6 * * 1-5"],
+    "schedule": ["* 1-2 * * 2-5"],
     "ignoreDeps": ["apify_client", "docusaurus-plugin-typedoc-api"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
         "enabled": true,
         "automerge": true,
         "automergeType": "pr",
-        "schedule": ["before 11am every weekday"]
+        "schedule": ["* 1-3 * * 1"]
     },
     "packageRules": [
         {
@@ -32,6 +32,6 @@
     ],
     "minimumReleaseAge": "1 day",
     "internalChecksFilter": "strict",
-    "schedule": ["before 7am every weekday"],
+    "schedule": ["* 4-6 * * 1-5"],
     "ignoreDeps": ["apify_client", "docusaurus-plugin-typedoc-api"]
 }


### PR DESCRIPTION
- Replace deprecated `breejslater` syntax with `cron` syntax
https://docs.renovatebot.com/key-concepts/scheduling/#deprecated-breejslater-syntax
- Use these triggers, limit the window to avoid spam:
  - Every **Tuesday - Friday** between **1:00 and 2:00** to update **dependencies**
  - Every **Monday** between **1:00 and 2:00** to update **lockfiles** 
- Do not run both jobs on the same day.