### PR TITLE
fix: Propagate API token to custom HTTP clients

### DIFF
--- a/docs/03_guides/code/05_custom_http_client_async.py
+++ b/docs/03_guides/code/05_custom_http_client_async.py
@@ -35,6 +35,10 @@ class HttpxClientAsync(HttpClientAsync):
     ) -> HttpResponse:
         timeout_secs = self._compute_timeout(timeout, attempt=1) or 0
 
+        # Merge the client's default headers (including authorization)
+        # with the per-request ones.
+        headers = {**self._headers, **(headers or {})}
+
         # httpx.Response satisfies the HttpResponse protocol,
         # so it can be returned directly.
         return await self._client.request(

--- a/docs/03_guides/code/05_custom_http_client_async.py
+++ b/docs/03_guides/code/05_custom_http_client_async.py
@@ -37,7 +37,7 @@ class HttpxClientAsync(HttpClientAsync):
 
         # Merge the client's default headers (including authorization)
         # with the per-request ones.
-        headers = {**self._headers, **(headers or {})}
+        headers = self._merge_headers(self._headers, headers)
 
         # httpx.Response satisfies the HttpResponse protocol,
         # so it can be returned directly.

--- a/docs/03_guides/code/05_custom_http_client_sync.py
+++ b/docs/03_guides/code/05_custom_http_client_sync.py
@@ -34,6 +34,10 @@ class HttpxClient(HttpClient):
     ) -> HttpResponse:
         timeout_secs = self._compute_timeout(timeout, attempt=1) or 0
 
+        # Merge the client's default headers (including authorization)
+        # with the per-request ones.
+        headers = {**self._headers, **(headers or {})}
+
         # httpx.Response satisfies the HttpResponse protocol,
         # so it can be returned directly.
         return self._client.request(

--- a/docs/03_guides/code/05_custom_http_client_sync.py
+++ b/docs/03_guides/code/05_custom_http_client_sync.py
@@ -36,7 +36,7 @@ class HttpxClient(HttpClient):
 
         # Merge the client's default headers (including authorization)
         # with the per-request ones.
-        headers = {**self._headers, **(headers or {})}
+        headers = self._merge_headers(self._headers, headers)
 
         # httpx.Response satisfies the HttpResponse protocol,
         # so it can be returned directly.

--- a/src/apify_client/_apify_client.py
+++ b/src/apify_client/_apify_client.py
@@ -254,7 +254,7 @@ class ApifyClient:
         """
         instance = cls(token=token, api_url=api_url, api_public_url=api_public_url)
         if token is not None:
-            http_client._set_default_authorization(token)  # noqa: SLF001
+            http_client.set_default_authorization(token)
         instance._http_client = http_client
         return instance
 
@@ -616,7 +616,7 @@ class ApifyClientAsync:
         """
         instance = cls(token=token, api_url=api_url, api_public_url=api_public_url)
         if token is not None:
-            http_client._set_default_authorization(token)  # noqa: SLF001
+            http_client.set_default_authorization(token)
         instance._http_client = http_client
         return instance
 

--- a/src/apify_client/_apify_client.py
+++ b/src/apify_client/_apify_client.py
@@ -253,9 +253,8 @@ class ApifyClient:
             http_client: A custom HTTP client instance extending `HttpClient`.
         """
         instance = cls(token=token, api_url=api_url, api_public_url=api_public_url)
-        client_headers = http_client._headers  # noqa: SLF001
-        if token is not None and not any(key.title() == 'Authorization' for key in client_headers):
-            client_headers['Authorization'] = f'Bearer {token}'
+        if token is not None:
+            http_client._set_default_authorization(token)  # noqa: SLF001
         instance._http_client = http_client
         return instance
 
@@ -616,9 +615,8 @@ class ApifyClientAsync:
             http_client: A custom HTTP client instance extending `HttpClientAsync`.
         """
         instance = cls(token=token, api_url=api_url, api_public_url=api_public_url)
-        client_headers = http_client._headers  # noqa: SLF001
-        if token is not None and not any(key.title() == 'Authorization' for key in client_headers):
-            client_headers['Authorization'] = f'Bearer {token}'
+        if token is not None:
+            http_client._set_default_authorization(token)  # noqa: SLF001
         instance._http_client = http_client
         return instance
 

--- a/src/apify_client/_apify_client.py
+++ b/src/apify_client/_apify_client.py
@@ -227,7 +227,7 @@ class ApifyClient:
 
         Use this alternative constructor when you want to provide your own HTTP client implementation
         instead of the default one. The custom client is responsible for its own configuration
-        (retries, timeouts, headers, etc.).
+        (retries, timeouts, etc.); only the token is applied to it, as described below.
 
         ### Usage
 
@@ -246,12 +246,16 @@ class ApifyClient:
         ```
 
         Args:
-            token: The Apify API token.
+            token: The Apify API token. It is set as the `Authorization` header on the custom client,
+                unless the client already has one configured.
             api_url: The URL of the Apify API server to connect to. Defaults to https://api.apify.com.
             api_public_url: The globally accessible URL of the Apify API server. Defaults to https://api.apify.com.
             http_client: A custom HTTP client instance extending `HttpClient`.
         """
         instance = cls(token=token, api_url=api_url, api_public_url=api_public_url)
+        client_headers = http_client._headers  # noqa: SLF001
+        if token is not None and not any(key.title() == 'Authorization' for key in client_headers):
+            client_headers['Authorization'] = f'Bearer {token}'
         instance._http_client = http_client
         return instance
 
@@ -586,7 +590,7 @@ class ApifyClientAsync:
 
         Use this alternative constructor when you want to provide your own HTTP client implementation
         instead of the default one. The custom client is responsible for its own configuration
-        (retries, timeouts, headers, etc.).
+        (retries, timeouts, etc.); only the token is applied to it, as described below.
 
         ### Usage
 
@@ -605,12 +609,16 @@ class ApifyClientAsync:
         ```
 
         Args:
-            token: The Apify API token.
+            token: The Apify API token. It is set as the `Authorization` header on the custom client,
+                unless the client already has one configured.
             api_url: The URL of the Apify API server to connect to. Defaults to https://api.apify.com.
             api_public_url: The globally accessible URL of the Apify API server. Defaults to https://api.apify.com.
             http_client: A custom HTTP client instance extending `HttpClientAsync`.
         """
         instance = cls(token=token, api_url=api_url, api_public_url=api_public_url)
+        client_headers = http_client._headers  # noqa: SLF001
+        if token is not None and not any(key.title() == 'Authorization' for key in client_headers):
+            client_headers['Authorization'] = f'Bearer {token}'
         instance._http_client = http_client
         return instance
 

--- a/src/apify_client/http_clients/_base.py
+++ b/src/apify_client/http_clients/_base.py
@@ -143,7 +143,7 @@ class HttpClientBase:
         if token is not None:
             default_headers['Authorization'] = f'Bearer {token}'
 
-        self._headers = {**default_headers, **(headers or {})}
+        self._headers = self._merge_headers(default_headers, headers)
 
     def set_default_authorization(self, token: str) -> None:
         """Set the `Authorization` header from the token, unless an authorization header is already configured.
@@ -151,8 +151,22 @@ class HttpClientBase:
         Args:
             token: The Apify API token to set as the `Bearer` authorization.
         """
-        if not any(key.title() == 'Authorization' for key in self._headers):
+        if not any(key.lower() == 'authorization' for key in self._headers):
             self._headers['Authorization'] = f'Bearer {token}'
+
+    @staticmethod
+    def _merge_headers(base: dict[str, str] | None, override: dict[str, str] | None) -> dict[str, str]:
+        """Merge two header dicts, treating header names case-insensitively.
+
+        A header from `override` replaces a same-named header in `base` regardless of the casing
+        of either name, and keeps the casing it was passed with.
+        """
+        merged = dict(base) if base else {}
+        for key, value in (override or {}).items():
+            for existing_key in [k for k in merged if k.lower() == key.lower()]:
+                del merged[existing_key]
+            merged[key] = value
+        return merged
 
     @staticmethod
     def _parse_params(params: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -219,17 +233,20 @@ class HttpClientBase:
         """Prepare headers, params, and body for an HTTP request.
 
         Merges the client's default headers (including authorization) with per-request headers,
-        serializes JSON and compresses the body.
+        serializes JSON and compresses the body. Header names are treated case-insensitively and
+        per-request values win over the client defaults. For JSON bodies, a `Content-Type` header
+        is set unless the caller supplied one.
         """
         if json is not None and data is not None:
             raise ValueError('Cannot pass both "json" and "data" parameters at the same time!')
 
-        headers = {**self._headers, **(headers or {})}
+        headers = self._merge_headers(self._headers, headers)
 
         # Dump JSON data to string so it can be compressed.
         if json is not None:
             data = jsonlib.dumps(json, ensure_ascii=False, allow_nan=False, default=str).encode('utf-8')
-            headers['Content-Type'] = 'application/json'
+            if not any(key.lower() == 'content-type' for key in headers):
+                headers['Content-Type'] = 'application/json'
 
         if isinstance(data, (str, bytes, bytearray)):
             if isinstance(data, str):
@@ -237,7 +254,7 @@ class HttpClientBase:
             elif isinstance(data, bytearray):
                 data = bytes(data)
             data = self._http_compressor.compress(data)
-            headers['Content-Encoding'] = self._http_compressor.content_encoding
+            headers = self._merge_headers(headers, {'Content-Encoding': self._http_compressor.content_encoding})
 
         return (headers, self._parse_params(params), data)
 

--- a/src/apify_client/http_clients/_base.py
+++ b/src/apify_client/http_clients/_base.py
@@ -145,6 +145,11 @@ class HttpClientBase:
 
         self._headers = {**default_headers, **(headers or {})}
 
+    def _set_default_authorization(self, token: str) -> None:
+        """Set the `Authorization` header from the token, unless an authorization header is already configured."""
+        if not any(key.title() == 'Authorization' for key in self._headers):
+            self._headers['Authorization'] = f'Bearer {token}'
+
     @staticmethod
     def _parse_params(params: dict[str, Any] | None) -> dict[str, Any] | None:
         """Convert request parameters to Apify API-compatible formats.

--- a/src/apify_client/http_clients/_base.py
+++ b/src/apify_client/http_clients/_base.py
@@ -145,8 +145,12 @@ class HttpClientBase:
 
         self._headers = {**default_headers, **(headers or {})}
 
-    def _set_default_authorization(self, token: str) -> None:
-        """Set the `Authorization` header from the token, unless an authorization header is already configured."""
+    def set_default_authorization(self, token: str) -> None:
+        """Set the `Authorization` header from the token, unless an authorization header is already configured.
+
+        Args:
+            token: The Apify API token to set as the `Bearer` authorization.
+        """
         if not any(key.title() == 'Authorization' for key in self._headers):
             self._headers['Authorization'] = f'Bearer {token}'
 

--- a/src/apify_client/http_clients/_base.py
+++ b/src/apify_client/http_clients/_base.py
@@ -207,11 +207,15 @@ class HttpClientBase:
         data: str | bytes | bytearray | None = None,
         json: JsonSerializable | None = None,
     ) -> tuple[dict[str, str], dict[str, Any] | None, bytes | None]:
-        """Prepare headers, params, and body for an HTTP request. Serializes JSON and compresses the body."""
+        """Prepare headers, params, and body for an HTTP request.
+
+        Merges the client's default headers (including authorization) with per-request headers,
+        serializes JSON and compresses the body.
+        """
         if json is not None and data is not None:
             raise ValueError('Cannot pass both "json" and "data" parameters at the same time!')
 
-        headers = dict(headers) if headers else {}
+        headers = {**self._headers, **(headers or {})}
 
         # Dump JSON data to string so it can be compressed.
         if json is not None:
@@ -252,6 +256,10 @@ class HttpClient(HttpClientBase, ABC):
     Extend this class to create a custom synchronous HTTP client. Override the `call` method
     with your implementation. Helper methods from the base class are available for request
     preparation, URL building, and parameter parsing.
+
+    Implementations must send the client's default headers from `self._headers` with every request,
+    otherwise the `Authorization` header never reaches the API. The `_prepare_request_call` helper
+    merges them into the per-request headers automatically.
     """
 
     @abstractmethod

--- a/src/apify_client/http_clients/_impit.py
+++ b/src/apify_client/http_clients/_impit.py
@@ -104,7 +104,6 @@ class ImpitHttpClient(HttpClient):
         )
 
         self._impit_client = impit.Client(
-            headers=self._headers,
             follow_redirects=True,
         )
 
@@ -354,7 +353,6 @@ class ImpitHttpClientAsync(HttpClientAsync):
         )
 
         self._impit_async_client = impit.AsyncClient(
-            headers=self._headers,
             follow_redirects=True,
         )
 

--- a/tests/unit/test_client_headers.py
+++ b/tests/unit/test_client_headers.py
@@ -124,3 +124,33 @@ def test_headers_sync(httpserver: HTTPServer) -> None:
     }
     assert {k: v for k, v in request_headers.items() if k != 'Accept-Encoding'} == expected_headers
     assert _parse_accept_encoding(request_headers['Accept-Encoding']) == {'gzip', 'br', 'zstd', 'deflate'}
+
+
+async def test_per_request_headers_override_defaults_async(httpserver: HTTPServer) -> None:
+    """Test that a per-request header overrides a same-named default header on the wire, without duplication."""
+    client = ImpitHttpClientAsync(token='placeholder_token')
+    httpserver.expect_request('/').respond_with_handler(_header_handler)
+    api_url = httpserver.url_for('/').removesuffix('/')
+
+    response = await client.call(method='GET', url=f'{api_url}/', headers={'authorization': 'Bearer per-request'})
+
+    request_headers = json.loads(response.text)['received_headers']
+
+    # WSGI joins duplicate headers into one comma-separated value, so exact equality
+    # also proves the authorization header was sent only once.
+    assert request_headers['Authorization'] == 'Bearer per-request'
+
+
+def test_per_request_headers_override_defaults_sync(httpserver: HTTPServer) -> None:
+    """Test that a per-request header overrides a same-named default header on the wire, without duplication."""
+    client = ImpitHttpClient(token='placeholder_token')
+    httpserver.expect_request('/').respond_with_handler(_header_handler)
+    api_url = httpserver.url_for('/').removesuffix('/')
+
+    response = client.call(method='GET', url=f'{api_url}/', headers={'authorization': 'Bearer per-request'})
+
+    request_headers = json.loads(response.text)['received_headers']
+
+    # WSGI joins duplicate headers into one comma-separated value, so exact equality
+    # also proves the authorization header was sent only once.
+    assert request_headers['Authorization'] == 'Bearer per-request'

--- a/tests/unit/test_http_clients.py
+++ b/tests/unit/test_http_clients.py
@@ -167,6 +167,53 @@ def test_base_http_client_initialization() -> None:
     assert isinstance(client2._statistics, ClientStatistics)
 
 
+def test_http_client_init_headers_override_defaults_case_insensitively() -> None:
+    """Constructor headers replace same-named default headers even when their casings differ."""
+    client = _ConcreteHttpClient(token='default_token', headers={'authorization': 'Bearer custom'})
+
+    auth_headers = {key: value for key, value in client._headers.items() if key.lower() == 'authorization'}
+    assert auth_headers == {'authorization': 'Bearer custom'}
+
+
+def test_http_client_init_workflow_key_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The X-Apify-Workflow-Key default header is set from the APIFY_WORKFLOW_KEY env var."""
+    monkeypatch.setenv('APIFY_WORKFLOW_KEY', 'workflow_key_123')
+
+    client = _ConcreteHttpClient()
+
+    assert client._headers['X-Apify-Workflow-Key'] == 'workflow_key_123'
+
+
+def test_set_default_authorization_sets_token_when_missing() -> None:
+    """set_default_authorization sets the Bearer token when no authorization header is configured."""
+    client = _ConcreteHttpClient()
+
+    client.set_default_authorization('test_token')
+
+    assert client._headers['Authorization'] == 'Bearer test_token'
+
+
+@pytest.mark.parametrize(
+    ('base', 'override', 'expected'),
+    [
+        pytest.param(None, None, {}, id='both none'),
+        pytest.param({'Accept': 'a'}, None, {'Accept': 'a'}, id='override none'),
+        pytest.param(None, {'Accept': 'a'}, {'Accept': 'a'}, id='base none'),
+        pytest.param({'Accept': 'a'}, {'X-Custom': 'b'}, {'Accept': 'a', 'X-Custom': 'b'}, id='disjoint names'),
+        pytest.param({'Authorization': 'x'}, {'Authorization': 'y'}, {'Authorization': 'y'}, id='same casing'),
+        pytest.param({'Authorization': 'x'}, {'authorization': 'y'}, {'authorization': 'y'}, id='lowercase override'),
+        pytest.param({'authorization': 'x'}, {'AUTHORIZATION': 'y'}, {'AUTHORIZATION': 'y'}, id='uppercase override'),
+    ],
+)
+def test_merge_headers(
+    base: dict[str, str] | None,
+    override: dict[str, str] | None,
+    expected: dict[str, str],
+) -> None:
+    """_merge_headers merges case-insensitively, override values win and keep their casing."""
+    assert HttpClient._merge_headers(base, override) == expected
+
+
 def test_http_client_creates_sync_impit_client() -> None:
     """Test that ImpitHttpClient creates sync impit client correctly."""
     client = ImpitHttpClient(token='test_token_123')
@@ -444,6 +491,39 @@ def test_prepare_request_call_does_not_mutate_caller_headers() -> None:
 
     client._prepare_request_call(headers=caller_headers, data='payload')
     assert caller_headers == original
+
+
+def test_prepare_request_call_per_request_headers_override_defaults_case_insensitively() -> None:
+    """A per-request header replaces a same-named default header even when their casings differ."""
+    client = _ConcreteHttpClient(token='default_token')
+
+    headers, _params, _data = client._prepare_request_call(headers={'authorization': 'Bearer per-request'})
+
+    auth_headers = {key: value for key, value in headers.items() if key.lower() == 'authorization'}
+    assert auth_headers == {'authorization': 'Bearer per-request'}
+
+
+def test_prepare_request_call_json_keeps_caller_content_type() -> None:
+    """A caller-supplied content type is not overwritten by the JSON default, regardless of casing."""
+    client = _ConcreteHttpClient()
+
+    headers, _params, _data = client._prepare_request_call(
+        headers={'content-type': 'application/json; charset=utf-8'},
+        json={'key': 'value'},
+    )
+
+    content_type_headers = {key: value for key, value in headers.items() if key.lower() == 'content-type'}
+    assert content_type_headers == {'content-type': 'application/json; charset=utf-8'}
+
+
+def test_prepare_request_call_replaces_caller_content_encoding() -> None:
+    """The Content-Encoding header always reflects the compressor actually applied, replacing any caller value."""
+    client = _ConcreteHttpClient(http_compressor=GzipHttpCompressor())
+
+    headers, _params, _data = client._prepare_request_call(headers={'content-encoding': 'br'}, data='payload')
+
+    encoding_headers = {key: value for key, value in headers.items() if key.lower() == 'content-encoding'}
+    assert encoding_headers == {'Content-Encoding': 'gzip'}
 
 
 def test_build_url_with_params_none() -> None:

--- a/tests/unit/test_http_clients.py
+++ b/tests/unit/test_http_clients.py
@@ -279,11 +279,13 @@ def compressor_case(request: pytest.FixtureRequest) -> tuple:
 
 
 def test_prepare_request_call_basic() -> None:
-    """Test _prepare_request_call with basic parameters."""
-    client = _ConcreteHttpClient()
+    """Test _prepare_request_call returns the client default headers when no per-request values are given."""
+    client = _ConcreteHttpClient(token='test_token')
 
     headers, params, data = client._prepare_request_call()
-    assert headers == {}
+    assert headers == client._headers
+    assert headers is not client._headers
+    assert headers['Authorization'] == 'Bearer test_token'
     assert params is None
     assert data is None
 

--- a/tests/unit/test_pluggable_http_client.py
+++ b/tests/unit/test_pluggable_http_client.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import json as jsonlib
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+import impit
 import pytest
+from werkzeug import Request, Response
 
 import apify_client as apify_client_module
 import apify_client.http_clients as http_clients_module
@@ -423,3 +426,125 @@ async def test_custom_http_client_async_with_real_server(httpserver: HTTPServer)
 
     assert result is not None
     assert result['data']['id'] == 'test-dataset'
+
+
+class PreparingHttpClient(HttpClient):
+    """A custom sync HTTP client that sends requests prepared by the base-class helpers."""
+
+    def __init__(self, token: str | None = None) -> None:
+        super().__init__(token=token)
+        self._impit_client = impit.Client()
+
+    def call(
+        self,
+        *,
+        method: str,
+        url: str,
+        headers: dict[str, str] | None = None,
+        params: dict[str, Any] | None = None,
+        data: str | bytes | bytearray | None = None,
+        json: Any = None,
+        **_kwargs: Any,
+    ) -> HttpResponse:
+        headers, params, content = self._prepare_request_call(headers=headers, params=params, data=data, json=json)
+        url = self._build_url_with_params(url, params=params)
+        return self._impit_client.request(method=method, url=url, headers=headers, content=content)
+
+
+class PreparingHttpClientAsync(HttpClientAsync):
+    """A custom async HTTP client that sends requests prepared by the base-class helpers."""
+
+    def __init__(self, token: str | None = None) -> None:
+        super().__init__(token=token)
+        self._impit_client = impit.AsyncClient()
+
+    async def call(
+        self,
+        *,
+        method: str,
+        url: str,
+        headers: dict[str, str] | None = None,
+        params: dict[str, Any] | None = None,
+        data: str | bytes | bytearray | None = None,
+        json: Any = None,
+        **_kwargs: Any,
+    ) -> HttpResponse:
+        headers, params, content = self._prepare_request_call(headers=headers, params=params, data=data, json=json)
+        url = self._build_url_with_params(url, params=params)
+        return await self._impit_client.request(method=method, url=url, headers=headers, content=content)
+
+
+def _echo_headers(request: Request) -> Response:
+    """Respond with the received request headers so tests can assert on them."""
+    return Response(
+        response=jsonlib.dumps({'received_headers': dict(request.headers)}),
+        status=200,
+        content_type='application/json',
+    )
+
+
+def test_custom_http_client_sends_token_from_classmethod(httpserver: HTTPServer) -> None:
+    """Token passed to with_custom_http_client is sent as the Authorization header by the custom client."""
+    httpserver.expect_request('/v2/datasets/test-dataset').respond_with_handler(_echo_headers)
+
+    api_url = httpserver.url_for('/').removesuffix('/')
+    client = ApifyClient.with_custom_http_client(
+        token='test_token',
+        api_url=api_url,
+        http_client=PreparingHttpClient(),
+    )
+
+    result = client.dataset('test-dataset')._get(timeout='short')
+
+    assert result is not None
+    assert result['received_headers']['Authorization'] == 'Bearer test_token'
+
+
+async def test_custom_http_client_async_sends_token_from_classmethod(httpserver: HTTPServer) -> None:
+    """Token passed to async with_custom_http_client is sent as the Authorization header by the custom client."""
+    httpserver.expect_request('/v2/datasets/test-dataset').respond_with_handler(_echo_headers)
+
+    api_url = httpserver.url_for('/').removesuffix('/')
+    client = ApifyClientAsync.with_custom_http_client(
+        token='test_token',
+        api_url=api_url,
+        http_client=PreparingHttpClientAsync(),
+    )
+
+    result = await client.dataset('test-dataset')._get(timeout='short')
+
+    assert result is not None
+    assert result['received_headers']['Authorization'] == 'Bearer test_token'
+
+
+def test_custom_http_client_impit_instance_sends_token(httpserver: HTTPServer) -> None:
+    """Token from with_custom_http_client reaches the wire even for a pre-built tokenless ImpitHttpClient."""
+    httpserver.expect_request('/v2/datasets/test-dataset').respond_with_handler(_echo_headers)
+
+    api_url = httpserver.url_for('/').removesuffix('/')
+    client = ApifyClient.with_custom_http_client(token='test_token', api_url=api_url, http_client=ImpitHttpClient())
+
+    result = client.dataset('test-dataset')._get(timeout='short')
+
+    assert result is not None
+    assert result['received_headers']['Authorization'] == 'Bearer test_token'
+
+
+def test_custom_http_client_keeps_own_token() -> None:
+    """An Authorization header configured on the custom client itself is not overridden by with_custom_http_client."""
+    http_client = PreparingHttpClient(token='client_token')
+
+    ApifyClient.with_custom_http_client(token='outer_token', http_client=http_client)
+
+    assert http_client._headers['Authorization'] == 'Bearer client_token'
+
+
+def test_custom_http_client_keeps_differently_cased_authorization() -> None:
+    """A lowercase 'authorization' header on the custom client is not duplicated by the token injection."""
+    http_client = PreparingHttpClient()
+    http_client._headers['authorization'] = 'Bearer client_token'
+
+    ApifyClient.with_custom_http_client(token='outer_token', http_client=http_client)
+
+    assert 'Authorization' not in http_client._headers
+    assert http_client._headers['authorization'] == 'Bearer client_token'


### PR DESCRIPTION
`ApifyClient.with_custom_http_client(token=...)` (and the async twin) stored the token on the `ApifyClient` instance but never passed it to the injected HTTP client, so no request carried an `Authorization` header and every call failed with 401. The documented custom HTTP client example inherited the bug.

- `with_custom_http_client` now sets `Authorization: Bearer <token>` on the injected client's default headers, unless the client already has an auth header configured (checked case-insensitively).
- `HttpClientBase._prepare_request_call` now merges the client's default headers under the per-request headers, so any custom client using the helper (including a pre-built `ImpitHttpClient` passed as the custom client) actually sends them. For the default client the wire behavior is unchanged, since impit request-level headers replace the identical client-level ones.
- The HTTPX guide examples now merge `self._headers` before delegating, and the `HttpClient` ABC docstring states that implementations must send the default headers with every request.

Regression tests cover the token reaching the wire (custom sync/async clients and a pre-built tokenless `ImpitHttpClient`) and the no-clobber semantics for client-configured auth headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)