### PR TITLE
chore(ci): run Renovate dependency updates only on Tuesday

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,6 @@
     ],
     "minimumReleaseAge": "1 day",
     "internalChecksFilter": "strict",
-    "schedule": ["* 0-5 * * 2-5"],
+    "schedule": ["* 0-5 * * 2"],
     "ignoreDeps": ["apify_client", "docusaurus-plugin-typedoc-api"]
 }


### PR DESCRIPTION
Renovate previously opened dependency-update PRs on every weekday night (`* 0-5 * * 2-5`, Tue–Fri). This narrows the schedule for regular package updates to Tuesday nights only (`* 0-5 * * 2`), so the bot no longer opens PRs every day.

The `lockFileMaintenance` schedule (Monday nights, `* 0-5 * * 1`) is left unchanged.
