### PR TITLE
test: Deflake test_schedule_list and test_task_list by polling eventually consistent listings

### DIFF
--- a/tests/integration/test_schedule.py
+++ b/tests/integration/test_schedule.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .._utils import collect_iterate_until_present, get_random_resource_name, maybe_await
+from .._utils import collect_iterate_until_present, get_random_resource_name, maybe_await, poll_until_condition
 from apify_client._models import Actor, ListOfSchedules, Schedule, ScheduleActionRunActor, ScheduleShort
 
 if TYPE_CHECKING:
@@ -110,10 +110,16 @@ async def test_schedule_list(client: ApifyClient | ApifyClientAsync) -> None:
     assert isinstance(created_2, Schedule)
 
     try:
-        # List schedules
-        schedules_page = await maybe_await(client.schedules().list(limit=100))
-        assert isinstance(schedules_page, ListOfSchedules)
-        assert schedules_page.items is not None
+        # Poll until both fresh schedules appear in the listing (eventual consistency)
+        async def list_schedules() -> ListOfSchedules:
+            page = await maybe_await(client.schedules().list(limit=100))
+            assert isinstance(page, ListOfSchedules)
+            return page
+
+        schedules_page = await poll_until_condition(
+            list_schedules,
+            lambda page: {created_1.id, created_2.id} <= {s.id for s in page.items},
+        )
 
         # Verify our schedules are in the list
         schedule_ids = [s.id for s in schedules_page.items]

--- a/tests/integration/test_task.py
+++ b/tests/integration/test_task.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncIterator, Iterator
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
-from .._utils import collect_iterate_until_present, get_random_resource_name, maybe_await
+from .._utils import collect_iterate_until_present, get_random_resource_name, maybe_await, poll_until_condition
 from apify_client._models import Actor, ListOfRuns, ListOfTasks, ListOfWebhooks, Run, RunShort, Task, TaskShort
 
 if TYPE_CHECKING:
@@ -106,10 +106,16 @@ async def test_task_list(client: ApifyClient | ApifyClientAsync) -> None:
     assert isinstance(created_task, Task)
 
     try:
-        # List tasks
-        tasks_page = await maybe_await(client.tasks().list(limit=100))
-        assert isinstance(tasks_page, ListOfTasks)
-        assert tasks_page.items is not None
+        # Poll until the fresh task appears in the listing (eventual consistency)
+        async def list_tasks() -> ListOfTasks:
+            page = await maybe_await(client.tasks().list(limit=100))
+            assert isinstance(page, ListOfTasks)
+            return page
+
+        tasks_page = await poll_until_condition(
+            list_tasks,
+            lambda page: created_task.id in {t.id for t in page.items},
+        )
 
         # Verify our task is in the list
         task_ids = [t.id for t in tasks_page.items]


### PR DESCRIPTION
`test_schedule_list` and `test_task_list` failed in CI ([schedule run](https://github.com/apify/apify-client-python/actions/runs/29497290807/job/87617167353), [task run](https://github.com/apify/apify-client-python/actions/runs/29498108478/job/87619855853)) because they assert read-your-write on listing endpoints: they list resources immediately after creating them, and under load the listing can serve a view that hasn't yet caught up with the creates, so the fresh IDs are sometimes missing. The creates themselves succeeded in both cases, so these are eventual-consistency flakes, not client bugs.

The fix wraps each list read in the existing `poll_until_condition` helper (30 s ceiling), waiting until the created IDs appear in the listing. The original assertions still run on the final page, so a real regression still fails. Follows the same deflaking pattern as #824, #831, #844, and #868.
