### PR TITLE
docs: Enable Ruff formatting of Python code blocks in Markdown

### DIFF
--- a/docs/04_upgrading/upgrading_to_v3.mdx
+++ b/docs/04_upgrading/upgrading_to_v3.mdx
@@ -81,7 +81,9 @@ client.key_value_store('my-store').set_record('my-key', {'data': 1}, 'applicatio
 client.run('my-run').charge('my-event', 5, 'my-idempotency-key')
 
 # After
-client.key_value_store('my-store').set_record('my-key', {'data': 1}, content_type='application/json')
+client.key_value_store('my-store').set_record(
+    'my-key', {'data': 1}, content_type='application/json'
+)
 client.run('my-run').charge('my-event', count=5, idempotency_key='my-idempotency-key')
 ```
 
@@ -97,10 +99,10 @@ Generated enum-like types are now [`Literal`](https://docs.python.org/3/library/
 
 ```python
 # Before
-event_types=[WebhookEventType.ACTOR_RUN_SUCCEEDED]
+event_types = [WebhookEventType.ACTOR_RUN_SUCCEEDED]
 
 # After
-event_types=['ACTOR.RUN.SUCCEEDED']
+event_types = ['ACTOR.RUN.SUCCEEDED']
 ```
 
 Affected types: `ActorJobStatus`, `ActorPermissionLevel`, `ErrorType`, `GeneralAccess`, `HttpMethod`, `RunOrigin`, `SourceCodeFileFormat`, `StorageOwnership`, `VersionSourceType`, `WebhookDispatchStatus`, `WebhookEventType`. For more on the generated types and how they fit into the typed client surface, see [Typed models](/api/client/python/docs/concepts/typed-models).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,11 +83,7 @@ only-include = [
 [tool.ruff]
 line-length = 120
 include = [
-    "src/**/*.py",
-    "tests/**/*.py",
-    "scripts/**/*.py",
-    "docs/**/*.py",
-    "website/**/*.py",
+    "**/*.py",
     # Ruff formats Python code blocks embedded in Markdown files.
     "**/*.md",
     "**/*.mdx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,10 +88,15 @@ include = [
     "scripts/**/*.py",
     "docs/**/*.py",
     "website/**/*.py",
+    # Ruff formats Python code blocks embedded in Markdown files.
+    "**/*.md",
+    "**/*.mdx",
 ]
 exclude = [
     "website/versioned_docs/**",
 ]
+# MDX is Markdown; without this mapping Ruff would try to parse `.mdx` files as Python.
+extension = { mdx = "markdown" }
 
 [tool.ruff.lint]
 select = ["ALL"]


### PR DESCRIPTION
### What & why

Ruff 0.16 formats Python code blocks embedded in Markdown files, and does so by default. In this repo the feature was inert because `[tool.ruff] include` was an allowlist of `*.py` globs, so no Markdown file ever reached the formatter. Adding `**/*.md` and `**/*.mdx` turns it on, which means docs snippets are now held to the same formatting standard as the rest of the codebase instead of drifting by hand.

MDX needs the explicit `extension = { mdx = "markdown" }` mapping - without it Ruff would try to parse `.mdx` as Python and fail. Most of the Python snippets in `docs/` live in `.mdx`, so the mapping is what makes this useful here.

No changes to the `lint` / `format` Poe tasks are needed. `lint` already runs `ruff format --check` and `format` already runs `ruff format`, so both pick Markdown up automatically. Note that `ruff check` (lint rules) does not support Markdown yet, so only formatting is enforced there.

### Notes

- Code blocks under `docs/` are formatted to 90 columns, not 120, because of the existing `docs/pyproject.toml` override that keeps doc snippets free of a horizontal scrollbar. That is why one line in the upgrading guide got wrapped.
- The second commit collapses the `include` allowlist to a single `**/*.py` glob. This is a pure simplification: no tracked `.py` file lives outside the previously listed directories, and Ruff processes exactly the same 189 files before and after.

*✍️ Drafted by Claude Code*
