### PR TITLE
chore(ci): Relax renovate hours trigger

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
         "enabled": true,
         "automerge": true,
         "automergeType": "pr",
-        "schedule": ["* 1-2 * * 1"]
+        "schedule": ["* 0-5 * * 1"]
     },
     "packageRules": [
         {
@@ -32,6 +32,6 @@
     ],
     "minimumReleaseAge": "1 day",
     "internalChecksFilter": "strict",
-    "schedule": ["* 1-2 * * 2-5"],
+    "schedule": ["* 0-5 * * 2-5"],
     "ignoreDeps": ["apify_client", "docusaurus-plugin-typedoc-api"]
 }


### PR DESCRIPTION
Renovate jobs trigger cca 4 times a day in a window outside of our control. In that window, it has to match our update window as well. 