### PR TITLE
fix: Propagate last_run status/origin filters to chained storage clients

### DIFF
--- a/src/apify_client/_resource_clients/run.py
+++ b/src/apify_client/_resource_clients/run.py
@@ -289,6 +289,7 @@ class RunClient(ResourceClient):
         """
         return self._client_registry.dataset_client(
             resource_path='dataset',
+            params=self._default_params,
             **self._base_client_kwargs,
         )
 
@@ -302,6 +303,7 @@ class RunClient(ResourceClient):
         """
         return self._client_registry.key_value_store_client(
             resource_path='key-value-store',
+            params=self._default_params,
             **self._base_client_kwargs,
         )
 
@@ -315,6 +317,7 @@ class RunClient(ResourceClient):
         """
         return self._client_registry.request_queue_client(
             resource_path='request-queue',
+            params=self._default_params,
             **self._base_client_kwargs,
         )
 
@@ -328,6 +331,7 @@ class RunClient(ResourceClient):
         """
         return self._client_registry.log_client(
             resource_path='log',
+            params=self._default_params,
             **self._base_client_kwargs,
         )
 
@@ -716,6 +720,7 @@ class RunClientAsync(ResourceClientAsync):
         """
         return self._client_registry.dataset_client(
             resource_path='dataset',
+            params=self._default_params,
             **self._base_client_kwargs,
         )
 
@@ -729,6 +734,7 @@ class RunClientAsync(ResourceClientAsync):
         """
         return self._client_registry.key_value_store_client(
             resource_path='key-value-store',
+            params=self._default_params,
             **self._base_client_kwargs,
         )
 
@@ -742,6 +748,7 @@ class RunClientAsync(ResourceClientAsync):
         """
         return self._client_registry.request_queue_client(
             resource_path='request-queue',
+            params=self._default_params,
             **self._base_client_kwargs,
         )
 
@@ -755,6 +762,7 @@ class RunClientAsync(ResourceClientAsync):
         """
         return self._client_registry.log_client(
             resource_path='log',
+            params=self._default_params,
             **self._base_client_kwargs,
         )
 

--- a/tests/unit/test_last_run_params.py
+++ b/tests/unit/test_last_run_params.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from apify_client import ApifyClient, ApifyClientAsync
+from apify_client.errors import NotFoundError
+
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
+
+_CHILD_CLIENT_PARAMS = [
+    pytest.param('dataset', 'dataset', id='dataset'),
+    pytest.param('key_value_store', 'key-value-store', id='key-value-store'),
+    pytest.param('request_queue', 'request-queue', id='request-queue'),
+    pytest.param('log', 'log', id='log'),
+]
+
+
+_NOT_FOUND_BODY = {'error': {'type': 'record-not-found', 'message': 'not found'}}
+
+
+@pytest.mark.parametrize(('child_method', 'child_path'), _CHILD_CLIENT_PARAMS)
+def test_last_run_filters_propagate_to_chained_clients(
+    httpserver: HTTPServer,
+    child_method: str,
+    child_path: str,
+) -> None:
+    """`last_run(status=..., origin=...)` filters must be sent by the chained storage clients (regression vs 1.x)."""
+    httpserver.expect_request(f'/v2/actors/actor-id/runs/last/{child_path}').respond_with_json(
+        _NOT_FOUND_BODY, status=404
+    )
+    client = ApifyClient(token='test-token', api_url=httpserver.url_for('/').removesuffix('/'))
+
+    last_run = client.actor('actor-id').last_run(status='SUCCEEDED', origin='WEB')
+    with pytest.raises(NotFoundError):
+        getattr(last_run, child_method)().get()
+
+    request, _ = httpserver.log[-1]
+    assert request.args.get('status') == 'SUCCEEDED'
+    assert request.args.get('origin') == 'WEB'
+
+
+@pytest.mark.parametrize(('child_method', 'child_path'), _CHILD_CLIENT_PARAMS)
+async def test_last_run_filters_propagate_to_chained_clients_async(
+    httpserver: HTTPServer,
+    child_method: str,
+    child_path: str,
+) -> None:
+    """`last_run(status=..., origin=...)` filters must be sent by the chained storage clients (regression vs 1.x)."""
+    httpserver.expect_request(f'/v2/actors/actor-id/runs/last/{child_path}').respond_with_json(
+        _NOT_FOUND_BODY, status=404
+    )
+    client = ApifyClientAsync(token='test-token', api_url=httpserver.url_for('/').removesuffix('/'))
+
+    last_run = client.actor('actor-id').last_run(status='SUCCEEDED', origin='WEB')
+    with pytest.raises(NotFoundError):
+        await getattr(last_run, child_method)().get()
+
+    request, _ = httpserver.log[-1]
+    assert request.args.get('status') == 'SUCCEEDED'
+    assert request.args.get('origin') == 'WEB'

--- a/tests/unit/test_last_run_params.py
+++ b/tests/unit/test_last_run_params.py
@@ -10,18 +10,18 @@ from apify_client.errors import NotFoundError
 if TYPE_CHECKING:
     from pytest_httpserver import HTTPServer
 
-_CHILD_CLIENT_PARAMS = [
-    pytest.param('dataset', 'dataset', id='dataset'),
-    pytest.param('key_value_store', 'key-value-store', id='key-value-store'),
-    pytest.param('request_queue', 'request-queue', id='request-queue'),
-    pytest.param('log', 'log', id='log'),
-]
-
-
 _NOT_FOUND_BODY = {'error': {'type': 'record-not-found', 'message': 'not found'}}
 
 
-@pytest.mark.parametrize(('child_method', 'child_path'), _CHILD_CLIENT_PARAMS)
+@pytest.mark.parametrize(
+    ('child_method', 'child_path'),
+    [
+        pytest.param('dataset', 'dataset', id='dataset'),
+        pytest.param('key_value_store', 'key-value-store', id='key-value-store'),
+        pytest.param('request_queue', 'request-queue', id='request-queue'),
+        pytest.param('log', 'log', id='log'),
+    ],
+)
 def test_last_run_filters_propagate_to_chained_clients(
     httpserver: HTTPServer,
     child_method: str,
@@ -42,7 +42,15 @@ def test_last_run_filters_propagate_to_chained_clients(
     assert request.args.get('origin') == 'WEB'
 
 
-@pytest.mark.parametrize(('child_method', 'child_path'), _CHILD_CLIENT_PARAMS)
+@pytest.mark.parametrize(
+    ('child_method', 'child_path'),
+    [
+        pytest.param('dataset', 'dataset', id='dataset'),
+        pytest.param('key_value_store', 'key-value-store', id='key-value-store'),
+        pytest.param('request_queue', 'request-queue', id='request-queue'),
+        pytest.param('log', 'log', id='log'),
+    ],
+)
 async def test_last_run_filters_propagate_to_chained_clients_async(
     httpserver: HTTPServer,
     child_method: str,


### PR DESCRIPTION
The `status` and `origin` filters passed to `ActorClient.last_run(...)` and `TaskClient.last_run(...)` were silently dropped by the chained storage clients. For example, `actor.last_run(status='SUCCEEDED').dataset().list_items()` queried the most recent run's dataset regardless of status. This is a regression vs 1.x, where `_sub_resource_init_options` forwarded the parent's params to every child client; the typed-client refactor (#604) lost that.

The fix passes the run client's default params to its four child-client factories (`dataset()`, `key_value_store()`, `request_queue()`, `log()`) in both `RunClient` and `RunClientAsync`, so the filters ride along on the `runs/last` storage endpoints again, matching 1.x and the JS client.

Adds a parametrized regression test covering all four chained clients, sync and async. All 8 cases fail before the fix and pass after.