### PR TITLE
fix: Fix casing in `isAtHome` in `user-agent` header

### DIFF
--- a/src/apify_client/http_clients/_base.py
+++ b/src/apify_client/http_clients/_base.py
@@ -129,7 +129,7 @@ class HttpClientBase:
         if workflow_key is not None:
             default_headers['X-Apify-Workflow-Key'] = workflow_key
 
-        is_at_home = 'APIFY_IS_AT_HOME' in os.environ
+        is_at_home = str('APIFY_IS_AT_HOME' in os.environ).lower()
         python_version = '.'.join([str(x) for x in sys.version_info[:3]])
         client_version = metadata.version('apify-client')
 

--- a/tests/unit/test_client_headers.py
+++ b/tests/unit/test_client_headers.py
@@ -28,7 +28,7 @@ def _header_handler(request: Request) -> Response:
 
 
 def _get_user_agent() -> str:
-    is_at_home = 'APIFY_IS_AT_HOME' in os.environ
+    is_at_home = str('APIFY_IS_AT_HOME' in os.environ).lower()
     python_version = '.'.join([str(x) for x in sys.version_info[:3]])
     client_version = metadata.version('apify-client')
     return f'ApifyClient/{client_version} ({sys.platform}; Python/{python_version}); isAtHome/{is_at_home}'


### PR DESCRIPTION
To be consistent with the reference JS implementation.

Example:
`User-Agent: ... isAtHome/True` -> `User-Agent: ... isAtHome/true`