### PR TITLE
ci: prevent regenerate-models from opening duplicate empty PRs

### DIFF
--- a/.github/workflows/manual_regenerate_models.yaml
+++ b/.github/workflows/manual_regenerate_models.yaml
@@ -151,11 +151,11 @@ jobs:
         uses: apify/actions/signed-commit@v1.2.0
         with:
           message: ${{ env.TITLE }}
-          add: 'src/apify_client/_models.py src/apify_client/_typeddicts.py src/apify_client/_literals.py'
+          add: "src/apify_client/_models.py src/apify_client/_typeddicts.py src/apify_client/_literals.py"
           github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
           branch: ${{ env.BRANCH }}
           create-branch: ${{ steps.branch.outputs.create }}
-          retries: '3'
+          retries: "3"
 
       # Ensure exactly one PR exists for this branch. It's no longer auto-closed, so an existing PR is
       # reused. Only the first run (or one whose PR step a concurrent dispatch cancelled) creates it.

--- a/.github/workflows/manual_regenerate_models.yaml
+++ b/.github/workflows/manual_regenerate_models.yaml
@@ -108,31 +108,56 @@ jobs:
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Point the auto-update branch at the current master so the signed-commit step below records
-      # the regenerated models as a single commit on top of it. Resetting to master (instead of
-      # building on a possibly stale existing branch) is what keeps the committed diff relative to
-      # the current master: an already-merged change can never reappear. Any previous content on the
-      # branch is intentionally replaced, so the PR always reflects "current master + freshly
-      # regenerated models" — and it still updates whenever the source docs PR gets new commits.
-      - name: Point branch at current master
-        if: steps.changes.outputs.has_changes == 'true'
-        run: |
-          git checkout -B "$BRANCH"
-          git push --force origin "HEAD:refs/heads/$BRANCH"
-
-      - name: Commit model changes
+      # Commit the regenerated models as a single commit on top of the current master and move the
+      # auto-update branch to it with one atomic force-push. Building on a fresh master checkout (not
+      # on the possibly stale existing branch) keeps the committed diff relative to the current
+      # master, so an already-merged change can never reappear as a fresh diff.
+      #
+      # The branch goes straight from its previous state to "master + commit" in a single push — it
+      # is never published as being equal to master. This is the crux of the fix: the previous flow
+      # force-pushed the branch to master first and committed on top in a second step, and that
+      # intermediate "branch == master" state made the open PR's head identical to its base, which
+      # GitHub auto-closes. The next dispatch then opened a brand-new PR (`gh pr list --head` only
+      # matches open PRs), and the auto-closed one was left looking empty once its commit was orphaned
+      # by the following reset. Moving the branch forward in one step keeps the single existing PR
+      # open and simply updates it.
+      #
+      # Trade-off vs. apify/actions/signed-commit (used before): the commit is authored with a plain
+      # `git commit` and is therefore not GPG-"Verified". Signed commits are not required on master
+      # (branch protection has required_signatures disabled) and this branch is always squash-merged
+      # through a reviewed PR, so the verified badge carries no weight here.
+      - name: Update branch with regenerated models
         id: commit
         if: steps.changes.outputs.has_changes == 'true'
-        uses: apify/actions/signed-commit@v1.2.0
-        with:
-          message: ${{ env.TITLE }}
-          add: 'src/apify_client/_models.py src/apify_client/_typeddicts.py src/apify_client/_literals.py'
-          github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
-          branch: ${{ env.BRANCH }}
-          create-branch: 'false'
+        run: |
+          git config user.name 'Apify Service Account'
+          git config user.email '64261774+apify-service-account@users.noreply.github.com'
 
+          files='src/apify_client/_models.py src/apify_client/_typeddicts.py src/apify_client/_literals.py'
+
+          # If the remote branch already carries exactly these regenerated files, there is nothing to
+          # do. Skipping the push avoids a redundant commit and the CI re-run it triggers when the
+          # same docs PR dispatches this workflow repeatedly without actually changing the spec.
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git fetch --depth=1 origin "$BRANCH"
+            if git diff --quiet FETCH_HEAD -- $files; then
+              echo "Remote branch '$BRANCH' already has the current regenerated models — skipping push."
+              echo "pushed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          git checkout -B "$BRANCH"
+          git add $files
+          git commit -m "$TITLE"
+          git push --force origin "$BRANCH"
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
+      # Ensure exactly one PR exists for this branch. The branch is never auto-closed now, so an
+      # existing open PR is found and reused; only the first run (or one whose PR step was cancelled
+      # by a concurrent dispatch before it could open the PR) actually creates it.
       - name: Create or update PR
-        if: steps.commit.outputs.committed == 'true'
+        if: steps.changes.outputs.has_changes == 'true'
         id: pr
         env:
           GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
@@ -164,9 +189,12 @@ jobs:
             echo "created=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Post a cross-repo comment on the original docs PR so reviewers know about the corresponding client-python PR.
+      # Post a cross-repo comment on the original docs PR so reviewers know about the corresponding
+      # client-python PR. Comment only when something actually happened — the companion PR was just
+      # created, or a real spec change was pushed to it. Repeated dispatches that change nothing
+      # (pushed=false) post no comment, avoiding noise on the docs PR.
       - name: Comment on apify-docs PR
-        if: steps.commit.outputs.committed == 'true' && inputs.docs_pr_number
+        if: inputs.docs_pr_number && (steps.pr.outputs.created == 'true' || steps.commit.outputs.pushed == 'true')
         env:
           GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
           PR_CREATED: ${{ steps.pr.outputs.created }}

--- a/.github/workflows/manual_regenerate_models.yaml
+++ b/.github/workflows/manual_regenerate_models.yaml
@@ -63,16 +63,14 @@ jobs:
         with:
           token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
-      # Remember master's commit. A subsequent dispatch checks out the auto-update branch before
-      # regenerating, so "did regeneration change anything vs. master?" is answered against this
-      # recorded SHA rather than the current HEAD (which may be the branch tip by then).
+      # Record master's SHA now: a later dispatch checks out the auto-update branch before regenerating,
+      # so the "did anything change vs. master?" check below must compare against this SHA, not HEAD.
       - name: Record master ref
         id: base
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      # Detect whether the auto-update branch already exists on the remote. If it does, a previous
-      # dispatch for the same docs PR already opened a PR and we append to it; if not, the
-      # signed-commit step creates the branch from master.
+      # Does the auto-update branch already exist on the remote? If so, a previous dispatch opened the PR
+      # and we append to it. If not, the signed-commit step creates it from master.
       - name: Determine auto-update branch state
         id: branch
         run: |
@@ -84,13 +82,10 @@ jobs:
             echo "create=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # When the branch already exists, check it out before regenerating so the regenerated models
-      # are committed as a NEW commit on top of it — mirroring the new commit just pushed to the
-      # apify-docs PR. signed-commit checks out this same branch internally; switching to it now,
-      # while the tree is still clean, makes that internal checkout a no-op and keeps the regenerated
-      # files staged. Staying on master and letting signed-commit switch branches would fail: the
-      # regenerated files differ between master and the branch, and a plain `git checkout` refuses to
-      # overwrite local modifications.
+      # Check out the existing branch before regenerating so the new models land as a NEW commit on top,
+      # mirroring the commit just pushed to the docs PR. We must switch now, while the tree is clean:
+      # signed-commit's own checkout is a plain `git checkout` that would refuse to overwrite the
+      # regenerated files (which differ between master and the branch) once they're in the working tree.
       - name: Check out existing auto-update branch
         if: steps.branch.outputs.exists == 'true'
         run: |
@@ -127,11 +122,9 @@ jobs:
             uv run poe generate-models
           fi
 
-      # Proceed only when the regenerated models differ from the current master. Comparing against
-      # the recorded master SHA (the working tree may now sit on the auto-update branch) skips runs
-      # that would produce an empty PR — a spec change that doesn't affect the client models, or a
-      # change already merged into master. On a brand-new branch it also avoids creating the branch
-      # at all when there is nothing to regenerate.
+      # Proceed only when the regenerated models differ from master (compared against the recorded SHA,
+      # since the tree may now sit on the branch), which skips empty-PR runs: a spec change that doesn't
+      # affect the client models, or one already merged into master. Also avoids creating an empty branch.
       - name: Check for model changes
         id: changes
         run: |
@@ -142,20 +135,16 @@ jobs:
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Append the regenerated models to the auto-update branch as a single signed ("Verified")
-      # commit via apify/actions/signed-commit (GitHub's createCommitOnBranch GraphQL mutation).
+      # Append the regenerated models to the auto-update branch as a single signed ("Verified") commit
+      # via apify/actions/signed-commit (GitHub's createCommitOnBranch GraphQL mutation). It's added on
+      # top of the branch tip, never resetting to master: a fresh docs PR creates the branch
+      # (create-branch) and its first commit, and each later docs-PR commit triggers a dispatch that
+      # appends another, so the client PR mirrors the docs PR and stays open.
       #
-      # The commit is APPENDED on top of the branch's current tip — the branch is never reset to
-      # master. A fresh docs PR creates the branch (create-branch) and its first commit; every later
-      # dispatch, triggered by a new commit on the docs PR, adds another commit, so the client PR
-      # mirrors the docs PR commit-for-commit and stays open throughout. The previous flow instead
-      # force-pushed the branch to master before committing, and that intermediate "branch == master"
-      # state made the open PR's head identical to its base, which GitHub auto-closes; each dispatch
-      # then opened a brand-new duplicate PR (`gh pr list --head` only matches open PRs) and left the
-      # auto-closed one looking empty.
-      #
-      # signed-commit stages the files against the branch tip and sets committed=false when they are
-      # identical, so a repeated dispatch that regenerates the same models adds no commit.
+      # Appending (rather than force-pushing the branch to master, as before) is what keeps the PR open:
+      # a "branch == master" tip makes the PR head equal its base, which GitHub auto-closes, and each
+      # dispatch then opens a duplicate PR. signed-commit also sets committed=false when the staged
+      # files match the tip, so a repeated dispatch regenerating identical models adds no commit.
       - name: Commit regenerated models
         id: commit
         if: steps.changes.outputs.has_changes == 'true'
@@ -168,9 +157,8 @@ jobs:
           create-branch: ${{ steps.branch.outputs.create }}
           retries: '3'
 
-      # Ensure exactly one PR exists for this branch. The branch is never auto-closed now, so an
-      # existing open PR is found and reused; only the first run (or one whose PR step was cancelled
-      # by a concurrent dispatch before it could open the PR) actually creates it.
+      # Ensure exactly one PR exists for this branch. It's no longer auto-closed, so an existing PR is
+      # reused. Only the first run (or one whose PR step a concurrent dispatch cancelled) creates it.
       - name: Create or update PR
         if: steps.changes.outputs.has_changes == 'true'
         id: pr
@@ -204,10 +192,9 @@ jobs:
             echo "created=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Post a cross-repo comment on the original docs PR so reviewers know about the corresponding
-      # client-python PR. Comment only when something actually happened — the companion PR was just
-      # created, or a new commit was appended to it. Repeated dispatches that change nothing
-      # (committed=false) post no comment, avoiding noise on the docs PR.
+      # Post a cross-repo comment on the docs PR pointing reviewers to the companion client-python PR.
+      # Only when something happened: the PR was just created, or a commit was appended. A repeated
+      # dispatch that changes nothing (committed=false) posts no comment, avoiding noise on the docs PR.
       - name: Comment on apify-docs PR
         if: inputs.docs_pr_number && (steps.pr.outputs.created == 'true' || steps.commit.outputs.committed == 'true')
         env:

--- a/.github/workflows/manual_regenerate_models.yaml
+++ b/.github/workflows/manual_regenerate_models.yaml
@@ -63,11 +63,14 @@ jobs:
         with:
           token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
-      # Record master's SHA now: a later dispatch checks out the auto-update branch before regenerating,
-      # so the "did anything change vs. master?" check below must compare against this SHA, not HEAD.
+      # Record master's SHA up front: a later step checks out the auto-update branch, so the change check below
+      # can't compare against HEAD. Resolve master from the remote rather than the checked-out ref: the run may be
+      # dispatched from a non-master ref, but that check and the PR both target master, so master is the baseline.
       - name: Record master ref
         id: base
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        run: |
+          git fetch --depth=1 origin master
+          echo "sha=$(git rev-parse FETCH_HEAD)" >> "$GITHUB_OUTPUT"
 
       # Does the auto-update branch already exist on the remote? If so, a previous dispatch opened the PR
       # and we append to it. If not, the signed-commit step creates it from master.
@@ -155,7 +158,6 @@ jobs:
           github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
           branch: ${{ env.BRANCH }}
           create-branch: ${{ steps.branch.outputs.create }}
-          retries: "3"
 
       # Ensure exactly one PR exists for this branch. It's no longer auto-closed, so an existing PR is
       # reused. Only the first run (or one whose PR step a concurrent dispatch cancelled) creates it.

--- a/.github/workflows/manual_regenerate_models.yaml
+++ b/.github/workflows/manual_regenerate_models.yaml
@@ -73,7 +73,7 @@ jobs:
           echo "sha=$(git rev-parse FETCH_HEAD)" >> "$GITHUB_OUTPUT"
 
       # Does the auto-update branch already exist on the remote? If so, a previous dispatch opened the PR
-      # and we append to it. If not, the signed-commit step creates it from master.
+      # and we append to it. If not, we start it from master (below) so signed-commit creates it there.
       - name: Determine auto-update branch state
         id: branch
         run: |
@@ -94,6 +94,13 @@ jobs:
         run: |
           git fetch --depth=1 origin "$BRANCH"
           git checkout -B "$BRANCH" FETCH_HEAD
+
+      # The branch doesn't exist yet, so regenerate from the recorded master SHA rather than the dispatched
+      # ref (a manual run may be dispatched from a non-master ref). Regenerating on master keeps the codegen
+      # tooling current, and signed-commit then creates the branch (the PR head) on top of master, the PR base.
+      - name: Start the auto-update branch from master
+        if: steps.branch.outputs.exists == 'false'
+        run: git checkout "${{ steps.base.outputs.sha }}"
 
       # Download the pre-built OpenAPI spec artifact from the apify-docs workflow run.
       # Skipped for manual runs — datamodel-codegen will fetch from the published spec URL instead.

--- a/.github/workflows/manual_regenerate_models.yaml
+++ b/.github/workflows/manual_regenerate_models.yaml
@@ -63,6 +63,40 @@ jobs:
         with:
           token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
+      # Remember master's commit. A subsequent dispatch checks out the auto-update branch before
+      # regenerating, so "did regeneration change anything vs. master?" is answered against this
+      # recorded SHA rather than the current HEAD (which may be the branch tip by then).
+      - name: Record master ref
+        id: base
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      # Detect whether the auto-update branch already exists on the remote. If it does, a previous
+      # dispatch for the same docs PR already opened a PR and we append to it; if not, the
+      # signed-commit step creates the branch from master.
+      - name: Determine auto-update branch state
+        id: branch
+        run: |
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "create=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "create=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # When the branch already exists, check it out before regenerating so the regenerated models
+      # are committed as a NEW commit on top of it — mirroring the new commit just pushed to the
+      # apify-docs PR. signed-commit checks out this same branch internally; switching to it now,
+      # while the tree is still clean, makes that internal checkout a no-op and keeps the regenerated
+      # files staged. Staying on master and letting signed-commit switch branches would fail: the
+      # regenerated files differ between master and the branch, and a plain `git checkout` refuses to
+      # overwrite local modifications.
+      - name: Check out existing auto-update branch
+        if: steps.branch.outputs.exists == 'true'
+        run: |
+          git fetch origin "$BRANCH"
+          git checkout -B "$BRANCH" FETCH_HEAD
+
       # Download the pre-built OpenAPI spec artifact from the apify-docs workflow run.
       # Skipped for manual runs — datamodel-codegen will fetch from the published spec URL instead.
       - name: Download OpenAPI spec artifact
@@ -93,65 +127,46 @@ jobs:
             uv run poe generate-models
           fi
 
-      # Proceed only when regeneration actually changes the models relative to the current master.
-      # The job runs on a fresh master checkout, so anything already merged into master (e.g. a
-      # manually merged client PR carrying the same spec change, or a docs PR that merged master in
-      # and re-emits an already-applied change) produces no diff here and we skip — instead of
-      # opening a PR that just duplicates what master already has.
+      # Proceed only when the regenerated models differ from the current master. Comparing against
+      # the recorded master SHA (the working tree may now sit on the auto-update branch) skips runs
+      # that would produce an empty PR — a spec change that doesn't affect the client models, or a
+      # change already merged into master. On a brand-new branch it also avoids creating the branch
+      # at all when there is nothing to regenerate.
       - name: Check for model changes
         id: changes
         run: |
-          if git diff --quiet -- src/apify_client/_models.py src/apify_client/_typeddicts.py src/apify_client/_literals.py; then
+          if git diff --quiet "${{ steps.base.outputs.sha }}" -- src/apify_client/_models.py src/apify_client/_typeddicts.py src/apify_client/_literals.py; then
             echo "No model changes relative to master — nothing to regenerate."
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Commit the regenerated models as a single commit on top of the current master and move the
-      # auto-update branch to it with one atomic force-push. Building on a fresh master checkout (not
-      # on the possibly stale existing branch) keeps the committed diff relative to the current
-      # master, so an already-merged change can never reappear as a fresh diff.
+      # Append the regenerated models to the auto-update branch as a single signed ("Verified")
+      # commit via apify/actions/signed-commit (GitHub's createCommitOnBranch GraphQL mutation).
       #
-      # The branch goes straight from its previous state to "master + commit" in a single push — it
-      # is never published as being equal to master. This is the crux of the fix: the previous flow
-      # force-pushed the branch to master first and committed on top in a second step, and that
-      # intermediate "branch == master" state made the open PR's head identical to its base, which
-      # GitHub auto-closes. The next dispatch then opened a brand-new PR (`gh pr list --head` only
-      # matches open PRs), and the auto-closed one was left looking empty once its commit was orphaned
-      # by the following reset. Moving the branch forward in one step keeps the single existing PR
-      # open and simply updates it.
+      # The commit is APPENDED on top of the branch's current tip — the branch is never reset to
+      # master. A fresh docs PR creates the branch (create-branch) and its first commit; every later
+      # dispatch, triggered by a new commit on the docs PR, adds another commit, so the client PR
+      # mirrors the docs PR commit-for-commit and stays open throughout. The previous flow instead
+      # force-pushed the branch to master before committing, and that intermediate "branch == master"
+      # state made the open PR's head identical to its base, which GitHub auto-closes; each dispatch
+      # then opened a brand-new duplicate PR (`gh pr list --head` only matches open PRs) and left the
+      # auto-closed one looking empty.
       #
-      # Trade-off vs. apify/actions/signed-commit (used before): the commit is authored with a plain
-      # `git commit` and is therefore not GPG-"Verified". Signed commits are not required on master
-      # (branch protection has required_signatures disabled) and this branch is always squash-merged
-      # through a reviewed PR, so the verified badge carries no weight here.
-      - name: Update branch with regenerated models
+      # signed-commit stages the files against the branch tip and sets committed=false when they are
+      # identical, so a repeated dispatch that regenerates the same models adds no commit.
+      - name: Commit regenerated models
         id: commit
         if: steps.changes.outputs.has_changes == 'true'
-        run: |
-          git config user.name 'Apify Service Account'
-          git config user.email '64261774+apify-service-account@users.noreply.github.com'
-
-          files='src/apify_client/_models.py src/apify_client/_typeddicts.py src/apify_client/_literals.py'
-
-          # If the remote branch already carries exactly these regenerated files, there is nothing to
-          # do. Skipping the push avoids a redundant commit and the CI re-run it triggers when the
-          # same docs PR dispatches this workflow repeatedly without actually changing the spec.
-          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            git fetch --depth=1 origin "$BRANCH"
-            if git diff --quiet FETCH_HEAD -- $files; then
-              echo "Remote branch '$BRANCH' already has the current regenerated models — skipping push."
-              echo "pushed=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          fi
-
-          git checkout -B "$BRANCH"
-          git add $files
-          git commit -m "$TITLE"
-          git push --force origin "$BRANCH"
-          echo "pushed=true" >> "$GITHUB_OUTPUT"
+        uses: apify/actions/signed-commit@v1.2.0
+        with:
+          message: ${{ env.TITLE }}
+          add: 'src/apify_client/_models.py src/apify_client/_typeddicts.py src/apify_client/_literals.py'
+          github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+          branch: ${{ env.BRANCH }}
+          create-branch: ${{ steps.branch.outputs.create }}
+          retries: '3'
 
       # Ensure exactly one PR exists for this branch. The branch is never auto-closed now, so an
       # existing open PR is found and reused; only the first run (or one whose PR step was cancelled
@@ -191,10 +206,10 @@ jobs:
 
       # Post a cross-repo comment on the original docs PR so reviewers know about the corresponding
       # client-python PR. Comment only when something actually happened — the companion PR was just
-      # created, or a real spec change was pushed to it. Repeated dispatches that change nothing
-      # (pushed=false) post no comment, avoiding noise on the docs PR.
+      # created, or a new commit was appended to it. Repeated dispatches that change nothing
+      # (committed=false) post no comment, avoiding noise on the docs PR.
       - name: Comment on apify-docs PR
-        if: inputs.docs_pr_number && (steps.pr.outputs.created == 'true' || steps.commit.outputs.pushed == 'true')
+        if: inputs.docs_pr_number && (steps.pr.outputs.created == 'true' || steps.commit.outputs.committed == 'true')
         env:
           GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
           PR_CREATED: ${{ steps.pr.outputs.created }}

--- a/.github/workflows/manual_regenerate_models.yaml
+++ b/.github/workflows/manual_regenerate_models.yaml
@@ -92,7 +92,7 @@ jobs:
       - name: Check out existing auto-update branch
         if: steps.branch.outputs.exists == 'true'
         run: |
-          git fetch origin "$BRANCH"
+          git fetch --depth=1 origin "$BRANCH"
           git checkout -B "$BRANCH" FETCH_HEAD
 
       # Download the pre-built OpenAPI spec artifact from the apify-docs workflow run.
@@ -157,7 +157,7 @@ jobs:
           add: "src/apify_client/_models.py src/apify_client/_typeddicts.py src/apify_client/_literals.py"
           github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
           branch: ${{ env.BRANCH }}
-          create-branch: ${{ steps.branch.outputs.create }}
+          create-branch: "${{ steps.branch.outputs.create }}"
 
       # Ensure exactly one PR exists for this branch. It's no longer auto-closed, so an existing PR is
       # reused. Only the first run (or one whose PR step a concurrent dispatch cancelled) creates it.


### PR DESCRIPTION
The `Regenerate models` workflow opened a new (and mostly empty) PR on every dispatch from a single apify-docs PR. For example, docs PR #2689 produced 7 client PRs (#888 to #894).

Root cause: the "Point branch at current master" step force-pushed the shared `update-models-docs-pr-<N>` branch to master before committing. That intermediate "branch == master" state made the open PR's head identical to its base, which GitHub auto-closes. The next dispatch's `gh pr list --head` (open PRs only) then found nothing and created a brand-new PR, leaving the auto-closed one looking empty.

Fix: drop the force-push-to-master step and append the regenerated models to the auto-update branch as signed ("Verified") commits via `apify/actions/signed-commit`. A fresh docs PR creates the branch and its first commit; each later commit on the docs PR appends another commit, so the client PR mirrors the docs PR and stays open throughout. Repeated dispatches that regenerate identical models add no commit (`committed=false`), and the docs-PR comment fires only when a PR is created or a commit is appended.
