### PR TITLE
build: replace hatchling with the uv_build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,8 @@ dev = [
     "werkzeug<4.0.0", # Werkzeug is used by pytest-httpserver
 ]
 
-# The module, pyproject.toml, README, and LICENSE are included in the sdist by default.
 [tool.uv.build-backend]
+# The module, pyproject.toml, README, and LICENSE are included in the sdist by default.
 source-include = ["CHANGELOG.md", "CONTRIBUTING.md"]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.12.0,<0.13.0"]
+requires = ["uv_build"]
 build-backend = "uv_build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,20 +1,20 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["uv_build>=0.12.0,<0.13.0"]
+build-backend = "uv_build"
 
 [project]
 name = "apify_client"
 version = "3.1.1"
 description = "Apify API client for Python"
 authors = [{ name = "Apify Technologies s.r.o.", email = "support@apify.com" }]
-license = { file = "LICENSE" }
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.11"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -67,18 +67,9 @@ dev = [
     "werkzeug<4.0.0", # Werkzeug is used by pytest-httpserver
 ]
 
-[tool.hatch.build.targets.wheel]
-packages = ["src/apify_client"]
-
-[tool.hatch.build.targets.sdist]
-only-include = [
-    "src/apify_client",
-    "CHANGELOG.md",
-    "CONTRIBUTING.md",
-    "LICENSE",
-    "README.md",
-    "pyproject.toml",
-]
+# The module, pyproject.toml, README, and LICENSE are included in the sdist by default.
+[tool.uv.build-backend]
+source-include = ["CHANGELOG.md", "CONTRIBUTING.md"]
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
Switches the build backend from `hatchling` to `uv_build`, replacing the `[tool.hatch.build.targets.*]` config with `[tool.uv.build-backend]`. Only `CHANGELOG.md` and `CONTRIBUTING.md` need an explicit `source-include` - the module, `pyproject.toml`, README, and LICENSE are in the sdist by default.

License metadata moves to PEP 639: `license = "Apache-2.0"` plus `license-files = ["LICENSE"]`. That part is required, not cosmetic: `uv_build` ships `LICENSE` inside the wheel only when it is declared via `license-files`, and uv rejects `license-files` combined with the legacy `license = { file = ... }` table.

The `License :: OSI Approved :: Apache Software License` classifier is dropped because [PEP 639 deprecates license classifiers](https://peps.python.org/pep-0639/#deprecate-license-classifiers) in favor of `License-Expression`, which now carries the same information ("Using license classifier in the `Classifier` Core Metadata field is deprecated and replaced by the more precise `License-Expression` field"). See also the [core metadata spec](https://packaging.python.org/en/latest/specifications/core-metadata/#license-expression). uv warns about the classifier on every build.

Verified by building sdist + wheel before and after: the wheel contents are identical, and the metadata differs only in `License-Expression: Apache-2.0` replacing the inlined license text. The sdist drops `.gitignore` and gains `pyproject.toml.orig` (uv 0.12 writes a TOML 1.0-compatible `pyproject.toml` into the sdist and keeps the original alongside it). `uv.lock` is unchanged.

*✍️ Drafted by Claude Code*