### PR TITLE
fix: Add missing cannot-monetize-without-payout-billing-info error code

### DIFF
--- a/src/apify_client/_literals.py
+++ b/src/apify_client/_literals.py
@@ -95,6 +95,7 @@ ErrorType = (
         'cannot-metamorph-to-pay-per-result-actor',
         'cannot-modify-actor-pricing-too-frequently',
         'cannot-modify-actor-pricing-with-immediate-effect',
+        'cannot-monetize-without-payout-billing-info',
         'cannot-override-paid-actor-trial',
         'cannot-permanently-delete-subscription',
         'cannot-publish-actor',

--- a/src/apify_client/_models.py
+++ b/src/apify_client/_models.py
@@ -3332,7 +3332,7 @@ class TaggedBuildInfo(BaseModel):
         str | None, Field(examples=['0.0.2'], pattern='^([0-9]|[1-9][0-9])\\.([0-9]|[1-9][0-9])(\\.[1-9][0-9]{0,4})$')
     ] = None
     """
-    The build number/version string.
+    The build number/version string. Can be `null` for legacy builds that lack a valid build number.
     """
     build_number_int: Annotated[int | None, Field(examples=[42])] = None
     """


### PR DESCRIPTION
- Updates the auto-generated Pydantic models and TypedDicts based on the proposed OpenAPI specification changes.
- Based on apify-docs PR [#2785](https://github.com/apify/apify-docs/pull/2785).