### PR TITLE
docs: Remove conda special instructions for brotli

### DIFF
--- a/docs/01_introduction/index.mdx
+++ b/docs/01_introduction/index.mdx
@@ -56,16 +56,10 @@ For better request-body compression, opt in to `brotli`, which compresses better
     </TabItem>
     <TabItem value="conda-forge" label="conda-forge">
         ```bash
-        conda install conda-forge::apify-client conda-forge::brotli-python
+        conda install conda-forge::apify-client
         ```
     </TabItem>
 </Tabs>
-
-:::note Extras on conda-forge
-
-Conda doesn't support optional extras. On conda-forge, install the `brotli-python` package directly alongside the client. It provides the same `brotli` module as the PyPI extra.
-
-:::
 
 For details, see [HTTP compression](../02_concepts/13_http_compression.mdx).
 

--- a/website/versioned_docs/version-3.1/01_introduction/index.mdx
+++ b/website/versioned_docs/version-3.1/01_introduction/index.mdx
@@ -56,16 +56,10 @@ For better request-body compression, opt in to `brotli`, which compresses better
     </TabItem>
     <TabItem value="conda-forge" label="conda-forge">
         ```bash
-        conda install conda-forge::apify-client conda-forge::brotli-python
+        conda install conda-forge::apify-client
         ```
     </TabItem>
 </Tabs>
-
-:::note Extras on conda-forge
-
-Conda doesn't support optional extras. On conda-forge, install the `brotli-python` package directly alongside the client. It provides the same `brotli` module as the PyPI extra.
-
-:::
 
 For details, see [HTTP compression](../02_concepts/13_http_compression.mdx).
 


### PR DESCRIPTION
It is now included by default: https://github.com/conda-forge/apify-client-feedstock/pull/4/changes