### PR TITLE
chore(ci): modernize Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
-    "extends": ["config:base", ":semanticCommitTypeAll(chore)"],
+    "extends": ["config:recommended", ":semanticCommitTypeAll(chore)"],
     "ignorePaths": ["docs/**", "website/versioned_docs/**"],
-    "pinVersions": false,
+    "rangeStrategy": "replace",
     "separateMajorMinor": false,
     "dependencyDashboard": false,
     "semanticCommits": "enabled",
@@ -13,7 +13,7 @@
     },
     "packageRules": [
         {
-            "matchPaths": ["pyproject.toml"],
+            "matchFileNames": ["pyproject.toml"],
             "matchDepTypes": ["devDependencies"],
             "matchUpdateTypes": ["major", "minor"],
             "groupName": "major/minor dev dependencies",
@@ -26,8 +26,8 @@
             "minimumReleaseAge": "0 days"
         },
         {
-          "matchUpdateTypes": ["lockFileMaintenance"],
-          "minimumReleaseAgeBehaviour": "timestamp-optional"
+            "matchUpdateTypes": ["lockFileMaintenance"],
+            "minimumReleaseAgeBehaviour": "timestamp-optional"
         }
     ],
     "minimumReleaseAge": "1 day",


### PR DESCRIPTION
Modernizes the Renovate config to the current schema. Renovate v36+ renamed several options, and `renovate-config-validator --strict` reported that the config needs migration. Applies exactly the migrations the validator prescribes:

- `config:base` → `config:recommended`
- `pinVersions: false` → `rangeStrategy: "replace"`
- `matchPaths` → `matchFileNames`

Also fixes the inconsistent indentation of the last `packageRules` entry (10 → 12 spaces).

No behavior change: after the change the config validates cleanly (`Config validated successfully`), whereas before it emitted `Config migration necessary`.
