### PR TITLE
fix: Require value in EnvVarRequest and allow null error messages in request dicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,7 +255,7 @@ keep_model_order = true
 # workflow committing nothing unless the models changed. A local regeneration that only moves this line is that
 # same case - drop it rather than committing it alone.
 [tool.apify.openapi-spec]
-version = "v2-2026-07-28T083939Z"
+version = "v2-2026-08-05T133145Z"
 
 [tool.uv]
 # Minimal defense against supply-chain atatcks.

--- a/src/apify_client/_models.py
+++ b/src/apify_client/_models.py
@@ -1330,6 +1330,10 @@ class EnvVarRequest(EnvVar):
         populate_by_name=True,
         alias_generator=to_camel,
     )
+    value: Annotated[str, Field(examples=['my-value'])]
+    """
+    The value of the environment variable. If `isSecret` is `true`, this value isn't returned by the API.
+    """
 
 
 @docs_group('Models')

--- a/src/apify_client/_typeddicts.py
+++ b/src/apify_client/_typeddicts.py
@@ -39,7 +39,7 @@ class RequestBaseDict(TypedDict):
     """
     Indicates whether the request should not be retried if processing fails.
     """
-    error_messages: NotRequired[list[str]]
+    error_messages: NotRequired[list[str] | None]
     """
     Error messages recorded from failed processing attempts.
     """
@@ -81,7 +81,7 @@ class RequestBaseCamelDict(TypedDict):
     """
     Indicates whether the request should not be retried if processing fails.
     """
-    errorMessages: NotRequired[list[str]]
+    errorMessages: NotRequired[list[str] | None]
     """
     Error messages recorded from failed processing attempts.
     """


### PR DESCRIPTION
- Regenerates the Pydantic models, TypedDicts, and literal aliases from the [published OpenAPI specification](https://docs.apify.com/api/openapi.json), and records its version in `pyproject.toml`.
- Specification version: `v2-2026-07-28T083939Z` -> `v2-2026-08-05T133145Z`.

> [!IMPORTANT]
> Retitle this pull request to `fix:` or `feat:` when the diff is user-facing, so that it lands in the changelog and triggers a release - `chore:` does neither.

> Generated by the [Regenerate models](https://github.com/apify/apify-client-python/actions/workflows/on_schedule_regenerate_models.yaml) workflow.