### PR TITLE
docs: fix input guide example to bound the wait with wait_duration

### DIFF
--- a/docs/03_guides/code/01_input_async.py
+++ b/docs/03_guides/code/01_input_async.py
@@ -15,10 +15,10 @@ async def main() -> None:
 
     input_data = {'hashtags': ['rainbow'], 'resultsLimit': 20}
 
-    # Run the Actor and wait for it to finish up to 60 seconds.
+    # Run the Actor and wait up to 60 seconds for it to finish.
     # Input is not persisted for next runs.
     run_result = await actor_client.call(
-        run_input=input_data, timeout=timedelta(seconds=60)
+        run_input=input_data, wait_duration=timedelta(seconds=60)
     )
 
 

--- a/docs/03_guides/code/01_input_sync.py
+++ b/docs/03_guides/code/01_input_sync.py
@@ -14,9 +14,11 @@ def main() -> None:
 
     input_data = {'hashtags': ['rainbow'], 'resultsLimit': 20}
 
-    # Run the Actor and wait for it to finish up to 60 seconds.
+    # Run the Actor and wait up to 60 seconds for it to finish.
     # Input is not persisted for next runs.
-    run_result = actor_client.call(run_input=input_data, timeout=timedelta(seconds=60))
+    run_result = actor_client.call(
+        run_input=input_data, wait_duration=timedelta(seconds=60)
+    )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The "Pass input to an Actor" guide example claimed that `timeout=timedelta(seconds=60)` makes `call()` wait up to 60 seconds for the run to finish. It doesn't. On `call()`, `timeout` is the per-request HTTP timeout forwarded to `start()`, while the wait cap is `wait_duration` (default `None`, i.e. wait indefinitely). A user copying the example would block indefinitely on a long or never-finishing run. The sync and async examples now use `wait_duration=timedelta(seconds=60)` and the comment is reworded accordingly.

The stale copies under `website/versioned_docs/` are left untouched on purpose. The versioning workflow deletes and re-snapshots `version-3.0` from `docs/` on every 3.x release, so the fix propagates there automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)