### PR TITLE
fix: add missing MCP to RunOrigin enum

### DIFF
--- a/.github/workflows/manual_regenerate_models.yaml
+++ b/.github/workflows/manual_regenerate_models.yaml
@@ -42,8 +42,8 @@ jobs:
       # branch history. It is deliberately NOT reused as the PR title.
       COMMIT_MESSAGE: "${{ inputs.docs_pr_number && format('update generated models from apify-docs PR #{0}', inputs.docs_pr_number) || 'update generated models from published OpenAPI spec' }}"
       # Placeholder PR title — just `TODO`, so it carries no valid commit type and `pr-title-check` stays red
-      # until a human replaces it (the default can never be merged as-is). The required action, the apify-docs
-      # reference, and its link all live in the PR body, not the title.
+      # until a human replaces it (the default can never be merged as-is). The apify-docs reference and its
+      # link live in the PR body, not the title.
       PR_TITLE: 'TODO'
       ASSIGNEE: ${{ inputs.docs_pr_author || github.actor }}
       REVIEWER: vdusek
@@ -187,14 +187,13 @@ jobs:
             echo "pr_url=$EXISTING_PR" >> "$GITHUB_OUTPUT"
             echo "created=false" >> "$GITHUB_OUTPUT"
           else
-            # The PR opens with a `TODO` placeholder title that fails `pr-title-check`. Spell out the required
-            # action: the assignee must replace both the PR title and this description before merging.
-            ACTION_NOTE=$'> [!IMPORTANT]\n> **Replace this PR title and description before merging.**\n> - Title: a Conventional Commits message describing the actual model changes (e.g. `chore: ...` for a routine sync, or `refactor:`/`feat:`/`fix:` when models meaningfully change).\n> - Description: summarize what changed in the models.\n\n'
+            # The PR opens with a `TODO` placeholder title that fails `pr-title-check`, so it can't be merged
+            # until a human replaces it with a proper Conventional Commits title.
             if [[ -n "$DOCS_PR_NUMBER" ]]; then
               DOCS_PR_URL="https://github.com/apify/apify-docs/pull/${DOCS_PR_NUMBER}"
-              BODY="${ACTION_NOTE}- Updates the auto-generated Pydantic models and TypedDicts based on the proposed OpenAPI specification changes."$'\n'"- Based on apify-docs PR [#${DOCS_PR_NUMBER}](${DOCS_PR_URL})."
+              BODY="- Updates the auto-generated Pydantic models and TypedDicts based on the proposed OpenAPI specification changes."$'\n'"- Based on apify-docs PR [#${DOCS_PR_NUMBER}](${DOCS_PR_URL})."
             else
-              BODY="${ACTION_NOTE}- Updates the auto-generated Pydantic models and TypedDicts based on the latest OpenAPI specification changes."$'\n'"- Based on the [published OpenAPI specification](https://docs.apify.com/api/openapi.json)."
+              BODY="- Updates the auto-generated Pydantic models and TypedDicts based on the latest OpenAPI specification changes."$'\n'"- Based on the [published OpenAPI specification](https://docs.apify.com/api/openapi.json)."
             fi
 
             PR_URL=$(gh pr create \

--- a/src/apify_client/_literals.py
+++ b/src/apify_client/_literals.py
@@ -455,6 +455,7 @@ RunOrigin = Literal[
     'CLI',
     'CI',
     'STANDBY',
+    'MCP',
 ]
 
 


### PR DESCRIPTION
- Updates the auto-generated Pydantic models and TypedDicts based on the proposed OpenAPI specification changes.
- Based on apify-docs PR [#2752](https://github.com/apify/apify-docs/pull/2752).