### PR TITLE
feat: support APIFY_API_BASE_URL and APIFY_API_PUBLIC_BASE_URL env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,23 @@ client = ApifyClient(
 )
 ```
 
+### Point the client at a different API server
+
+```python
+from apify_client import ApifyClient
+
+client = ApifyClient(
+    token='MY-APIFY-TOKEN',
+    api_url='http://localhost:8080',
+)
+```
+
+`api_url` and `api_public_url` also fall back to the `APIFY_API_BASE_URL` and `APIFY_API_PUBLIC_BASE_URL`
+environment variables (in that precedence order: explicit argument > environment variable > the
+`https://api.apify.com` default) — handy for pointing the client at a local or staging instance of the
+Apify platform without changing code. The two variables are independent, so setting one does not affect
+the default of the other.
+
 For end-to-end recipes — passing input, managing tasks for reusable input, retrieving and merging Actor data, integrating with Pandas, plugging in a custom HTTP client — see the [Guides](https://docs.apify.com/api/client/python/docs/guides/passing-input-to-actor).
 
 ## Documentation

--- a/src/apify_client/_apify_client.py
+++ b/src/apify_client/_apify_client.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from apify_client._client_registry import ClientRegistry, ClientRegistryAsync
 from apify_client._consts import (
     API_VERSION,
+    DEFAULT_API_PUBLIC_URL,
     DEFAULT_API_URL,
     DEFAULT_MAX_RETRIES,
     DEFAULT_MIN_DELAY_BETWEEN_RETRIES,
@@ -72,7 +73,7 @@ from apify_client._resource_clients import (
     WebhookDispatchCollectionClientAsync,
 )
 from apify_client._statistics import ClientStatistics
-from apify_client._utils import check_custom_headers
+from apify_client._utils import check_custom_headers, resolve_base_url
 from apify_client.http_clients import HttpClient, HttpClientAsync, ImpitHttpClient, ImpitHttpClientAsync
 
 if TYPE_CHECKING:
@@ -113,8 +114,8 @@ class ApifyClient:
         self,
         token: str | None = None,
         *,
-        api_url: str = DEFAULT_API_URL,
-        api_public_url: str | None = DEFAULT_API_URL,
+        api_url: str | None = None,
+        api_public_url: str | None = None,
         max_retries: int = DEFAULT_MAX_RETRIES,
         min_delay_between_retries: timedelta = DEFAULT_MIN_DELAY_BETWEEN_RETRIES,
         timeout_short: timedelta = DEFAULT_TIMEOUT_SHORT,
@@ -130,11 +131,12 @@ class ApifyClient:
         Args:
             token: The Apify API token. You can find your token on the
                 [Integrations](https://console.apify.com/account/integrations) page in the Apify Console.
-            api_url: The URL of the Apify API server to connect to. Defaults to https://api.apify.com. It can
-                be an internal URL that is not globally accessible, in which case `api_public_url` should be set
-                as well.
+            api_url: The URL of the Apify API server to connect to. Defaults to the `APIFY_API_BASE_URL`
+                environment variable if set, otherwise https://api.apify.com. It can be an internal URL that is
+                not globally accessible, in which case `api_public_url` should be set as well.
             api_public_url: The globally accessible URL of the Apify API server. Should be set only if `api_url`
-                is an internal URL that is not globally accessible. Defaults to https://api.apify.com.
+                is an internal URL that is not globally accessible. Defaults to the `APIFY_API_PUBLIC_BASE_URL`
+                environment variable if set, otherwise https://api.apify.com.
             max_retries: How many times to retry a failed request at most.
             min_delay_between_retries: How long will the client wait between retrying requests
                 (increases exponentially from this value).
@@ -144,9 +146,10 @@ class ApifyClient:
             timeout_max: Maximum timeout cap for exponential timeout growth across retries.
             headers: Additional HTTP headers to include in all API requests.
         """
-        # We need to do this because of mocking in tests and default mutable arguments.
-        api_url = DEFAULT_API_URL if api_url is None else api_url
-        api_public_url = DEFAULT_API_URL if api_public_url is None else api_public_url
+        # Resolve as explicit argument > environment variable > default, so an unset env var still yields the
+        # production default while an explicitly passed value always wins.
+        api_url = resolve_base_url(api_url, 'APIFY_API_BASE_URL', DEFAULT_API_URL)
+        api_public_url = resolve_base_url(api_public_url, 'APIFY_API_PUBLIC_BASE_URL', DEFAULT_API_PUBLIC_URL)
 
         if headers:
             check_custom_headers(self.__class__.__name__, headers)
@@ -211,8 +214,8 @@ class ApifyClient:
         cls,
         token: str | None = None,
         *,
-        api_url: str = DEFAULT_API_URL,
-        api_public_url: str | None = DEFAULT_API_URL,
+        api_url: str | None = None,
+        api_public_url: str | None = None,
         http_client: HttpClient,
     ) -> ApifyClient:
         """Create an `ApifyClient` instance with a custom HTTP client.
@@ -239,8 +242,10 @@ class ApifyClient:
 
         Args:
             token: The Apify API token.
-            api_url: The URL of the Apify API server to connect to. Defaults to https://api.apify.com.
-            api_public_url: The globally accessible URL of the Apify API server. Defaults to https://api.apify.com.
+            api_url: The URL of the Apify API server to connect to. Defaults to the `APIFY_API_BASE_URL`
+                environment variable if set, otherwise https://api.apify.com.
+            api_public_url: The globally accessible URL of the Apify API server. Defaults to the
+                `APIFY_API_PUBLIC_BASE_URL` environment variable if set, otherwise https://api.apify.com.
             http_client: A custom HTTP client instance extending `HttpClient`.
         """
         instance = cls(token=token, api_url=api_url, api_public_url=api_public_url)
@@ -467,8 +472,8 @@ class ApifyClientAsync:
         self,
         token: str | None = None,
         *,
-        api_url: str = DEFAULT_API_URL,
-        api_public_url: str | None = DEFAULT_API_URL,
+        api_url: str | None = None,
+        api_public_url: str | None = None,
         max_retries: int = DEFAULT_MAX_RETRIES,
         min_delay_between_retries: timedelta = DEFAULT_MIN_DELAY_BETWEEN_RETRIES,
         timeout_short: timedelta = DEFAULT_TIMEOUT_SHORT,
@@ -484,11 +489,12 @@ class ApifyClientAsync:
         Args:
             token: The Apify API token. You can find your token on the
                 [Integrations](https://console.apify.com/account/integrations) page in the Apify Console.
-            api_url: The URL of the Apify API server to connect to. Defaults to https://api.apify.com. It can
-                be an internal URL that is not globally accessible, in which case `api_public_url` should be set
-                as well.
+            api_url: The URL of the Apify API server to connect to. Defaults to the `APIFY_API_BASE_URL`
+                environment variable if set, otherwise https://api.apify.com. It can be an internal URL that is
+                not globally accessible, in which case `api_public_url` should be set as well.
             api_public_url: The globally accessible URL of the Apify API server. Should be set only if `api_url`
-                is an internal URL that is not globally accessible. Defaults to https://api.apify.com.
+                is an internal URL that is not globally accessible. Defaults to the `APIFY_API_PUBLIC_BASE_URL`
+                environment variable if set, otherwise https://api.apify.com.
             max_retries: How many times to retry a failed request at most.
             min_delay_between_retries: How long will the client wait between retrying requests
                 (increases exponentially from this value).
@@ -498,9 +504,10 @@ class ApifyClientAsync:
             timeout_max: Maximum timeout cap for exponential timeout growth across retries.
             headers: Additional HTTP headers to include in all API requests.
         """
-        # We need to do this because of mocking in tests and default mutable arguments.
-        api_url = DEFAULT_API_URL if api_url is None else api_url
-        api_public_url = DEFAULT_API_URL if api_public_url is None else api_public_url
+        # Resolve as explicit argument > environment variable > default, so an unset env var still yields the
+        # production default while an explicitly passed value always wins.
+        api_url = resolve_base_url(api_url, 'APIFY_API_BASE_URL', DEFAULT_API_URL)
+        api_public_url = resolve_base_url(api_public_url, 'APIFY_API_PUBLIC_BASE_URL', DEFAULT_API_PUBLIC_URL)
 
         if headers:
             check_custom_headers(self.__class__.__name__, headers)
@@ -565,8 +572,8 @@ class ApifyClientAsync:
         cls,
         token: str | None = None,
         *,
-        api_url: str = DEFAULT_API_URL,
-        api_public_url: str | None = DEFAULT_API_URL,
+        api_url: str | None = None,
+        api_public_url: str | None = None,
         http_client: HttpClientAsync,
     ) -> ApifyClientAsync:
         """Create an `ApifyClientAsync` instance with a custom HTTP client.
@@ -593,8 +600,10 @@ class ApifyClientAsync:
 
         Args:
             token: The Apify API token.
-            api_url: The URL of the Apify API server to connect to. Defaults to https://api.apify.com.
-            api_public_url: The globally accessible URL of the Apify API server. Defaults to https://api.apify.com.
+            api_url: The URL of the Apify API server to connect to. Defaults to the `APIFY_API_BASE_URL`
+                environment variable if set, otherwise https://api.apify.com.
+            api_public_url: The globally accessible URL of the Apify API server. Defaults to the
+                `APIFY_API_PUBLIC_BASE_URL` environment variable if set, otherwise https://api.apify.com.
             http_client: A custom HTTP client instance extending `HttpClientAsync`.
         """
         instance = cls(token=token, api_url=api_url, api_public_url=api_public_url)

--- a/src/apify_client/_consts.py
+++ b/src/apify_client/_consts.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 from datetime import timedelta
 
 DEFAULT_API_URL = 'https://api.apify.com'
-"""Default base URL for the Apify API."""
+"""Default base URL for the Apify API. Overridable via the `APIFY_API_BASE_URL` environment variable."""
+
+DEFAULT_API_PUBLIC_URL = DEFAULT_API_URL
+"""Default globally accessible base URL for the Apify API.
+
+Overridable via the `APIFY_API_PUBLIC_BASE_URL` environment variable.
+"""
 
 API_VERSION = 'v2'
 """Current Apify API version."""

--- a/src/apify_client/_utils.py
+++ b/src/apify_client/_utils.py
@@ -4,6 +4,7 @@ import hashlib
 import hmac
 import io
 import json
+import os
 import string
 import time
 import warnings
@@ -256,6 +257,23 @@ def create_storage_content_signature(
 
     base64url_encoded_payload = urlsafe_b64encode(f'{version}.{expires_at}.{hmac_sig}'.encode())
     return base64url_encoded_payload.decode('utf-8')
+
+
+def resolve_base_url(explicit_url: str | None, env_var_name: str, default_url: str) -> str:
+    """Resolve a base URL using the explicit-argument > environment-variable > default precedence.
+
+    Args:
+        explicit_url: The value explicitly passed by the caller, if any. Wins over everything else when not `None`.
+        env_var_name: The name of the environment variable to fall back to when `explicit_url` is `None`.
+        default_url: The value to fall back to when neither `explicit_url` nor the environment variable is set.
+
+    Returns:
+        The resolved base URL.
+    """
+    if explicit_url is not None:
+        return explicit_url
+
+    return os.environ.get(env_var_name) or default_url
 
 
 def check_custom_headers(class_name: str, headers: dict[str, str]) -> None:

--- a/tests/unit/test_base_url_resolution.py
+++ b/tests/unit/test_base_url_resolution.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from apify_client import ApifyClient, ApifyClientAsync
+from apify_client._consts import DEFAULT_API_PUBLIC_URL, DEFAULT_API_URL
+from apify_client.http_clients import ImpitHttpClient, ImpitHttpClientAsync
+
+if TYPE_CHECKING:
+    import pytest
+
+# ============================================================================
+# API base URL (`APIFY_API_BASE_URL`) — criteria 1-4
+# ============================================================================
+
+
+def test_api_url_defaults_to_production_when_unset_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No env var and no argument: resolves to the production default."""
+    monkeypatch.delenv('APIFY_API_BASE_URL', raising=False)
+    client = ApifyClient(token='dummy-token')
+    assert client._base_url == f'{DEFAULT_API_URL}/v2'
+
+
+async def test_api_url_defaults_to_production_when_unset_async(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No env var and no argument: resolves to the production default (async)."""
+    monkeypatch.delenv('APIFY_API_BASE_URL', raising=False)
+    client = ApifyClientAsync(token='dummy-token')
+    assert client._base_url == f'{DEFAULT_API_URL}/v2'
+
+
+def test_api_url_env_var_used_when_no_argument_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`APIFY_API_BASE_URL` is used when no explicit `api_url` argument is given."""
+    monkeypatch.setenv('APIFY_API_BASE_URL', 'http://localhost:8080')
+    client = ApifyClient(token='dummy-token')
+    assert client._base_url == 'http://localhost:8080/v2'
+
+
+async def test_api_url_env_var_used_when_no_argument_async(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`APIFY_API_BASE_URL` is used when no explicit `api_url` argument is given (async)."""
+    monkeypatch.setenv('APIFY_API_BASE_URL', 'http://localhost:8080')
+    client = ApifyClientAsync(token='dummy-token')
+    assert client._base_url == 'http://localhost:8080/v2'
+
+
+def test_explicit_api_url_wins_over_env_var_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit `api_url` argument wins over `APIFY_API_BASE_URL`."""
+    monkeypatch.setenv('APIFY_API_BASE_URL', 'http://localhost:8080')
+    client = ApifyClient(token='dummy-token', api_url='http://example.test')
+    assert client._base_url == 'http://example.test/v2'
+
+
+async def test_explicit_api_url_wins_over_env_var_async(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit `api_url` argument wins over `APIFY_API_BASE_URL` (async)."""
+    monkeypatch.setenv('APIFY_API_BASE_URL', 'http://localhost:8080')
+    client = ApifyClientAsync(token='dummy-token', api_url='http://example.test')
+    assert client._base_url == 'http://example.test/v2'
+
+
+def test_api_url_custom_port_from_env_needs_no_special_handling(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A custom port supplied via the env var works with no special handling."""
+    monkeypatch.setenv('APIFY_API_BASE_URL', 'http://localhost:9999')
+    client = ApifyClient(token='dummy-token')
+    assert client._base_url == 'http://localhost:9999/v2'
+
+
+# ============================================================================
+# Public API base URL (`APIFY_API_PUBLIC_BASE_URL`) — criteria 5-8
+# ============================================================================
+
+
+def test_api_public_url_defaults_to_production_when_unset_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No env var and no argument: the public base URL resolves to the production default."""
+    monkeypatch.delenv('APIFY_API_PUBLIC_BASE_URL', raising=False)
+    client = ApifyClient(token='dummy-token')
+    assert client._public_base_url == f'{DEFAULT_API_PUBLIC_URL}/v2'
+
+
+async def test_api_public_url_defaults_to_production_when_unset_async(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No env var and no argument: the public base URL resolves to the production default (async)."""
+    monkeypatch.delenv('APIFY_API_PUBLIC_BASE_URL', raising=False)
+    client = ApifyClientAsync(token='dummy-token')
+    assert client._public_base_url == f'{DEFAULT_API_PUBLIC_URL}/v2'
+
+
+def test_api_public_url_env_var_used_when_no_argument(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`APIFY_API_PUBLIC_BASE_URL` is used when no explicit `api_public_url` argument is given."""
+    monkeypatch.setenv('APIFY_API_PUBLIC_BASE_URL', 'http://localhost:8080')
+    client = ApifyClient(token='dummy-token')
+    assert client._public_base_url == 'http://localhost:8080/v2'
+
+
+def test_explicit_api_public_url_wins_over_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit `api_public_url` argument wins over `APIFY_API_PUBLIC_BASE_URL`."""
+    monkeypatch.setenv('APIFY_API_PUBLIC_BASE_URL', 'http://localhost:8080')
+    client = ApifyClient(token='dummy-token', api_public_url='http://example.test')
+    assert client._public_base_url == 'http://example.test/v2'
+
+
+def test_api_base_and_public_base_env_vars_are_independent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Setting only `APIFY_API_BASE_URL` leaves the public base URL at its default."""
+    monkeypatch.delenv('APIFY_API_PUBLIC_BASE_URL', raising=False)
+    monkeypatch.setenv('APIFY_API_BASE_URL', 'http://localhost:8080')
+    client = ApifyClient(token='dummy-token')
+    assert client._base_url == 'http://localhost:8080/v2'
+    assert client._public_base_url == f'{DEFAULT_API_PUBLIC_URL}/v2'
+
+
+def test_api_base_and_public_base_env_vars_are_independent_other_direction(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Setting only `APIFY_API_PUBLIC_BASE_URL` leaves the API base URL at its default."""
+    monkeypatch.delenv('APIFY_API_BASE_URL', raising=False)
+    monkeypatch.setenv('APIFY_API_PUBLIC_BASE_URL', 'http://localhost:8080')
+    client = ApifyClient(token='dummy-token')
+    assert client._public_base_url == 'http://localhost:8080/v2'
+    assert client._base_url == f'{DEFAULT_API_URL}/v2'
+
+
+# ============================================================================
+# `with_custom_http_client` resolves URLs by the same precedence — criterion 9
+# ============================================================================
+
+
+def test_with_custom_http_client_resolves_env_var_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('APIFY_API_BASE_URL', 'http://localhost:8080')
+    client = ApifyClient.with_custom_http_client(token='dummy-token', http_client=ImpitHttpClient())
+    assert client._base_url == 'http://localhost:8080/v2'
+
+
+async def test_with_custom_http_client_resolves_env_var_async(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('APIFY_API_BASE_URL', 'http://localhost:8080')
+    client = ApifyClientAsync.with_custom_http_client(token='dummy-token', http_client=ImpitHttpClientAsync())
+    assert client._base_url == 'http://localhost:8080/v2'
+
+
+def test_with_custom_http_client_explicit_arg_wins_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('APIFY_API_BASE_URL', 'http://localhost:8080')
+    client = ApifyClient.with_custom_http_client(
+        token='dummy-token',
+        api_url='http://example.test',
+        http_client=ImpitHttpClient(),
+    )
+    assert client._base_url == 'http://example.test/v2'
+
+
+def test_with_custom_http_client_public_url_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('APIFY_API_PUBLIC_BASE_URL', 'http://localhost:8080')
+    client = ApifyClient.with_custom_http_client(token='dummy-token', http_client=ImpitHttpClient())
+    assert client._public_base_url == 'http://localhost:8080/v2'
+
+
+async def test_with_custom_http_client_public_url_env_var_async(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('APIFY_API_PUBLIC_BASE_URL', 'http://localhost:8080')
+    client = ApifyClientAsync.with_custom_http_client(token='dummy-token', http_client=ImpitHttpClientAsync())
+    assert client._public_base_url == 'http://localhost:8080/v2'
+
+
+# ============================================================================
+# The `/v2` suffix invariant — criterion 19
+# ============================================================================
+
+
+def test_v2_suffix_applied_to_env_supplied_api_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('APIFY_API_BASE_URL', 'http://localhost:8080')
+    client = ApifyClient(token='dummy-token')
+    assert client._base_url.endswith('/v2')
+    assert client._base_url == 'http://localhost:8080/v2'
+
+
+def test_v2_suffix_applied_to_env_supplied_public_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('APIFY_API_PUBLIC_BASE_URL', 'http://localhost:8080')
+    client = ApifyClient(token='dummy-token')
+    assert client._public_base_url.endswith('/v2')
+    assert client._public_base_url == 'http://localhost:8080/v2'

--- a/tests/unit/test_base_url_resolution.py
+++ b/tests/unit/test_base_url_resolution.py
@@ -1,66 +1,85 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import pytest
 
 from apify_client import ApifyClient, ApifyClientAsync
 from apify_client._consts import DEFAULT_API_PUBLIC_URL, DEFAULT_API_URL
 from apify_client.http_clients import ImpitHttpClient, ImpitHttpClientAsync
 
-if TYPE_CHECKING:
-    import pytest
+# Both clients resolve base URLs identically; construction is synchronous for both.
+CLIENT_CLASSES = [
+    pytest.param(ApifyClient, id='sync'),
+    pytest.param(ApifyClientAsync, id='async'),
+]
+
+# Scenarios for the `with_custom_http_client` tests: (env_var, api_url, api_public_url, attr, expected).
+WITH_CUSTOM_HTTP_CLIENT_SCENARIOS = [
+    pytest.param(
+        'APIFY_API_BASE_URL',
+        None,
+        None,
+        '_base_url',
+        'http://localhost:8080/v2',
+        id='api-base-env-var-resolved',
+    ),
+    pytest.param(
+        'APIFY_API_BASE_URL',
+        'http://example.test',
+        None,
+        '_base_url',
+        'http://example.test/v2',
+        id='explicit-api-url-wins',
+    ),
+    pytest.param(
+        'APIFY_API_PUBLIC_BASE_URL',
+        None,
+        None,
+        '_public_base_url',
+        'http://localhost:8080/v2',
+        id='public-base-env-var-resolved',
+    ),
+]
+
 
 # ============================================================================
 # API base URL (`APIFY_API_BASE_URL`) — criteria 1-4
 # ============================================================================
 
 
-def test_api_url_defaults_to_production_when_unset_sync(monkeypatch: pytest.MonkeyPatch) -> None:
-    """No env var and no argument: resolves to the production default."""
-    monkeypatch.delenv('APIFY_API_BASE_URL', raising=False)
-    client = ApifyClient(token='dummy-token')
-    assert client._base_url == f'{DEFAULT_API_URL}/v2'
-
-
-async def test_api_url_defaults_to_production_when_unset_async(monkeypatch: pytest.MonkeyPatch) -> None:
-    """No env var and no argument: resolves to the production default (async)."""
-    monkeypatch.delenv('APIFY_API_BASE_URL', raising=False)
-    client = ApifyClientAsync(token='dummy-token')
-    assert client._base_url == f'{DEFAULT_API_URL}/v2'
-
-
-def test_api_url_env_var_used_when_no_argument_sync(monkeypatch: pytest.MonkeyPatch) -> None:
-    """`APIFY_API_BASE_URL` is used when no explicit `api_url` argument is given."""
-    monkeypatch.setenv('APIFY_API_BASE_URL', 'http://localhost:8080')
-    client = ApifyClient(token='dummy-token')
-    assert client._base_url == 'http://localhost:8080/v2'
-
-
-async def test_api_url_env_var_used_when_no_argument_async(monkeypatch: pytest.MonkeyPatch) -> None:
-    """`APIFY_API_BASE_URL` is used when no explicit `api_url` argument is given (async)."""
-    monkeypatch.setenv('APIFY_API_BASE_URL', 'http://localhost:8080')
-    client = ApifyClientAsync(token='dummy-token')
-    assert client._base_url == 'http://localhost:8080/v2'
-
-
-def test_explicit_api_url_wins_over_env_var_sync(monkeypatch: pytest.MonkeyPatch) -> None:
-    """An explicit `api_url` argument wins over `APIFY_API_BASE_URL`."""
-    monkeypatch.setenv('APIFY_API_BASE_URL', 'http://localhost:8080')
-    client = ApifyClient(token='dummy-token', api_url='http://example.test')
-    assert client._base_url == 'http://example.test/v2'
-
-
-async def test_explicit_api_url_wins_over_env_var_async(monkeypatch: pytest.MonkeyPatch) -> None:
-    """An explicit `api_url` argument wins over `APIFY_API_BASE_URL` (async)."""
-    monkeypatch.setenv('APIFY_API_BASE_URL', 'http://localhost:8080')
-    client = ApifyClientAsync(token='dummy-token', api_url='http://example.test')
-    assert client._base_url == 'http://example.test/v2'
-
-
-def test_api_url_custom_port_from_env_needs_no_special_handling(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A custom port supplied via the env var works with no special handling."""
-    monkeypatch.setenv('APIFY_API_BASE_URL', 'http://localhost:9999')
-    client = ApifyClient(token='dummy-token')
-    assert client._base_url == 'http://localhost:9999/v2'
+@pytest.mark.parametrize('client_class', CLIENT_CLASSES)
+@pytest.mark.parametrize(
+    ('env_value', 'explicit_arg', 'expected'),
+    [
+        pytest.param(None, None, f'{DEFAULT_API_URL}/v2', id='defaults-to-production-when-unset'),
+        pytest.param('http://localhost:8080', None, 'http://localhost:8080/v2', id='env-var-used-when-no-argument'),
+        pytest.param(
+            'http://localhost:8080',
+            'http://example.test',
+            'http://example.test/v2',
+            id='explicit-arg-wins-over-env-var',
+        ),
+        pytest.param(
+            'http://localhost:9999',
+            None,
+            'http://localhost:9999/v2',
+            id='custom-port-needs-no-special-handling',
+        ),
+    ],
+)
+def test_api_url_resolution(
+    client_class: type[ApifyClient | ApifyClientAsync],
+    env_value: str | None,
+    explicit_arg: str | None,
+    expected: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """API base URL resolves as explicit arg > `APIFY_API_BASE_URL` > default, for both clients."""
+    if env_value is None:
+        monkeypatch.delenv('APIFY_API_BASE_URL', raising=False)
+    else:
+        monkeypatch.setenv('APIFY_API_BASE_URL', env_value)
+    client = client_class(token='dummy-token', api_url=explicit_arg)
+    assert client._base_url == expected
 
 
 # ============================================================================
@@ -68,50 +87,66 @@ def test_api_url_custom_port_from_env_needs_no_special_handling(monkeypatch: pyt
 # ============================================================================
 
 
-def test_api_public_url_defaults_to_production_when_unset_sync(monkeypatch: pytest.MonkeyPatch) -> None:
-    """No env var and no argument: the public base URL resolves to the production default."""
-    monkeypatch.delenv('APIFY_API_PUBLIC_BASE_URL', raising=False)
-    client = ApifyClient(token='dummy-token')
-    assert client._public_base_url == f'{DEFAULT_API_PUBLIC_URL}/v2'
+@pytest.mark.parametrize('client_class', CLIENT_CLASSES)
+@pytest.mark.parametrize(
+    ('env_value', 'explicit_arg', 'expected'),
+    [
+        pytest.param(None, None, f'{DEFAULT_API_PUBLIC_URL}/v2', id='defaults-to-production-when-unset'),
+        pytest.param('http://localhost:8080', None, 'http://localhost:8080/v2', id='env-var-used-when-no-argument'),
+        pytest.param(
+            'http://localhost:8080',
+            'http://example.test',
+            'http://example.test/v2',
+            id='explicit-arg-wins-over-env-var',
+        ),
+    ],
+)
+def test_api_public_url_resolution(
+    client_class: type[ApifyClient | ApifyClientAsync],
+    env_value: str | None,
+    explicit_arg: str | None,
+    expected: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Public API base URL resolves as explicit arg > `APIFY_API_PUBLIC_BASE_URL` > default, for both clients."""
+    if env_value is None:
+        monkeypatch.delenv('APIFY_API_PUBLIC_BASE_URL', raising=False)
+    else:
+        monkeypatch.setenv('APIFY_API_PUBLIC_BASE_URL', env_value)
+    client = client_class(token='dummy-token', api_public_url=explicit_arg)
+    assert client._public_base_url == expected
 
 
-async def test_api_public_url_defaults_to_production_when_unset_async(monkeypatch: pytest.MonkeyPatch) -> None:
-    """No env var and no argument: the public base URL resolves to the production default (async)."""
-    monkeypatch.delenv('APIFY_API_PUBLIC_BASE_URL', raising=False)
-    client = ApifyClientAsync(token='dummy-token')
-    assert client._public_base_url == f'{DEFAULT_API_PUBLIC_URL}/v2'
-
-
-def test_api_public_url_env_var_used_when_no_argument(monkeypatch: pytest.MonkeyPatch) -> None:
-    """`APIFY_API_PUBLIC_BASE_URL` is used when no explicit `api_public_url` argument is given."""
-    monkeypatch.setenv('APIFY_API_PUBLIC_BASE_URL', 'http://localhost:8080')
-    client = ApifyClient(token='dummy-token')
-    assert client._public_base_url == 'http://localhost:8080/v2'
-
-
-def test_explicit_api_public_url_wins_over_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
-    """An explicit `api_public_url` argument wins over `APIFY_API_PUBLIC_BASE_URL`."""
-    monkeypatch.setenv('APIFY_API_PUBLIC_BASE_URL', 'http://localhost:8080')
-    client = ApifyClient(token='dummy-token', api_public_url='http://example.test')
-    assert client._public_base_url == 'http://example.test/v2'
-
-
-def test_api_base_and_public_base_env_vars_are_independent(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Setting only `APIFY_API_BASE_URL` leaves the public base URL at its default."""
-    monkeypatch.delenv('APIFY_API_PUBLIC_BASE_URL', raising=False)
-    monkeypatch.setenv('APIFY_API_BASE_URL', 'http://localhost:8080')
-    client = ApifyClient(token='dummy-token')
-    assert client._base_url == 'http://localhost:8080/v2'
-    assert client._public_base_url == f'{DEFAULT_API_PUBLIC_URL}/v2'
-
-
-def test_api_base_and_public_base_env_vars_are_independent_other_direction(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Setting only `APIFY_API_PUBLIC_BASE_URL` leaves the API base URL at its default."""
+@pytest.mark.parametrize(
+    ('env_var', 'expected_base', 'expected_public'),
+    [
+        pytest.param(
+            'APIFY_API_BASE_URL',
+            'http://localhost:8080/v2',
+            f'{DEFAULT_API_PUBLIC_URL}/v2',
+            id='only-api-base-set-leaves-public-at-default',
+        ),
+        pytest.param(
+            'APIFY_API_PUBLIC_BASE_URL',
+            f'{DEFAULT_API_URL}/v2',
+            'http://localhost:8080/v2',
+            id='only-public-set-leaves-api-base-at-default',
+        ),
+    ],
+)
+def test_api_base_and_public_base_env_vars_are_independent(
+    env_var: str,
+    expected_base: str,
+    expected_public: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setting only one of the two env vars leaves the other at its default."""
     monkeypatch.delenv('APIFY_API_BASE_URL', raising=False)
-    monkeypatch.setenv('APIFY_API_PUBLIC_BASE_URL', 'http://localhost:8080')
+    monkeypatch.delenv('APIFY_API_PUBLIC_BASE_URL', raising=False)
+    monkeypatch.setenv(env_var, 'http://localhost:8080')
     client = ApifyClient(token='dummy-token')
-    assert client._public_base_url == 'http://localhost:8080/v2'
-    assert client._base_url == f'{DEFAULT_API_URL}/v2'
+    assert client._base_url == expected_base
+    assert client._public_base_url == expected_public
 
 
 # ============================================================================
@@ -119,38 +154,48 @@ def test_api_base_and_public_base_env_vars_are_independent_other_direction(monke
 # ============================================================================
 
 
-def test_with_custom_http_client_resolves_env_var_sync(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv('APIFY_API_BASE_URL', 'http://localhost:8080')
-    client = ApifyClient.with_custom_http_client(token='dummy-token', http_client=ImpitHttpClient())
-    assert client._base_url == 'http://localhost:8080/v2'
-
-
-async def test_with_custom_http_client_resolves_env_var_async(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv('APIFY_API_BASE_URL', 'http://localhost:8080')
-    client = ApifyClientAsync.with_custom_http_client(token='dummy-token', http_client=ImpitHttpClientAsync())
-    assert client._base_url == 'http://localhost:8080/v2'
-
-
-def test_with_custom_http_client_explicit_arg_wins_sync(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv('APIFY_API_BASE_URL', 'http://localhost:8080')
+@pytest.mark.parametrize(
+    ('env_var', 'api_url', 'api_public_url', 'attr', 'expected'), WITH_CUSTOM_HTTP_CLIENT_SCENARIOS
+)
+def test_with_custom_http_client_resolution_sync(
+    env_var: str,
+    api_url: str | None,
+    api_public_url: str | None,
+    attr: str,
+    expected: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`with_custom_http_client` resolves URLs by the same precedence as the constructor (sync)."""
+    monkeypatch.setenv(env_var, 'http://localhost:8080')
     client = ApifyClient.with_custom_http_client(
         token='dummy-token',
-        api_url='http://example.test',
         http_client=ImpitHttpClient(),
+        api_url=api_url,
+        api_public_url=api_public_url,
     )
-    assert client._base_url == 'http://example.test/v2'
+    assert getattr(client, attr) == expected
 
 
-def test_with_custom_http_client_public_url_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv('APIFY_API_PUBLIC_BASE_URL', 'http://localhost:8080')
-    client = ApifyClient.with_custom_http_client(token='dummy-token', http_client=ImpitHttpClient())
-    assert client._public_base_url == 'http://localhost:8080/v2'
-
-
-async def test_with_custom_http_client_public_url_env_var_async(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv('APIFY_API_PUBLIC_BASE_URL', 'http://localhost:8080')
-    client = ApifyClientAsync.with_custom_http_client(token='dummy-token', http_client=ImpitHttpClientAsync())
-    assert client._public_base_url == 'http://localhost:8080/v2'
+@pytest.mark.parametrize(
+    ('env_var', 'api_url', 'api_public_url', 'attr', 'expected'), WITH_CUSTOM_HTTP_CLIENT_SCENARIOS
+)
+async def test_with_custom_http_client_resolution_async(
+    env_var: str,
+    api_url: str | None,
+    api_public_url: str | None,
+    attr: str,
+    expected: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`with_custom_http_client` resolves URLs by the same precedence as the constructor (async)."""
+    monkeypatch.setenv(env_var, 'http://localhost:8080')
+    client = ApifyClientAsync.with_custom_http_client(
+        token='dummy-token',
+        http_client=ImpitHttpClientAsync(),
+        api_url=api_url,
+        api_public_url=api_public_url,
+    )
+    assert getattr(client, attr) == expected
 
 
 # ============================================================================
@@ -158,15 +203,21 @@ async def test_with_custom_http_client_public_url_env_var_async(monkeypatch: pyt
 # ============================================================================
 
 
-def test_v2_suffix_applied_to_env_supplied_api_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv('APIFY_API_BASE_URL', 'http://localhost:8080')
+@pytest.mark.parametrize(
+    ('env_var', 'attr'),
+    [
+        pytest.param('APIFY_API_BASE_URL', '_base_url', id='api-base'),
+        pytest.param('APIFY_API_PUBLIC_BASE_URL', '_public_base_url', id='public-base'),
+    ],
+)
+def test_v2_suffix_applied_to_env_supplied_url(
+    env_var: str,
+    attr: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The `/v2` version suffix is appended to an env-supplied base URL that lacks it."""
+    monkeypatch.setenv(env_var, 'http://localhost:8080')
     client = ApifyClient(token='dummy-token')
-    assert client._base_url.endswith('/v2')
-    assert client._base_url == 'http://localhost:8080/v2'
-
-
-def test_v2_suffix_applied_to_env_supplied_public_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv('APIFY_API_PUBLIC_BASE_URL', 'http://localhost:8080')
-    client = ApifyClient(token='dummy-token')
-    assert client._public_base_url.endswith('/v2')
-    assert client._public_base_url == 'http://localhost:8080/v2'
+    value = getattr(client, attr)
+    assert value.endswith('/v2')
+    assert value == 'http://localhost:8080/v2'


### PR DESCRIPTION
## Description

The API base URL and public API base URL could only be set through constructor arguments, so pointing the client at a local platform, a staging deployment, or a custom host/port meant threading arguments through every construction site.


Both URLs now resolve as **explicit argument > environment variable > default constant**:

- `APIFY_API_BASE_URL` → `api_url`
- `APIFY_API_PUBLIC_BASE_URL` → `api_public_url`

The two variables are independent (each keeps its own default). Empty-string env values are treated as unset. The resolution is applied identically in the sync `ApifyClient`, the async `ApifyClientAsync`, and the `with_custom_http_client` path, and the automatic `/v2` suffixing is unchanged. **Setting nothing reproduces today's behavior exactly.**

### Context

This is one of three sibling PRs applying the same env-var contract across the Apify clients and CLI (the CLI also adds `APIFY_CONSOLE_BASE_URL`). Separate repos, no overlapping files:

- apify-client-python (this PR): apify/apify-client-python#948
- apify-client-js: apify/apify-client-js#967
- apify-cli: apify/apify-cli#1275

