### PR TITLE
fix: Make batch_add_requests split batches by serialized payload size

### DIFF
--- a/src/apify_client/_resource_clients/request_queue.py
+++ b/src/apify_client/_resource_clients/request_queue.py
@@ -58,19 +58,37 @@ if TYPE_CHECKING:
     from apify_client.types import Timeout
 
 _RQ_MAX_REQUESTS_PER_BATCH = 25
-_MAX_PAYLOAD_SIZE_BYTES = 9 * 1024 * 1024  # 9 MB
-_SAFETY_BUFFER_PERCENT = 0.01 / 100  # 0.01%
+"""Maximum number of requests the API accepts in a single batch call."""
+
+_MAX_PAYLOAD_SIZE_BYTES = 9 * 1024 * 1024
+"""Maximum payload size (9 MB) the API accepts for a single batch call."""
+
+_SAFETY_BUFFER_PERCENT = 0.01 / 100
+"""Safety margin (0.01%) deducted from the maximum payload size when splitting requests into batches."""
 
 
-def _serialize_request(request: dict) -> bytes:
-    """Serialize a request into the JSON bytes it will occupy in the batch request body.
+def _serialize_requests(
+    requests: list[RequestDraft] | list[RequestDraftDict] | list[RequestDraftCamelDict],
+) -> list[bytes]:
+    """Validate requests and serialize each one into the JSON bytes it will occupy in the batch request body.
 
     Each request is serialized exactly once: the same bytes are measured when splitting requests into batches and
-    then assembled into the request body, so batch sizes are computed on exactly the bytes that get sent. Uses the
-    same `json.dumps` options as `HttpClientBase._prepare_request_call` to keep the wire format consistent with
-    other endpoints.
+    then assembled into the request body, so batch sizes are computed on exactly the bytes that get sent. Validation
+    and serialization happen in a single pass, so each intermediate dict stays transient instead of a whole dict list
+    being held in memory alongside the serialized requests. Uses the same `json.dumps` options as
+    `HttpClientBase._prepare_request_call` to keep the wire format consistent with other endpoints.
     """
-    return json.dumps(request, ensure_ascii=False, allow_nan=False, default=str).encode('utf-8')
+    return [
+        json.dumps(
+            (request if isinstance(request, RequestDraft) else RequestDraft.model_validate(request)).model_dump(
+                by_alias=True, exclude_none=True
+            ),
+            ensure_ascii=False,
+            allow_nan=False,
+            default=str,
+        ).encode('utf-8')
+        for request in requests
+    ]
 
 
 @docs_group('Resource clients')
@@ -412,23 +430,16 @@ class RequestQueueClient(ResourceClient):
         if max_parallel != 1:
             raise NotImplementedError('max_parallel is only supported in async client')
 
-        requests_as_dicts = [
-            (r if isinstance(r, RequestDraft) else RequestDraft.model_validate(r)).model_dump(
-                by_alias=True, exclude_none=True
-            )
-            for r in requests
-        ]
+        # Validate the requests and serialize each of them into JSON bytes.
+        serialized_requests = _serialize_requests(requests)
 
-        serialized_requests = [_serialize_request(r) for r in requests_as_dicts]
-
+        # Build the query parameters shared by all the batch API calls.
         request_params = self._build_params(clientKey=self.client_key, forefront=forefront)
 
         # Compute the payload size limit to ensure it doesn't exceed the maximum allowed size.
         payload_size_limit_bytes = _MAX_PAYLOAD_SIZE_BYTES - math.ceil(_MAX_PAYLOAD_SIZE_BYTES * _SAFETY_BUFFER_PERCENT)
 
-        # Split the requests into batches, constrained by the max payload size and max requests per batch. Each
-        # request costs its serialized bytes plus a separator, and the brackets are reserved up front, so an
-        # assembled `[...]` body can never exceed the limit.
+        # Split the requests into batches by payload size (counting commas and brackets) and max requests per batch.
         batches = constrained_batches(
             serialized_requests,
             max_size=payload_size_limit_bytes - len(b'[]'),
@@ -438,17 +449,17 @@ class RequestQueueClient(ResourceClient):
         )
 
         # Put the batches into the queue for processing.
-        queue = Queue[Iterable[bytes]]()
+        batch_queue = Queue[Iterable[bytes]]()
 
         for batch in batches:
-            queue.put(batch)
+            batch_queue.put(batch)
 
         processed_requests = list[AddedRequest]()
         unprocessed_requests = list[RequestDraft]()
 
         # Process all batches in the queue sequentially.
-        while not queue.empty():
-            request_batch = queue.get()
+        while not batch_queue.empty():
+            request_batch = batch_queue.get()
 
             # Send the batch to the API, assembling the body from the already serialized requests.
             response = self._http_client.call(
@@ -989,35 +1000,16 @@ class RequestQueueClientAsync(ResourceClientAsync):
         Returns:
             Result containing lists of processed and unprocessed requests.
         """
-        requests_as_dicts = [
-            (
-                request
-                if isinstance(request, RequestDraft)
-                else RequestDraft.model_validate(
-                    request,
-                )
-            ).model_dump(
-                by_alias=True,
-                exclude_none=True,
-            )
-            for request in requests
-        ]
+        # Validate and serialize the requests in a worker thread, as it is CPU-bound and would block the event loop.
+        serialized_requests = await asyncio.to_thread(_serialize_requests, requests)
 
-        # Serializing many requests is CPU-bound and would block the event loop, so offload it to a worker
-        # thread (the HTTP client offloads request body compression the same way).
-        serialized_requests = await asyncio.to_thread(
-            lambda: [_serialize_request(request) for request in requests_as_dicts]
-        )
-
-        asyncio_queue: asyncio.Queue[Iterable[bytes]] = asyncio.Queue()
+        # Build the query parameters shared by all the batch API calls.
         request_params = self._build_params(clientKey=self.client_key, forefront=forefront)
 
         # Compute the payload size limit to ensure it doesn't exceed the maximum allowed size.
         payload_size_limit_bytes = _MAX_PAYLOAD_SIZE_BYTES - math.ceil(_MAX_PAYLOAD_SIZE_BYTES * _SAFETY_BUFFER_PERCENT)
 
-        # Split the requests into batches, constrained by the max payload size and max requests per batch. Each
-        # request costs its serialized bytes plus a separator, and the brackets are reserved up front, so an
-        # assembled `[...]` body can never exceed the limit.
+        # Split the requests into batches by payload size (counting commas and brackets) and max requests per batch.
         batches = constrained_batches(
             serialized_requests,
             max_size=payload_size_limit_bytes - len(b'[]'),
@@ -1026,8 +1018,11 @@ class RequestQueueClientAsync(ResourceClientAsync):
             strict=False,
         )
 
+        # Create a queue with all the batches, from which the worker tasks will consume them.
+        batch_queue: asyncio.Queue[Iterable[bytes]] = asyncio.Queue()
+
         for batch in batches:
-            await asyncio_queue.put(batch)
+            await batch_queue.put(batch)
 
         # Use TaskGroup for structured concurrency — automatic cleanup and error propagation.
         try:
@@ -1035,7 +1030,7 @@ class RequestQueueClientAsync(ResourceClientAsync):
                 workers = [
                     tg.create_task(
                         self._batch_add_requests_worker(
-                            queue=asyncio_queue, request_params=request_params, timeout=timeout
+                            queue=batch_queue, request_params=request_params, timeout=timeout
                         ),
                         name=f'batch_add_requests_worker_{i}',
                     )
@@ -1043,7 +1038,7 @@ class RequestQueueClientAsync(ResourceClientAsync):
                 ]
 
                 # Wait for all batches to be processed, then cancel idle workers.
-                await asyncio_queue.join()
+                await batch_queue.join()
                 for worker in workers:
                     worker.cancel()
         except ExceptionGroup as eg:

--- a/src/apify_client/_resource_clients/request_queue.py
+++ b/src/apify_client/_resource_clients/request_queue.py
@@ -62,6 +62,15 @@ _MAX_PAYLOAD_SIZE_BYTES = 9 * 1024 * 1024  # 9 MB
 _SAFETY_BUFFER_PERCENT = 0.01 / 100  # 0.01%
 
 
+def _get_payload_size_bytes(request: dict) -> int:
+    """Return the byte size of a request as it will be serialized into the request body.
+
+    Must mirror the JSON serialization in `HttpClientBase._prepare_request_call`, so that measured sizes match the
+    bytes actually sent.
+    """
+    return len(json.dumps(request, ensure_ascii=False, allow_nan=False, default=str).encode('utf-8'))
+
+
 @docs_group('Resource clients')
 class RequestQueueClient(ResourceClient):
     """Sub-client for managing a specific request queue.
@@ -414,12 +423,11 @@ class RequestQueueClient(ResourceClient):
         payload_size_limit_bytes = _MAX_PAYLOAD_SIZE_BYTES - math.ceil(_MAX_PAYLOAD_SIZE_BYTES * _SAFETY_BUFFER_PERCENT)
 
         # Split the requests into batches, constrained by the max payload size and max requests per batch.
-        # Sizes are measured with the same JSON serialization the HTTP client applies to request bodies.
         batches = constrained_batches(
             requests_as_dicts,
             max_size=payload_size_limit_bytes,
             max_count=_RQ_MAX_REQUESTS_PER_BATCH,
-            get_len=lambda r: len(json.dumps(r, ensure_ascii=False, allow_nan=False, default=str).encode('utf-8')),
+            get_len=_get_payload_size_bytes,
             # An individually oversized request gets its own batch and is left for the API to reject.
             strict=False,
         )
@@ -995,12 +1003,11 @@ class RequestQueueClientAsync(ResourceClientAsync):
         payload_size_limit_bytes = _MAX_PAYLOAD_SIZE_BYTES - math.ceil(_MAX_PAYLOAD_SIZE_BYTES * _SAFETY_BUFFER_PERCENT)
 
         # Split the requests into batches, constrained by the max payload size and max requests per batch.
-        # Sizes are measured with the same JSON serialization the HTTP client applies to request bodies.
         batches = constrained_batches(
             requests_as_dicts,
             max_size=payload_size_limit_bytes,
             max_count=_RQ_MAX_REQUESTS_PER_BATCH,
-            get_len=lambda r: len(json.dumps(r, ensure_ascii=False, allow_nan=False, default=str).encode('utf-8')),
+            get_len=_get_payload_size_bytes,
             # An individually oversized request gets its own batch and is left for the API to reject.
             strict=False,
         )

--- a/src/apify_client/_resource_clients/request_queue.py
+++ b/src/apify_client/_resource_clients/request_queue.py
@@ -62,13 +62,15 @@ _MAX_PAYLOAD_SIZE_BYTES = 9 * 1024 * 1024  # 9 MB
 _SAFETY_BUFFER_PERCENT = 0.01 / 100  # 0.01%
 
 
-def _get_payload_size_bytes(request: dict) -> int:
-    """Return the byte size of a request as it will be serialized into the request body.
+def _serialize_request(request: dict) -> bytes:
+    """Serialize a request into the JSON bytes it will occupy in the batch request body.
 
-    Must mirror the JSON serialization in `HttpClientBase._prepare_request_call`, so that measured sizes match the
-    bytes actually sent.
+    Each request is serialized exactly once: the same bytes are measured when splitting requests into batches and
+    then assembled into the request body, so batch sizes are computed on exactly the bytes that get sent. Uses the
+    same `json.dumps` options as `HttpClientBase._prepare_request_call` to keep the wire format consistent with
+    other endpoints.
     """
-    return len(json.dumps(request, ensure_ascii=False, allow_nan=False, default=str).encode('utf-8'))
+    return json.dumps(request, ensure_ascii=False, allow_nan=False, default=str).encode('utf-8')
 
 
 @docs_group('Resource clients')
@@ -417,22 +419,26 @@ class RequestQueueClient(ResourceClient):
             for r in requests
         ]
 
+        serialized_requests = [_serialize_request(r) for r in requests_as_dicts]
+
         request_params = self._build_params(clientKey=self.client_key, forefront=forefront)
 
         # Compute the payload size limit to ensure it doesn't exceed the maximum allowed size.
         payload_size_limit_bytes = _MAX_PAYLOAD_SIZE_BYTES - math.ceil(_MAX_PAYLOAD_SIZE_BYTES * _SAFETY_BUFFER_PERCENT)
 
-        # Split the requests into batches, constrained by the max payload size and max requests per batch.
+        # Split the requests into batches, constrained by the max payload size and max requests per batch. Each
+        # request costs its serialized bytes plus a separator, and the brackets are reserved up front, so an
+        # assembled `[...]` body can never exceed the limit.
         batches = constrained_batches(
-            requests_as_dicts,
-            max_size=payload_size_limit_bytes,
+            serialized_requests,
+            max_size=payload_size_limit_bytes - len(b'[]'),
             max_count=_RQ_MAX_REQUESTS_PER_BATCH,
-            get_len=_get_payload_size_bytes,
+            get_len=lambda serialized: len(serialized) + len(b','),
             strict=False,
         )
 
         # Put the batches into the queue for processing.
-        queue = Queue[Iterable[dict]]()
+        queue = Queue[Iterable[bytes]]()
 
         for batch in batches:
             queue.put(batch)
@@ -444,12 +450,13 @@ class RequestQueueClient(ResourceClient):
         while not queue.empty():
             request_batch = queue.get()
 
-            # Send the batch to the API.
+            # Send the batch to the API, assembling the body from the already serialized requests.
             response = self._http_client.call(
                 url=self._build_url('requests/batch'),
                 method='POST',
+                headers={'content-type': 'application/json'},
                 params=request_params,
-                json=list(request_batch),
+                data=b'[' + b','.join(request_batch) + b']',
                 timeout=timeout,
             )
 
@@ -910,7 +917,7 @@ class RequestQueueClientAsync(ResourceClientAsync):
     async def _batch_add_requests_worker(
         self,
         *,
-        queue: asyncio.Queue[Iterable[dict]],
+        queue: asyncio.Queue[Iterable[bytes]],
         request_params: dict,
         timeout: Timeout,
     ) -> BatchAddResponse:
@@ -931,12 +938,13 @@ class RequestQueueClientAsync(ResourceClientAsync):
                 break
 
             try:
-                # Send the batch to the API.
+                # Send the batch to the API, assembling the body from the already serialized requests.
                 response = await self._http_client.call(
                     url=self._build_url('requests/batch'),
                     method='POST',
+                    headers={'content-type': 'application/json'},
                     params=request_params,
-                    json=list(request_batch),
+                    data=b'[' + b','.join(request_batch) + b']',
                     timeout=timeout,
                 )
 
@@ -995,18 +1003,26 @@ class RequestQueueClientAsync(ResourceClientAsync):
             for request in requests
         ]
 
-        asyncio_queue: asyncio.Queue[Iterable[dict]] = asyncio.Queue()
+        # Serializing many requests is CPU-bound and would block the event loop, so offload it to a worker
+        # thread (the HTTP client offloads request body compression the same way).
+        serialized_requests = await asyncio.to_thread(
+            lambda: [_serialize_request(request) for request in requests_as_dicts]
+        )
+
+        asyncio_queue: asyncio.Queue[Iterable[bytes]] = asyncio.Queue()
         request_params = self._build_params(clientKey=self.client_key, forefront=forefront)
 
         # Compute the payload size limit to ensure it doesn't exceed the maximum allowed size.
         payload_size_limit_bytes = _MAX_PAYLOAD_SIZE_BYTES - math.ceil(_MAX_PAYLOAD_SIZE_BYTES * _SAFETY_BUFFER_PERCENT)
 
-        # Split the requests into batches, constrained by the max payload size and max requests per batch.
+        # Split the requests into batches, constrained by the max payload size and max requests per batch. Each
+        # request costs its serialized bytes plus a separator, and the brackets are reserved up front, so an
+        # assembled `[...]` body can never exceed the limit.
         batches = constrained_batches(
-            requests_as_dicts,
-            max_size=payload_size_limit_bytes,
+            serialized_requests,
+            max_size=payload_size_limit_bytes - len(b'[]'),
             max_count=_RQ_MAX_REQUESTS_PER_BATCH,
-            get_len=_get_payload_size_bytes,
+            get_len=lambda serialized: len(serialized) + len(b','),
             strict=False,
         )
 

--- a/src/apify_client/_resource_clients/request_queue.py
+++ b/src/apify_client/_resource_clients/request_queue.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import math
 from collections.abc import Iterable
 from queue import Queue
@@ -413,10 +414,14 @@ class RequestQueueClient(ResourceClient):
         payload_size_limit_bytes = _MAX_PAYLOAD_SIZE_BYTES - math.ceil(_MAX_PAYLOAD_SIZE_BYTES * _SAFETY_BUFFER_PERCENT)
 
         # Split the requests into batches, constrained by the max payload size and max requests per batch.
+        # Sizes are measured with the same JSON serialization the HTTP client applies to request bodies.
         batches = constrained_batches(
             requests_as_dicts,
             max_size=payload_size_limit_bytes,
             max_count=_RQ_MAX_REQUESTS_PER_BATCH,
+            get_len=lambda r: len(json.dumps(r, ensure_ascii=False, allow_nan=False, default=str).encode('utf-8')),
+            # An individually oversized request gets its own batch and is left for the API to reject.
+            strict=False,
         )
 
         # Put the batches into the queue for processing.
@@ -990,10 +995,14 @@ class RequestQueueClientAsync(ResourceClientAsync):
         payload_size_limit_bytes = _MAX_PAYLOAD_SIZE_BYTES - math.ceil(_MAX_PAYLOAD_SIZE_BYTES * _SAFETY_BUFFER_PERCENT)
 
         # Split the requests into batches, constrained by the max payload size and max requests per batch.
+        # Sizes are measured with the same JSON serialization the HTTP client applies to request bodies.
         batches = constrained_batches(
             requests_as_dicts,
             max_size=payload_size_limit_bytes,
             max_count=_RQ_MAX_REQUESTS_PER_BATCH,
+            get_len=lambda r: len(json.dumps(r, ensure_ascii=False, allow_nan=False, default=str).encode('utf-8')),
+            # An individually oversized request gets its own batch and is left for the API to reject.
+            strict=False,
         )
 
         for batch in batches:

--- a/src/apify_client/_resource_clients/request_queue.py
+++ b/src/apify_client/_resource_clients/request_queue.py
@@ -428,7 +428,6 @@ class RequestQueueClient(ResourceClient):
             max_size=payload_size_limit_bytes,
             max_count=_RQ_MAX_REQUESTS_PER_BATCH,
             get_len=_get_payload_size_bytes,
-            # An individually oversized request gets its own batch and is left for the API to reject.
             strict=False,
         )
 
@@ -1008,7 +1007,6 @@ class RequestQueueClientAsync(ResourceClientAsync):
             max_size=payload_size_limit_bytes,
             max_count=_RQ_MAX_REQUESTS_PER_BATCH,
             get_len=_get_payload_size_bytes,
-            # An individually oversized request gets its own batch and is left for the API to reject.
             strict=False,
         )
 

--- a/tests/unit/test_client_request_queue.py
+++ b/tests/unit/test_client_request_queue.py
@@ -1,17 +1,28 @@
 from __future__ import annotations
 
+import gzip
+import json
 import re
 from typing import TYPE_CHECKING
 
 import pytest
+from werkzeug.wrappers import Response
 
 from apify_client import ApifyClient, ApifyClientAsync
 from apify_client.errors import ApifyApiError
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_httpserver import HTTPServer
+    from werkzeug.wrappers import Request
 
     from apify_client._typeddicts import RequestDraftDict
+
+# The Apify API limit on the payload size of a batch-add request, which the client's batching must respect.
+_API_MAX_PAYLOAD_SIZE_BYTES = 9 * 1024 * 1024
+
+_EMPTY_BATCH_RESPONSE_CONTENT = '{"data": {"processedRequests": [], "unprocessedRequests": []}}'
 
 _PARTIALLY_ADDED_BATCH_RESPONSE_CONTENT = """{
   "data": {
@@ -94,6 +105,126 @@ def test_batch_not_processed_raises_exception_sync(httpserver: HTTPServer) -> No
 
     with pytest.raises(ApifyApiError):
         rq_client.batch_add_requests(requests=requests)
+
+
+def _make_large_requests() -> list[RequestDraftDict]:
+    """Return 3 requests of ~4 MB each, so that all of them together exceed the 9 MB payload limit."""
+    return [
+        {
+            'unique_key': f'http://example.com/{i}',
+            'url': f'http://example.com/{i}?filler={"x" * (4 * 1024 * 1024)}',
+            'method': 'GET',
+        }
+        for i in range(3)
+    ]
+
+
+def _payload_capturing_handler(payloads: list[bytes]) -> Callable[[Request], Response]:
+    """Return a handler that records each POST body (gzip-decompressed) and responds with an empty batch result."""
+
+    def handler(request: Request) -> Response:
+        payloads.append(gzip.decompress(request.get_data()))
+        return Response(_EMPTY_BATCH_RESPONSE_CONTENT, status=200, content_type='application/json')
+
+    return handler
+
+
+async def test_batch_add_requests_splits_batches_by_payload_size_async(httpserver: HTTPServer) -> None:
+    """Test that batches are split by serialized byte size so no POST payload exceeds the 9 MB API limit."""
+    server_url = httpserver.url_for('/').removesuffix('/')
+    client = ApifyClientAsync(
+        token='placeholder_token',
+        api_url=server_url,
+        api_public_url=server_url,
+    )
+
+    payloads = list[bytes]()
+    httpserver.expect_request(re.compile(r'.*'), method='POST').respond_with_handler(
+        _payload_capturing_handler(payloads)
+    )
+    rq_client = client.request_queue(request_queue_id='whatever')
+
+    await rq_client.batch_add_requests(requests=_make_large_requests())
+
+    assert len(payloads) > 1
+    assert all(len(payload) <= _API_MAX_PAYLOAD_SIZE_BYTES for payload in payloads)
+    assert sum(len(json.loads(payload)) for payload in payloads) == 3
+
+
+def test_batch_add_requests_splits_batches_by_payload_size_sync(httpserver: HTTPServer) -> None:
+    """Test that batches are split by serialized byte size so no POST payload exceeds the 9 MB API limit."""
+    server_url = httpserver.url_for('/').removesuffix('/')
+    client = ApifyClient(
+        token='placeholder_token',
+        api_url=server_url,
+        api_public_url=server_url,
+    )
+
+    payloads = list[bytes]()
+    httpserver.expect_request(re.compile(r'.*'), method='POST').respond_with_handler(
+        _payload_capturing_handler(payloads)
+    )
+    rq_client = client.request_queue(request_queue_id='whatever')
+
+    rq_client.batch_add_requests(requests=_make_large_requests())
+
+    assert len(payloads) > 1
+    assert all(len(payload) <= _API_MAX_PAYLOAD_SIZE_BYTES for payload in payloads)
+    assert sum(len(json.loads(payload)) for payload in payloads) == 3
+
+
+def _make_oversized_and_small_requests() -> list[RequestDraftDict]:
+    """Return a small request plus one whose serialized size alone exceeds the 9 MB payload limit."""
+    return [
+        {'unique_key': 'small', 'url': 'http://example.com/small', 'method': 'GET'},
+        {
+            'unique_key': 'oversized',
+            'url': f'http://example.com/oversized?filler={"x" * (10 * 1024 * 1024)}',
+            'method': 'GET',
+        },
+    ]
+
+
+async def test_batch_add_requests_sends_oversized_request_alone_async(httpserver: HTTPServer) -> None:
+    """Test that a request exceeding the payload limit is sent in its own batch for the API to judge, not rejected."""
+    server_url = httpserver.url_for('/').removesuffix('/')
+    client = ApifyClientAsync(
+        token='placeholder_token',
+        api_url=server_url,
+        api_public_url=server_url,
+    )
+
+    payloads = list[bytes]()
+    httpserver.expect_request(re.compile(r'.*'), method='POST').respond_with_handler(
+        _payload_capturing_handler(payloads)
+    )
+    rq_client = client.request_queue(request_queue_id='whatever')
+
+    await rq_client.batch_add_requests(requests=_make_oversized_and_small_requests())
+
+    assert sum(len(json.loads(payload)) for payload in payloads) == 2
+    assert any(len(payload) > _API_MAX_PAYLOAD_SIZE_BYTES for payload in payloads)
+
+
+def test_batch_add_requests_sends_oversized_request_alone_sync(httpserver: HTTPServer) -> None:
+    """Test that a request exceeding the payload limit is sent in its own batch for the API to judge, not rejected."""
+    server_url = httpserver.url_for('/').removesuffix('/')
+    client = ApifyClient(
+        token='placeholder_token',
+        api_url=server_url,
+        api_public_url=server_url,
+    )
+
+    payloads = list[bytes]()
+    httpserver.expect_request(re.compile(r'.*'), method='POST').respond_with_handler(
+        _payload_capturing_handler(payloads)
+    )
+    rq_client = client.request_queue(request_queue_id='whatever')
+
+    rq_client.batch_add_requests(requests=_make_oversized_and_small_requests())
+
+    assert sum(len(json.loads(payload)) for payload in payloads) == 2
+    assert any(len(payload) > _API_MAX_PAYLOAD_SIZE_BYTES for payload in payloads)
 
 
 def test_batch_processed_partially_sync(httpserver: HTTPServer) -> None:


### PR DESCRIPTION
The 9 MB payload guard in `batch_add_requests` was inert: `constrained_batches` was called without `get_len`, so the default `len()` measured each request dict's key count (~4) instead of its serialized size. Batches were therefore split only by the 25-request count limit, and large requests shipped as one oversized POST that the API rejects with 413, failing the whole call.

The guard now measures each request as its UTF-8 JSON byte length, using the same serialization flags as the HTTP client's request body path. It also passes `strict=False`, which preserves the previous contract for an individually oversized request: it's sent in its own batch and left for the API to judge, instead of raising a client-side `ValueError`. Both the size-based splitting and the oversized-singleton path are covered by new sync/async regression tests.

*✍️ Drafted by Claude Code*