### PR TITLE
docs: Fix documentation mismatches with actual client behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ client = ApifyClient('MY-APIFY-TOKEN')
 run = client.actor('apify/hello-world').call(
     run_input={'message': 'Hello, Apify!'},
 )
+if run is None:
+    raise RuntimeError('Actor run was not found.')
 
 # Iterate items from the run's default dataset.
 for item in client.dataset(run.default_dataset_id).iterate_items():
@@ -99,6 +101,8 @@ async def main() -> None:
     run = await client.actor('apify/hello-world').call(
         run_input={'message': 'Hello, Apify!'},
     )
+    if run is None:
+        raise RuntimeError('Actor run was not found.')
 
     # Iterate items from the run's default dataset.
     async for item in client.dataset(run.default_dataset_id).iterate_items():
@@ -158,7 +162,7 @@ record = store.get_record('greeting')
 ### Iterate dataset items with automatic pagination
 
 ```python
-for item in client.dataset('DATASET-ID').iterate_items(fields='title,url'):
+for item in client.dataset('DATASET-ID').iterate_items(fields=['title', 'url']):
     process(item)
 ```
 

--- a/docs/01_introduction/index.mdx
+++ b/docs/01_introduction/index.mdx
@@ -61,6 +61,12 @@ For better request-body compression, opt in to `brotli`, which compresses better
     </TabItem>
 </Tabs>
 
+:::note Extras on conda-forge
+
+Conda doesn't support optional extras. On conda-forge, install the `brotli-python` package directly alongside the client. It provides the same `brotli` module as the PyPI extra.
+
+:::
+
 For details, see [HTTP compression](../02_concepts/13_http_compression.mdx).
 
 ## Quick example

--- a/docs/01_introduction/index.mdx
+++ b/docs/01_introduction/index.mdx
@@ -56,7 +56,7 @@ For better request-body compression, opt in to `brotli`, which compresses better
     </TabItem>
     <TabItem value="conda-forge" label="conda-forge">
         ```bash
-        conda install conda-forge::apify-client conda-forge::brotli
+        conda install conda-forge::apify-client conda-forge::brotli-python
         ```
     </TabItem>
 </Tabs>

--- a/docs/01_introduction/quick-start.mdx
+++ b/docs/01_introduction/quick-start.mdx
@@ -65,7 +65,7 @@ To define the Actor's input, pass a dictionary to the <ApiLink to="class/ActorCl
 
 ## Step 3: Get results from the dataset
 
-To get the results from the dataset, call the <ApiLink to="class/DatasetClient">`apify_client.dataset()`</ApiLink> method with the dataset ID, then call <ApiLink to="class/DatasetClient#list_items">`list_items()`</ApiLink> to retrieve the data. You can get the dataset ID from the Actor's run dictionary (represented by `defaultDatasetId`).
+To get the results from the dataset, call the <ApiLink to="class/DatasetClient">`apify_client.dataset()`</ApiLink> method with the dataset ID, then call <ApiLink to="class/DatasetClient#list_items">`list_items()`</ApiLink> to retrieve the data. You can get the dataset ID from the `default_dataset_id` attribute of the <ApiLink to="class/Run">`Run`</ApiLink> object returned by `call()`.
 
 <Tabs>
     <TabItem value="AsyncExample" label="Async client" default>

--- a/docs/02_concepts/06_logging.mdx
+++ b/docs/02_concepts/06_logging.mdx
@@ -20,12 +20,12 @@ The library logs useful debug information to the `apify_client` logger whenever 
 The log records include additional properties, provided via the extra argument, which can be helpful for debugging. Some of these properties are:
 
 - `attempt` - Number of retry attempts for the request.
-- `status_code` - HTTP status code of the response.
+- `status_code` - HTTP status code of the response. Only present on records about a request's outcome.
 - `url` - URL of the API endpoint being called.
 - `client_method` - Method name of the client that initiated the request.
 - `resource_id` - Identifier of the resource being accessed.
 
-To display these additional properties in the log output, you need to use a custom log formatter. Here's a basic example:
+To display these additional properties in the log output, you need to use a custom log formatter. Reference only the properties present on every record, since a `%`-style formatter raises an error for records that lack a referenced property. Here's a basic example:
 
 <CodeBlock className="language-python">
     {LoggingFormatterExample}

--- a/docs/02_concepts/08_pagination.mdx
+++ b/docs/02_concepts/08_pagination.mdx
@@ -17,7 +17,7 @@ import IterateItemsSyncExample from '!!raw-loader!./code/08_iterate_items_sync.p
 import IterateCollectionAsyncExample from '!!raw-loader!./code/08_iterate_collection_async.py';
 import IterateCollectionSyncExample from '!!raw-loader!./code/08_iterate_collection_sync.py';
 
-Most methods named `list` or `list_something` in the Apify client return a page model — a [Pydantic](https://docs.pydantic.dev/latest/) model such as <ApiLink to="class/ListOfActors">`ListOfActors`</ApiLink>, <ApiLink to="class/ListOfDatasets">`ListOfDatasets`</ApiLink>, or <ApiLink to="class/ListOfRequests">`ListOfRequests`</ApiLink>. Unstructured dataset items use the <ApiLink to="class/DatasetItemsPage">`DatasetItemsPage`</ApiLink> dataclass instead. All page models share a consistent interface for working with paginated data and expose the following fields:
+Most methods named `list` or `list_something` in the Apify client return a page model — a [Pydantic](https://docs.pydantic.dev/latest/) model such as <ApiLink to="class/ListOfActors">`ListOfActors`</ApiLink> or <ApiLink to="class/ListOfDatasets">`ListOfDatasets`</ApiLink>. Unstructured dataset items use the <ApiLink to="class/DatasetItemsPage">`DatasetItemsPage`</ApiLink> dataclass instead. All page models share a consistent interface for working with paginated data and expose the following fields:
 
 - `items` - The main results you're looking for.
 - `total` - The total number of items available.
@@ -25,7 +25,7 @@ Most methods named `list` or `list_something` in the Apify client return a page 
 - `count` - The number of items in the current page.
 - `limit` - The maximum number of items per page.
 
-Some methods, such as `list_keys` or `list_head`, paginate differently. Regardless, the primary results are always stored under the `items` field, and the `limit` field can be used to control the number of results returned.
+Some methods paginate differently. For example, <ApiLink to="class/RequestQueueClient#list_requests">`RequestQueueClient.list_requests`</ApiLink> returns a cursor-based <ApiLink to="class/ListOfRequests">`ListOfRequests`</ApiLink> without the `total`, `offset`, and `count` fields. To fetch the next page, pass its `next_cursor` value back as the `cursor` parameter. Other examples include `list_keys` and `list_head`. Regardless, the primary results are always stored under the `items` field, and the `limit` field can be used to control the number of results returned.
 
 The following example shows how to fetch all items from a dataset using pagination:
 

--- a/docs/02_concepts/09_streaming.mdx
+++ b/docs/02_concepts/09_streaming.mdx
@@ -17,11 +17,11 @@ Certain resources, such as dataset items, key-value store records, and logs, sup
 
 Supported streaming methods:
 
-- <ApiLink to="class/DatasetClient#stream_items">`DatasetClient.stream_items`</ApiLink> - Stream dataset items incrementally.
-- <ApiLink to="class/KeyValueStoreClient#stream_record">`KeyValueStoreClient.stream_record`</ApiLink> - Stream key-value store records as raw data.
-- <ApiLink to="class/LogClient#stream">`LogClient.stream`</ApiLink> - Stream logs in real time.
+- <ApiLink to="class/DatasetClient#stream_items">`DatasetClient.stream_items`</ApiLink> - Stream dataset items incrementally. Yields a raw streaming <ApiLink to="class/HttpResponse">`HttpResponse`</ApiLink>.
+- <ApiLink to="class/KeyValueStoreClient#stream_record">`KeyValueStoreClient.stream_record`</ApiLink> - Stream a key-value store record as raw data. Yields a `dict` with the `key`, `value`, and `content_type` fields, where `value` holds the raw streaming response, or `None` when the record doesn't exist.
+- <ApiLink to="class/LogClient#stream">`LogClient.stream`</ApiLink> - Stream logs in real time. Yields a raw streaming <ApiLink to="class/HttpResponse">`HttpResponse`</ApiLink>, or `None` when the log doesn't exist.
 
-These methods return a raw, context-managed `impit.Response` object. The response must be consumed within a with block to ensure that the connection is closed automatically, preventing memory leaks or unclosed connections.
+All three methods are context managers. Consume the streamed data within a `with` block to ensure that the connection is closed automatically, preventing memory leaks or unclosed connections.
 
 The following example shows how to stream the logs of an Actor run incrementally:
 

--- a/docs/02_concepts/11_timeouts.mdx
+++ b/docs/02_concepts/11_timeouts.mdx
@@ -19,7 +19,7 @@ The Apify client uses a tiered timeout system to set appropriate time limits for
 | `short` | 5 seconds | Fast CRUD operations (get, update, delete) |
 | `medium` | 30 seconds | Batch, list, and data transfer operations |
 | `long` | 360 seconds | Long-polling, streaming, and heavy operations |
-| `no_timeout` | — | Disables the timeout entirely |
+| `no_timeout` | — | Effectively disables the timeout (the default client caps it at 24 hours) |
 
 Every client method has a pre-assigned tier that matches the expected duration of the underlying API call. You generally don't need to change these unless you're working with unusually large payloads or slow network conditions.
 
@@ -53,7 +53,7 @@ client.dataset('id').list_items(timeout=timedelta(seconds=120))
 # Switch to a different tier.
 client.dataset('id').list_items(timeout='long')
 
-# Disable the timeout entirely.
+# Effectively disable the timeout (capped at 24 hours by the default client).
 client.dataset('id').list_items(timeout='no_timeout')
 ```
 

--- a/docs/02_concepts/code/06_logging_formatter.py
+++ b/docs/02_concepts/code/06_logging_formatter.py
@@ -1,15 +1,17 @@
 import logging
 
-# Configure the Apify client logger
-apify_client_logger = logging.getLogger('apify_client')
-apify_client_logger.setLevel(logging.DEBUG)
-apify_client_logger.addHandler(logging.StreamHandler())
-
-# Create a custom logging formatter
+# Create a custom logging formatter. Reference only the properties present
+# on every record. Properties attached to some records only, such as
+# `status_code`, would raise an error for the records that lack them.
 formatter = logging.Formatter(
     '%(asctime)s - %(name)s - %(levelname)s - %(message)s - '
-    '%(attempt)s - %(status_code)s - %(url)s'
+    '%(client_method)s - %(attempt)s - %(url)s'
 )
+
 handler = logging.StreamHandler()
 handler.setFormatter(formatter)
+
+# Configure the Apify client logger to use the custom formatter
+apify_client_logger = logging.getLogger('apify_client')
+apify_client_logger.setLevel(logging.DEBUG)
 apify_client_logger.addHandler(handler)

--- a/docs/03_guides/05_custom_http_client.mdx
+++ b/docs/03_guides/05_custom_http_client.mdx
@@ -33,6 +33,8 @@ The `call` method receives parameters like `method`, `url`, `headers`, `params`,
 
 A convenient property of HTTPX is that its `httpx.Response` object already satisfies the <ApiLink to="class/HttpResponse">`HttpResponse`</ApiLink> protocol, so you can return it directly without wrapping.
 
+One part of the contract isn't visible in the method signature: `call` must raise <ApiLink to="class/ApifyApiError">`ApifyApiError`</ApiLink> for error responses instead of returning them. The resource clients rely on that error to work correctly. For example, `get` methods translate a 404 raised this way into a `None` return value, and user code handling `ApifyApiError` keeps working.
+
 <Tabs>
     <TabItem value="AsyncExample" label="Async client" default>
         <CodeBlock className="language-python">

--- a/docs/03_guides/code/05_custom_http_client_async.py
+++ b/docs/03_guides/code/05_custom_http_client_async.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
 
 import httpx
 
 from apify_client import ApifyClientAsync
+from apify_client.errors import ApifyApiError
 from apify_client.http_clients import HttpClientAsync, HttpResponse
 
 if TYPE_CHECKING:
@@ -39,9 +41,7 @@ class HttpxClientAsync(HttpClientAsync):
         # with the per-request ones.
         headers = self._merge_headers(self._headers, headers)
 
-        # httpx.Response satisfies the HttpResponse protocol,
-        # so it can be returned directly.
-        return await self._client.request(
+        response = await self._client.request(
             method=method,
             url=url,
             headers=headers,
@@ -50,6 +50,16 @@ class HttpxClientAsync(HttpClientAsync):
             json=json,
             timeout=timeout_secs,
         )
+
+        # Raising `ApifyApiError` for error responses is part of the `call`
+        # contract. The resource clients rely on it, e.g. to translate a 404
+        # into a `None` return value of `get` methods.
+        if response.status_code >= HTTPStatus.BAD_REQUEST:
+            raise ApifyApiError(response, attempt=1, method=method)
+
+        # httpx.Response satisfies the HttpResponse protocol,
+        # so it can be returned directly.
+        return response
 
 
 async def main() -> None:

--- a/docs/03_guides/code/05_custom_http_client_sync.py
+++ b/docs/03_guides/code/05_custom_http_client_sync.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
 
 import httpx
 
 from apify_client import ApifyClient
+from apify_client.errors import ApifyApiError
 from apify_client.http_clients import HttpClient, HttpResponse
 
 if TYPE_CHECKING:
@@ -38,9 +40,7 @@ class HttpxClient(HttpClient):
         # with the per-request ones.
         headers = self._merge_headers(self._headers, headers)
 
-        # httpx.Response satisfies the HttpResponse protocol,
-        # so it can be returned directly.
-        return self._client.request(
+        response = self._client.request(
             method=method,
             url=url,
             headers=headers,
@@ -49,6 +49,16 @@ class HttpxClient(HttpClient):
             json=json,
             timeout=timeout_secs,
         )
+
+        # Raising `ApifyApiError` for error responses is part of the `call`
+        # contract. The resource clients rely on it, e.g. to translate a 404
+        # into a `None` return value of `get` methods.
+        if response.status_code >= HTTPStatus.BAD_REQUEST:
+            raise ApifyApiError(response, attempt=1, method=method)
+
+        # httpx.Response satisfies the HttpResponse protocol,
+        # so it can be returned directly.
+        return response
 
 
 def main() -> None:

--- a/docs/04_upgrading/upgrading_to_v3.mdx
+++ b/docs/04_upgrading/upgrading_to_v3.mdx
@@ -28,7 +28,7 @@ dataset_id = run.default_dataset_id
 
 Two endpoints still return plain types because their payloads are user-defined: <ApiLink to="class/DatasetClient#list_items">`DatasetClient.list_items()`</ApiLink> returns <ApiLink to="class/DatasetItemsPage">`DatasetItemsPage`</ApiLink> (with `items: list[dict[str, Any]]` following the [Actor output schema](https://docs.apify.com/platform/actors/development/actor-definition/output-schema)), and <ApiLink to="class/KeyValueStoreClient#get_record">`KeyValueStoreClient.get_record()`</ApiLink> returns a `dict`.
 
-On the input side, methods now also accept Pydantic models in addition to dicts. Plain dicts continue to work — keys may use either snake_case or camelCase, and each input shape has a matching [`TypedDict`](https://docs.python.org/3/library/typing.html#typing.TypedDict) so editors and type checkers can validate the keys. See [Typed models](/docs/concepts/typed-models) for details.
+On the input side, methods now also accept Pydantic models in addition to dicts. Plain dicts continue to work — keys may use either snake_case or camelCase, and each input shape has a matching [`TypedDict`](https://docs.python.org/3/library/typing.html#typing.TypedDict) so editors and type checkers can validate the keys. See [Typed models](/api/client/python/docs/concepts/typed-models) for details.
 
 ## Tiered timeouts
 
@@ -44,7 +44,7 @@ client.actor('apify/hello-world').get(timeout='long')
 client.actor('apify/hello-world').get(timeout=timedelta(seconds=120))
 ```
 
-If your code relied on the previous global timeout, review the methods you use. See [Timeouts](/docs/concepts/timeouts) for the full reference.
+If your code relied on the previous global timeout, review the methods you use. See [Timeouts](/api/client/python/docs/concepts/timeouts) for the full reference.
 
 ## 404 raises NotFoundError on ambiguous endpoints
 
@@ -69,7 +69,7 @@ Affected paths:
 - Chained `LogClient` reads — `run.log().get()`, `.get_as_bytes()`, `.stream()`.
 - Singleton endpoints fetched via a fixed path — <ApiLink to="class/ScheduleClient#get_log">`ScheduleClient.get_log()`</ApiLink>, <ApiLink to="class/TaskClient#get_input">`TaskClient.get_input()`</ApiLink>, <ApiLink to="class/DatasetClient#get_statistics">`DatasetClient.get_statistics()`</ApiLink>, <ApiLink to="class/UserClient#monthly_usage">`UserClient.monthly_usage()`</ApiLink>, <ApiLink to="class/UserClient#limits">`UserClient.limits()`</ApiLink>, <ApiLink to="class/WebhookClient#test">`WebhookClient.test()`</ApiLink>. Their return types changed from `T | None` to `T`.
 
-Status-specific subclasses such as <ApiLink to="class/RateLimitError">`RateLimitError`</ApiLink> are now available too — see [Error handling](/docs/concepts/error-handling#error-subclasses). Existing `except ApifyApiError` handlers are unaffected.
+Status-specific subclasses such as <ApiLink to="class/RateLimitError">`RateLimitError`</ApiLink> are now available too — see [Error handling](/api/client/python/docs/concepts/error-handling#error-subclasses). Existing `except ApifyApiError` handlers are unaffected.
 
 ## Keyword-only arguments
 
@@ -103,11 +103,11 @@ event_types=[WebhookEventType.ACTOR_RUN_SUCCEEDED]
 event_types=['ACTOR.RUN.SUCCEEDED']
 ```
 
-Affected types: `ActorJobStatus`, `ActorPermissionLevel`, `ErrorType`, `GeneralAccess`, `HttpMethod`, `RunOrigin`, `SourceCodeFileFormat`, `StorageOwnership`, `VersionSourceType`, `WebhookDispatchStatus`, `WebhookEventType`. For more on the generated types and how they fit into the typed client surface, see [Typed models](/docs/concepts/typed-models).
+Affected types: `ActorJobStatus`, `ActorPermissionLevel`, `ErrorType`, `GeneralAccess`, `HttpMethod`, `RunOrigin`, `SourceCodeFileFormat`, `StorageOwnership`, `VersionSourceType`, `WebhookDispatchStatus`, `WebhookEventType`. For more on the generated types and how they fit into the typed client surface, see [Typed models](/api/client/python/docs/concepts/typed-models).
 
 ## Async iterate_* are no longer coroutine functions
 
-<ApiLink to="class/DatasetClientAsync#iterate_items">`DatasetClientAsync.iterate_items()`</ApiLink> and <ApiLink to="class/KeyValueStoreClientAsync#iterate_keys">`KeyValueStoreClientAsync.iterate_keys()`</ApiLink> are now plain `def` functions returning `AsyncIterator[T]`. Consumer code (`async for ...`) is unchanged. If you annotate the call's return value, change `AsyncGenerator[T, None]` to `AsyncIterator[T]`. For background on these helpers and how they fit alongside page models, see [Pagination](/docs/concepts/pagination).
+<ApiLink to="class/DatasetClientAsync#iterate_items">`DatasetClientAsync.iterate_items()`</ApiLink> and <ApiLink to="class/KeyValueStoreClientAsync#iterate_keys">`KeyValueStoreClientAsync.iterate_keys()`</ApiLink> are now plain `def` functions returning `AsyncIterator[T]`. Consumer code (`async for ...`) is unchanged. If you annotate the call's return value, change `AsyncGenerator[T, None]` to `AsyncIterator[T]`. For background on these helpers and how they fit alongside page models, see [Pagination](/api/client/python/docs/concepts/pagination).
 
 ## Removed deprecated APIs
 
@@ -117,4 +117,4 @@ Affected types: `ActorJobStatus`, `ActorPermissionLevel`, `ErrorType`, `GeneralA
 
 ## Pluggable HTTP client
 
-Additive change, non-breaking. The HTTP layer is now abstracted behind the <ApiLink to="class/HttpClient">`HttpClient`</ApiLink> and <ApiLink to="class/HttpClientAsync">`HttpClientAsync`</ApiLink> base classes, so you can swap the underlying transport for your own implementation. The default client built on [Impit](https://github.com/apify/impit) is unchanged and existing code keeps working out of the box. To plug in a custom client, pass an instance to <ApiLink to="class/ApifyClient#with_custom_http_client">`ApifyClient.with_custom_http_client()`</ApiLink> — see [Custom HTTP clients](/docs/concepts/custom-http-clients) for the full walkthrough.
+Additive change, non-breaking. The HTTP layer is now abstracted behind the <ApiLink to="class/HttpClient">`HttpClient`</ApiLink> and <ApiLink to="class/HttpClientAsync">`HttpClientAsync`</ApiLink> base classes, so you can swap the underlying transport for your own implementation. The default client built on [Impit](https://github.com/apify/impit) is unchanged and existing code keeps working out of the box. To plug in a custom client, pass an instance to <ApiLink to="class/ApifyClient#with_custom_http_client">`ApifyClient.with_custom_http_client()`</ApiLink> — see [Custom HTTP clients](/api/client/python/docs/concepts/custom-http-clients) for the full walkthrough.

--- a/src/apify_client/_resource_clients/build.py
+++ b/src/apify_client/_resource_clients/build.py
@@ -110,7 +110,7 @@ class BuildClient(ResourceClient):
 
         Returns:
             The Actor build data. If the status on the object is not one of the terminal statuses (SUCCEEDED, FAILED,
-                TIMED_OUT, ABORTED), then the build has not yet finished.
+                TIMED-OUT, ABORTED), then the build has not yet finished.
         """
         result = self._wait_for_finish(
             url=self._build_url(),
@@ -230,7 +230,7 @@ class BuildClientAsync(ResourceClientAsync):
 
         Returns:
             The Actor build data. If the status on the object is not one of the terminal statuses (SUCCEEDED, FAILED,
-                TIMED_OUT, ABORTED), then the build has not yet finished.
+                TIMED-OUT, ABORTED), then the build has not yet finished.
         """
         result = await self._wait_for_finish(
             url=self._build_url(),

--- a/src/apify_client/_resource_clients/run.py
+++ b/src/apify_client/_resource_clients/run.py
@@ -148,7 +148,7 @@ class RunClient(ResourceClient):
 
         Returns:
             The Actor run data. If the status on the object is not one of the terminal statuses (SUCCEEDED, FAILED,
-                TIMED_OUT, ABORTED), then the run has not yet finished.
+                TIMED-OUT, ABORTED), then the run has not yet finished.
         """
         response = self._wait_for_finish(
             url=self._build_url(),
@@ -218,7 +218,7 @@ class RunClient(ResourceClient):
     ) -> Run:
         """Resurrect a finished Actor run.
 
-        Only finished runs, i.e. runs with status FINISHED, FAILED, ABORTED and TIMED-OUT can be resurrected.
+        Only finished runs, i.e. runs with status SUCCEEDED, FAILED, ABORTED and TIMED-OUT can be resurrected.
         Run status will be updated to RUNNING and its container will be restarted with the same default storages.
 
         https://docs.apify.com/api/v2#/reference/actor-runs/resurrect-run/resurrect-run
@@ -570,7 +570,7 @@ class RunClientAsync(ResourceClientAsync):
 
         Returns:
             The Actor run data. If the status on the object is not one of the terminal statuses (SUCCEEDED, FAILED,
-                TIMED_OUT, ABORTED), then the run has not yet finished.
+                TIMED-OUT, ABORTED), then the run has not yet finished.
         """
         response = await self._wait_for_finish(
             url=self._build_url(),
@@ -649,7 +649,7 @@ class RunClientAsync(ResourceClientAsync):
     ) -> Run:
         """Resurrect a finished Actor run.
 
-        Only finished runs, i.e. runs with status FINISHED, FAILED, ABORTED and TIMED-OUT can be resurrected.
+        Only finished runs, i.e. runs with status SUCCEEDED, FAILED, ABORTED and TIMED-OUT can be resurrected.
         Run status will be updated to RUNNING and its container will be restarted with the same default storages.
 
         https://docs.apify.com/api/v2#/reference/actor-runs/resurrect-run/resurrect-run


### PR DESCRIPTION
Fixes 12 documentation issues found by an engineering audit, where docs, examples, or docstrings contradict what the client actually does:

- The custom HTTP client guide example (`HttpxClient`) now raises `ApifyApiError` for error responses instead of returning them raw, and the guide documents this part of the `call` contract (resource clients rely on it, e.g. to translate a 404 into a `None` return value).
- The streaming concepts page no longer claims all three streaming methods yield a raw `impit.Response` — it now describes the actual yielded value per method (`stream_record` yields a `dict` with the response under `value`, `stream` and `stream_record` may yield `None`).
- The pagination concepts page no longer lists `ListOfRequests` among page models exposing `total`/`offset`/`count`; it now explains its cursor-based pagination via `next_cursor`.
- The logging formatter example no longer references `%(status_code)s` (absent on most records, causing logging errors) and no longer attaches a duplicate handler; the page notes which properties are present on every record.
- The upgrading-to-v3 guide cross-links now include the site baseUrl (`/api/client/python/...`), fixing 6 links that 404ed on the published site.
- The conda instruction for the brotli extra installs `brotli-python` (the Python bindings) instead of `brotli` (the C library).
- `RunClient.resurrect` docstrings cite the real `SUCCEEDED` status instead of the nonexistent `FINISHED`.
- `wait_for_finish` docstrings in `RunClient` and `BuildClient` spell the terminal status as `TIMED-OUT` (the real literal) instead of `TIMED_OUT`.
- The quick-start page refers to the `Run` model's `default_dataset_id` attribute instead of the v2-era run dictionary with `defaultDatasetId`.
- The README dataset example passes `fields` as `list[str]` per the signature instead of a comma-separated string.
- The README quick-start examples handle the `Run | None` return of `call()` instead of accessing attributes on a possible `None`.
- The timeouts concepts page states that `no_timeout` is capped at 24 hours by the default client instead of claiming it disables the timeout entirely.

*✍️ Drafted by Claude Code*