### PR TITLE
fix: Unify the request pipeline and retry policy across HTTP clients

### DIFF
--- a/.rules.md
+++ b/.rules.md
@@ -60,7 +60,8 @@ Docstrings are written on sync clients and **automatically copied** to async cli
 
 ### HTTP Client Abstraction
 
-- `HttpClient`/`HttpClientAsync` — abstract base classes in `_http_clients/_base.py`
+- `HttpClient`/`HttpClientAsync` — base classes in `http_clients/_base.py` holding the shared request pipeline (retries,
+  timeouts, API errors); transports implement the `send_request`, error-classification, and lifecycle hooks
 - `ImpitHttpClient`/`ImpitHttpClientAsync` — default implementation (Rust-based Impit)
 - `HttpResponse` — Protocol (not a concrete class) for response objects
 - Users can plug in custom HTTP clients via `ApifyClient.with_custom_http_client()`

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ For a guided walkthrough — authenticating, running an Actor, and reading its r
 - **Tiered timeouts** — short / medium / long tiers picked per endpoint, overridable per call ([Timeouts](https://docs.apify.com/api/client/python/docs/concepts/timeouts)).
 - **Pagination and streaming** — iterate datasets, key-value store keys, or live logs without manual paging or buffering ([Pagination](https://docs.apify.com/api/client/python/docs/concepts/pagination), [Streaming](https://docs.apify.com/api/client/python/docs/concepts/streaming-resources)).
 - **Convenience methods** — `call()`, `wait_for_finish()`, nested resource access, and other shortcuts that hide platform quirks ([Convenience methods](https://docs.apify.com/api/client/python/docs/concepts/convenience-methods)).
-- **Pluggable HTTP layer** — swap the default [Impit](https://github.com/apify/impit)-based HTTP client for `httpx`, `requests`, `aiohttp`, or any custom implementation ([Custom HTTP clients](https://docs.apify.com/api/client/python/docs/concepts/custom-http-clients)).
+- **Pluggable HTTP layer** — swap the default [Impit](https://github.com/apify/impit)-based HTTP client for `httpx`, `requests`, `aiohttp`, or any custom implementation ([HTTP clients](https://docs.apify.com/api/client/python/docs/concepts/custom-http-clients)).
 - **Structured errors** — every API error surfaces as an [`ApifyApiError`](https://docs.apify.com/api/client/python/reference/class/ApifyApiError) with HTTP-specific subclasses for precise handling ([Error handling](https://docs.apify.com/api/client/python/docs/concepts/error-handling)).
 - **Debug logging** — opt-in structured logging on the `apify_client` logger captures request URLs, status codes, retry attempts, and more ([Logging](https://docs.apify.com/api/client/python/docs/concepts/logging)).
 
@@ -192,7 +192,7 @@ The full documentation lives at **[docs.apify.com/api/client/python](https://doc
 | [Introduction](https://docs.apify.com/api/client/python/docs) | Overview, prerequisites, and a tour of the client. |
 | [Quick start](https://docs.apify.com/api/client/python/docs/quick-start) | Authenticate, run an Actor, and fetch its results step by step. |
 | [Concepts](https://docs.apify.com/api/client/python/docs/concepts/asyncio-support) | Asyncio, single vs. collection clients, nested clients, error handling, retries, logging, convenience methods, pagination, streaming, custom HTTP clients, timeouts. |
-| [Guides](https://docs.apify.com/api/client/python/docs/guides/passing-input-to-actor) | Pass input to an Actor, manage tasks for reusable input, retrieve Actor data, integrate with data libraries (e.g. Pandas), use HTTPX as the HTTP client. |
+| [Guides](https://docs.apify.com/api/client/python/docs/guides/passing-input-to-actor) | Pass input to an Actor, manage tasks for reusable input, retrieve Actor data, integrate with data libraries (e.g. Pandas), build a custom HTTP client. |
 | [Upgrading](https://docs.apify.com/api/client/python/docs/upgrading/upgrading-to-v3) | Migrating between major versions. |
 | [API reference](https://docs.apify.com/api/client/python/reference) | Generated reference for every class, method, and model. |
 | [Changelog](https://docs.apify.com/api/client/python/docs/changelog) | Release history and breaking changes. |

--- a/docs/02_concepts/10_custom_http_clients.mdx
+++ b/docs/02_concepts/10_custom_http_clients.mdx
@@ -86,7 +86,8 @@ The public `call` method provides the shared request pipeline. A concrete transp
 - `is_retryable_transport_error(exc)` classifies transport failures for the shared retry loop. The default classifies
   nothing as retryable, so a transport that skips it gives up on the first connection failure.
 - `is_timeout_error(exc)` identifies transport-specific timeout exceptions for higher-level client features. The
-  default recognizes Python's `TimeoutError`.
+  default recognizes Python's `TimeoutError`. Timeout classification is independent of retryability, so a timeout
+  the retry loop should retry has to be listed in `is_retryable_transport_error` too.
 - `close()` or `aclose()` closes resources owned by the transport. The default does nothing, which is correct for a
   transport that owns no pool or session.
 

--- a/docs/02_concepts/10_custom_http_clients.mdx
+++ b/docs/02_concepts/10_custom_http_clients.mdx
@@ -1,7 +1,7 @@
 ---
 id: custom-http-clients
-title: Custom HTTP clients
-description: Replace the default HTTP client with a custom implementation.
+title: HTTP clients
+description: Understand the built-in HTTP clients and the custom client interface.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -17,7 +17,8 @@ import ArchitectureImportsExample from '!!raw-loader!./code/10_architecture_impo
 import PluggingInAsyncExample from '!!raw-loader!./code/10_plugging_in_async.py';
 import PluggingInSyncExample from '!!raw-loader!./code/10_plugging_in_sync.py';
 
-The Apify API client uses a pluggable HTTP client architecture. By default, it ships with an [Impit](https://github.com/apify/impit)-based HTTP client that handles retries, timeouts, passing headers, and more. You can replace it with your own implementation for use cases like custom logging, proxying, request modification, or integrating with a different HTTP library.
+The Apify API client uses a pluggable HTTP layer. It ships with an [Impit](https://github.com/apify/impit)-based default
+and accepts fully custom synchronous or asynchronous implementations.
 
 ## Default HTTP client
 
@@ -25,8 +26,8 @@ When you create an <ApiLink to="class/ApifyClient">`ApifyClient`</ApiLink> or <A
 
 - Automatic retries with exponential backoff for network errors, HTTP 429, and HTTP 5xx responses.
 - Configurable timeouts.
-- Preparing request data and headers according to the API requirements, including authentication.
-- Collecting requests statistics for monitoring and debugging.
+- Request compression and preparation of API-compatible data, query parameters, and headers, including authentication.
+- API error handling, structured logging, and request statistics.
 
 You can configure the default client through the <ApiLink to="class/ApifyClient">`ApifyClient`</ApiLink> or <ApiLink to="class/ApifyClientAsync">`ApifyClientAsync`</ApiLink> constructor:
 
@@ -45,33 +46,52 @@ You can configure the default client through the <ApiLink to="class/ApifyClient"
 
 ## Architecture
 
-The HTTP client system is built on two key abstractions:
+Internally, the HTTP client hierarchy has three layers:
 
-- <ApiLink to="class/HttpClient">`HttpClient`</ApiLink> / <ApiLink to="class/HttpClientAsync">`HttpClientAsync`</ApiLink> - Abstract base classes that define the interface. Extend one of these to create a custom HTTP client by implementing the `call` method.
+- A common internal base contains configuration and utilities shared by synchronous and asynchronous clients, including
+  headers, request-body preparation, parameters, compression, and timeout tiers. It is not a public extension point.
+- <ApiLink to="class/HttpClient">`HttpClient`</ApiLink> and <ApiLink to="class/HttpClientAsync">`HttpClientAsync`</ApiLink>
+  add the synchronous or asynchronous request pipeline, retry loop, transport hooks, and lifecycle interface.
+- The built-in Impit classes inherit directly from the corresponding sync or async class and adapt the underlying
+  transport.
+
+`HttpClient.is_timeout_error(exc)` and `HttpClientAsync.is_timeout_error(exc)` provide the public, transport-neutral way
+to determine whether an exception is a timeout. Their shared implementation recognizes Python's `TimeoutError`;
+transport adapters override it when their HTTP library defines additional timeout exception types. This lets
+higher-level features such as streamed logs classify timeouts without depending on Impit or private implementation
+details.
+
+Responses use one separate abstraction:
+
 - <ApiLink to="class/HttpResponse">`HttpResponse`</ApiLink> - A [runtime-checkable protocol](https://docs.python.org/3/library/typing.html#typing.runtime_checkable) that defines the expected response shape. Any object with the required attributes and methods satisfies the protocol — no inheritance needed.
 
 To plug in your custom implementation, use the <ApiLink to="class/ApifyClient#with_custom_http_client">`ApifyClient.with_custom_http_client`</ApiLink> class method.
 
-All of these are available as top-level imports from the `apify_client` package:
+The built-in Impit classes are thin transport adapters over the request implementation in `HttpClient` and
+`HttpClientAsync`. Custom transport adapters implement the request, error-classification, and lifecycle hooks. They
+inherit request construction, retries, timeout growth, API error conversion, logging, and statistics from the base.
+
+All of these are available from the `apify_client.http_clients` module:
 
 <CodeBlock className="language-python">
     {ArchitectureImportsExample}
 </CodeBlock>
 
-### The call method
+### The transport contract
 
-The `call` method receives all the information needed to make an HTTP request:
+The public `call` method provides the shared request pipeline. A concrete transport implements these hooks:
 
-- `method` - HTTP method (`GET`, `POST`, `PUT`, `DELETE`, etc.).
-- `url` - Full URL to make the request to.
-- `headers` - Additional headers to include.
-- `params` - Query parameters to append to the URL.
-- `data` - Raw request body (mutually exclusive with `json`).
-- `json` - JSON-serializable request body (mutually exclusive with `data`).
-- `stream` - Whether to stream the response body.
-- `timeout` - Timeout for the request as a `timedelta`.
+- `send_request(...)` sends one prepared request and returns an `HttpResponse`. The inherited `call` needs it, so
+  every transport adapter has to implement it.
+- `is_retryable_transport_error(exc)` classifies transport failures for the shared retry loop. The default classifies
+  nothing as retryable, so a transport that skips it gives up on the first connection failure.
+- `is_timeout_error(exc)` identifies transport-specific timeout exceptions for higher-level client features. The
+  default recognizes Python's `TimeoutError`.
+- `close()` or `aclose()` closes resources owned by the transport. The default does nothing, which is correct for a
+  transport that owns no pool or session.
 
-It must return an object satisfying the <ApiLink to="class/HttpResponse">`HttpResponse`</ApiLink> protocol.
+The `@override` decorators in the built-in Impit adapters make these implementations explicit and allow type checkers
+to catch misspelled or incompatible overrides.
 
 ### The HTTP response protocol
 
@@ -93,6 +113,10 @@ It must return an object satisfying the <ApiLink to="class/HttpResponse">`HttpRe
 
 :::note
 Many HTTP libraries, including our default [Impit](https://github.com/apify/impit) or for example [HTTPX](https://www.python-httpx.org/) already satisfy this protocol out of the box.
+
+For a streamed response, consume the body inside its context manager with `iter_bytes()` / `aiter_bytes()`, or call
+`read()` / `aread()` before accessing `content`. Some transports, including HTTPX, intentionally reject `content` on
+an unread streamed response.
 :::
 
 ### Plugging it in
@@ -115,18 +139,23 @@ Use the <ApiLink to="class/ApifyClient#with_custom_http_client">`ApifyClient.wit
 After that, all API calls made through the client will go through your custom HTTP client.
 
 :::warning
-When using a custom HTTP client, you are responsible for constructing the request, handling retries, timeouts, and errors yourself. The default retry logic is not applied.
+If you override `call` itself, your implementation becomes responsible for request preparation, retries, timeouts, API
+error conversion, logging, and statistics. Implementing the transport hooks and inheriting `call` keeps the shared
+behavior.
 :::
 
 ## Use cases
 
-Custom HTTP clients might be useful when you need to:
+Custom HTTP clients might be useful when the built-in Impit clients don't cover your requirements, for example when
+you need to:
 
-- **Use a different HTTP library** - Swap Impit for [httpx](https://www.python-httpx.org/), [requests](https://requests.readthedocs.io/), or [aiohttp](https://docs.aiohttp.org/).
+- **Use a different HTTP library** - Integrate [httpx](https://www.python-httpx.org/), [requests](https://requests.readthedocs.io/), [aiohttp](https://docs.aiohttp.org/), or another transport.
 - **Route through a proxy** - Add proxy support or request routing.
 - **Implement custom retry logic** - Use different backoff strategies or retry conditions.
 - **Log requests and responses** - Track API calls for debugging or auditing.
 - **Modify requests** - Add custom fields, modify the body, or change headers.
 - **Collect custom metrics** - Measure request latency, track error rates, or count API calls.
 
-For a step-by-step walkthrough of building a custom HTTP client, see the [Using HTTPX as the HTTP client](/api/client/python/docs/guides/custom-http-client-httpx) guide.
+For complete synchronous and asynchronous implementations over a transport with a different response API, see
+[Build a custom HTTP client](../03_guides/05_custom_http_client.mdx). You can also refer to the
+<ApiLink to="class/HttpClient">`HttpClient` API reference</ApiLink> for the synchronous contract.

--- a/docs/02_concepts/code/10_plugging_in_async.py
+++ b/docs/02_concepts/code/10_plugging_in_async.py
@@ -1,8 +1,7 @@
-from typing import Any
+from typing_extensions import override
 
 from apify_client import ApifyClientAsync
 from apify_client.http_clients import HttpClientAsync, HttpResponse
-from apify_client.types import Timeout
 
 TOKEN = 'MY-APIFY-TOKEN'
 
@@ -10,18 +9,26 @@ TOKEN = 'MY-APIFY-TOKEN'
 class MyHttpClientAsync(HttpClientAsync):
     """Custom async HTTP client."""
 
-    async def call(
+    @override
+    async def send_request(
         self,
         *,
         method: str,
         url: str,
-        headers: dict[str, str] | None = None,
-        params: dict[str, Any] | None = None,
-        data: str | bytes | bytearray | None = None,
-        json: Any = None,
-        stream: bool | None = None,
-        timeout: Timeout = 'medium',
-    ) -> HttpResponse: ...
+        headers: dict[str, str],
+        content: bytes | None,
+        timeout: float | None,
+        stream: bool,
+    ) -> HttpResponse:
+        """Send one request through the custom transport."""
+        raise NotImplementedError
+
+    @override
+    def is_retryable_transport_error(self, exc: Exception) -> bool:
+        # List the transport's transient failures here, e.g. its timeout
+        # and connection errors. Returning False for everything opts out
+        # of transport retries entirely.
+        return isinstance(exc, TimeoutError)
 
 
 async def main() -> None:

--- a/docs/02_concepts/code/10_plugging_in_sync.py
+++ b/docs/02_concepts/code/10_plugging_in_sync.py
@@ -1,8 +1,7 @@
-from typing import Any
+from typing_extensions import override
 
 from apify_client import ApifyClient
 from apify_client.http_clients import HttpClient, HttpResponse
-from apify_client.types import Timeout
 
 TOKEN = 'MY-APIFY-TOKEN'
 
@@ -10,18 +9,26 @@ TOKEN = 'MY-APIFY-TOKEN'
 class MyHttpClient(HttpClient):
     """Custom sync HTTP client."""
 
-    def call(
+    @override
+    def send_request(
         self,
         *,
         method: str,
         url: str,
-        headers: dict[str, str] | None = None,
-        params: dict[str, Any] | None = None,
-        data: str | bytes | bytearray | None = None,
-        json: Any = None,
-        stream: bool | None = None,
-        timeout: Timeout = 'medium',
-    ) -> HttpResponse: ...
+        headers: dict[str, str],
+        content: bytes | None,
+        timeout: float | None,
+        stream: bool,
+    ) -> HttpResponse:
+        """Send one request through the custom transport."""
+        raise NotImplementedError
+
+    @override
+    def is_retryable_transport_error(self, exc: Exception) -> bool:
+        # List the transport's transient failures here, e.g. its timeout
+        # and connection errors. Returning False for everything opts out
+        # of transport retries entirely.
+        return isinstance(exc, TimeoutError)
 
 
 def main() -> None:

--- a/docs/03_guides/05_custom_http_client.mdx
+++ b/docs/03_guides/05_custom_http_client.mdx
@@ -1,39 +1,46 @@
 ---
-id: custom-http-client-httpx
-title: Use HTTPX as the HTTP client
-description: Replace the default Impit HTTP client with one based on HTTPX.
+id: custom-http-client
+title: Build a custom HTTP client
+description: Implement the HTTP client contract with AIOHTTP and requests.
 ---
 
 import ApiLink from '@theme/ApiLink';
+import CodeBlock from '@theme/CodeBlock';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
 
 import CustomHttpClientAsyncExample from '!!raw-loader!./code/05_custom_http_client_async.py';
 import CustomHttpClientSyncExample from '!!raw-loader!./code/05_custom_http_client_sync.py';
 
-This guide shows how to replace the default <ApiLink to="class/ImpitHttpClient">`ImpitHttpClient`</ApiLink> and <ApiLink to="class/ImpitHttpClientAsync">`ImpitHttpClientAsync`</ApiLink> with one based on [HTTPX](https://www.python-httpx.org/). The same approach works for any HTTP library — see [Custom HTTP clients](/api/client/python/docs/concepts/custom-http-clients) for the underlying architecture.
+This guide implements a custom <ApiLink to="class/HttpClientAsync">`HttpClientAsync`</ApiLink> with
+[AIOHTTP](https://docs.aiohttp.org/) and a custom <ApiLink to="class/HttpClient">`HttpClient`</ApiLink> with
+[requests](https://requests.readthedocs.io/). Neither library satisfies the
+<ApiLink to="class/HttpResponse">`HttpResponse`</ApiLink> protocol, so both examples also show how to adapt a
+foreign response API.
 
-## Why HTTPX?
+For an overview of the architecture and the built-in Impit implementation, see
+[HTTP clients](../02_concepts/10_custom_http_clients.mdx).
 
-You might want to use [HTTPX](https://www.python-httpx.org/) instead of the default [Impit](https://github.com/apify/impit)-based client for reasons like:
+## Installation
 
-- You already use HTTPX in your project and want a single HTTP stack.
-- You need HTTPX-specific features.
-- You want fine-grained control over connection pooling or proxy routing.
+Install the transport alongside the Apify client. Neither AIOHTTP nor requests is an `apify-client` extra:
+
+```bash
+pip install apify-client aiohttp   # for the asynchronous client
+pip install apify-client requests  # for the synchronous client
+```
 
 ## Implementation
 
-The implementation involves two steps:
+Each example has three parts:
 
-1. **Extend <ApiLink to="class/HttpClient">`HttpClient`</ApiLink> (sync) or <ApiLink to="class/HttpClientAsync">`HttpClientAsync`</ApiLink> (async)** and implement the `call` method that delegates to HTTPX.
-2. **Pass it to <ApiLink to="class/ApifyClient#with_custom_http_client">`ApifyClient.with_custom_http_client`</ApiLink>** to create a client that uses your implementation.
-
-The `call` method receives parameters like `method`, `url`, `headers`, `params`, `data`, `json`, `stream`, and `timeout`. Map them to the corresponding HTTPX arguments — most map directly, except `data` which becomes HTTPX's `content` parameter and `timeout` which needs conversion from `timedelta` to seconds.
-
-A convenient property of HTTPX is that its `httpx.Response` object already satisfies the <ApiLink to="class/HttpResponse">`HttpResponse`</ApiLink> protocol, so you can return it directly without wrapping.
-
-One part of the contract isn't visible in the method signature: `call` must raise <ApiLink to="class/ApifyApiError">`ApifyApiError`</ApiLink> for error responses instead of returning them. The resource clients rely on that error to work correctly. For example, `get` methods translate a 404 raised this way into a `None` return value, and user code handling `ApifyApiError` keeps working.
+1. The response adapter, `AiohttpResponse` or `RequestsResponse`, maps the library's own response onto the
+   <ApiLink to="class/HttpResponse">`HttpResponse`</ApiLink> protocol that resource clients expect.
+2. The client, `AiohttpHttpClient` or `RequestsHttpClient`, implements the transport, error-classification,
+   timeout-classification, and lifecycle hooks. It inherits request preparation, retry handling, timeout growth,
+   and API error conversion from its base class.
+3. `with_custom_http_client()` connects the implementation to the resource clients and applies the API token. The
+   context manager closes the session at shutdown.
 
 <Tabs>
     <TabItem value="AsyncExample" label="Async client" default>
@@ -49,16 +56,8 @@ One part of the contract isn't visible in the method signature: `call` must rais
 </Tabs>
 
 :::warning
-When using a custom HTTP client, you are responsible for handling retries, timeouts, and error handling yourself. The built-in retry logic with exponential backoff is part of the default <ApiLink to="class/ImpitHttpClient">`ImpitHttpClient`</ApiLink> and is not applied to custom implementations.
+These are compact integration examples, not a replacement for all built-in client behavior. A production custom
+client should account for transport-specific details such as proxy configuration, TLS settings, redirects, and
+response resource cleanup. The shared base provides retries, logging, statistics, timeout growth, and API error
+conversion.
 :::
-
-## Going further
-
-The example above is minimal on purpose. In a production setup, you might want to extend it with:
-
-- **Retry logic** - Use [HTTPX's event hooks](https://www.python-httpx.org/advanced/event-hooks/) or utilize library like [tenacity](https://tenacity.readthedocs.io/) to retry failed requests.
-- **Custom headers** - You can add headers in the `call` method before delegating to HTTPX.
-- **Connection lifecycle** - Close the underlying `httpx.Client` when done by adding a `close()` method to your custom client.
-- **Proxy support** - You can pass `proxy=...` when creating the `httpx.Client`.
-- **Metrics collection** - Track request latency, error rates, or other metrics by adding instrumentation in the `call` method.
-- **Logging** - Log requests and responses for debugging or auditing purposes.

--- a/docs/03_guides/code/05_custom_http_client_async.py
+++ b/docs/03_guides/code/05_custom_http_client_async.py
@@ -1,75 +1,138 @@
 from __future__ import annotations
 
 import asyncio
-from http import HTTPStatus
+import json as jsonlib
 from typing import TYPE_CHECKING, Any
 
-import httpx
+import aiohttp
+from typing_extensions import override
 
 from apify_client import ApifyClientAsync
-from apify_client.errors import ApifyApiError
 from apify_client.http_clients import HttpClientAsync, HttpResponse
 
 if TYPE_CHECKING:
-    from apify_client.types import Timeout
+    from collections.abc import AsyncIterator, Iterator, Mapping
 
 TOKEN = 'MY-APIFY-TOKEN'
 
 
-class HttpxClientAsync(HttpClientAsync):
-    """Custom async HTTP client using HTTPX library."""
+class AiohttpResponse:
+    """Adapt an aiohttp response to the Apify client's HttpResponse protocol."""
 
+    def __init__(self, response: aiohttp.ClientResponse) -> None:
+        self._response = response
+        self._body: bytes | None = None
+
+    @property
+    def status_code(self) -> int:
+        return self._response.status
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        return self._response.headers
+
+    @property
+    def content(self) -> bytes:
+        if self._body is None:
+            raise RuntimeError(
+                'The streamed response has not been read yet; '
+                'use aread() or aiter_bytes()'
+            )
+        return self._body
+
+    @property
+    def text(self) -> str:
+        encoding = self._response.charset or 'utf-8'
+        return self.content.decode(encoding, errors='replace')
+
+    def json(self) -> Any:
+        return jsonlib.loads(self.text)
+
+    def read(self) -> bytes:
+        return self.content
+
+    async def aread(self) -> bytes:
+        if self._body is None:
+            self._body = await self._response.read()
+        return self._body
+
+    def close(self) -> None:
+        self._response.close()
+
+    async def aclose(self) -> None:
+        self._response.release()
+        await self._response.wait_for_close()
+
+    def iter_bytes(self) -> Iterator[bytes]:
+        body = self.content
+        if body:
+            yield body
+
+    async def aiter_bytes(self) -> AsyncIterator[bytes]:
+        if self._body is not None:
+            if self._body:
+                yield self._body
+            return
+        async for chunk in self._response.content.iter_chunked(64 * 1024):
+            yield chunk
+
+
+class AiohttpHttpClient(HttpClientAsync):
+    """Minimal custom asynchronous HTTP client backed by aiohttp."""
+
+    @override
     def __init__(self) -> None:
         super().__init__()
-        self._client = httpx.AsyncClient()
+        self._session = aiohttp.ClientSession()
 
-    async def call(
+    @override
+    def is_timeout_error(self, exc: Exception) -> bool:
+        return super().is_timeout_error(exc) or isinstance(
+            exc, aiohttp.ServerTimeoutError
+        )
+
+    @override
+    async def aclose(self) -> None:
+        await self._session.close()
+
+    @override
+    async def send_request(
         self,
         *,
         method: str,
         url: str,
-        headers: dict[str, str] | None = None,
-        params: dict[str, Any] | None = None,
-        data: str | bytes | bytearray | None = None,
-        json: Any = None,
-        stream: bool | None = None,
-        timeout: Timeout = 'medium',
+        headers: dict[str, str],
+        content: bytes | None,
+        timeout: float | None,
+        stream: bool,
     ) -> HttpResponse:
-        timeout_secs = self._compute_timeout(timeout, attempt=1) or 0
-
-        # Merge the client's default headers (including authorization)
-        # with the per-request ones.
-        headers = self._merge_headers(self._headers, headers)
-
-        response = await self._client.request(
+        response = await self._session.request(
             method=method,
             url=url,
             headers=headers,
-            params=params,
-            content=data,
-            json=json,
-            timeout=timeout_secs,
+            data=content,
+            timeout=aiohttp.ClientTimeout(total=timeout),
         )
+        adapted_response = AiohttpResponse(response)
 
-        # Raising `ApifyApiError` for error responses is part of the `call`
-        # contract. The resource clients rely on it, e.g. to translate a 404
-        # into a `None` return value of `get` methods.
-        if response.status_code >= HTTPStatus.BAD_REQUEST:
-            raise ApifyApiError(response, attempt=1, method=method)
+        if not stream:
+            await adapted_response.aread()
 
-        # httpx.Response satisfies the HttpResponse protocol,
-        # so it can be returned directly.
-        return response
+        return adapted_response
+
+    @override
+    def is_retryable_transport_error(self, exc: Exception) -> bool:
+        return isinstance(exc, (TimeoutError, aiohttp.ClientError))
 
 
 async def main() -> None:
-    client = ApifyClientAsync.with_custom_http_client(
-        token=TOKEN,
-        http_client=HttpxClientAsync(),
-    )
-
-    actor = await client.actor('apify/hello-world').get()
-    print(actor)
+    async with AiohttpHttpClient() as http_client:
+        client = ApifyClientAsync.with_custom_http_client(
+            token=TOKEN,
+            http_client=http_client,
+        )
+        actor = await client.actor('apify/hello-world').get()
+        print(actor)
 
 
 if __name__ == '__main__':

--- a/docs/03_guides/code/05_custom_http_client_async.py
+++ b/docs/03_guides/code/05_custom_http_client_async.py
@@ -80,7 +80,6 @@ class AiohttpResponse:
 class AiohttpHttpClient(HttpClientAsync):
     """Minimal custom asynchronous HTTP client backed by aiohttp."""
 
-    @override
     def __init__(self) -> None:
         super().__init__()
         self._session = aiohttp.ClientSession()

--- a/docs/03_guides/code/05_custom_http_client_sync.py
+++ b/docs/03_guides/code/05_custom_http_client_sync.py
@@ -75,7 +75,6 @@ class RequestsResponse:
 class RequestsHttpClient(HttpClient):
     """Minimal custom synchronous HTTP client backed by requests."""
 
-    @override
     def __init__(self) -> None:
         super().__init__()
         self._session = requests.Session()

--- a/docs/03_guides/code/05_custom_http_client_sync.py
+++ b/docs/03_guides/code/05_custom_http_client_sync.py
@@ -1,74 +1,139 @@
 from __future__ import annotations
 
-from http import HTTPStatus
+import json as jsonlib
 from typing import TYPE_CHECKING, Any
 
-import httpx
+import requests
+from typing_extensions import override
 
 from apify_client import ApifyClient
-from apify_client.errors import ApifyApiError
 from apify_client.http_clients import HttpClient, HttpResponse
 
 if TYPE_CHECKING:
-    from apify_client.types import Timeout
+    from collections.abc import AsyncIterator, Iterator, Mapping
 
 TOKEN = 'MY-APIFY-TOKEN'
 
 
-class HttpxClient(HttpClient):
-    """Custom HTTP client using HTTPX library."""
+class RequestsResponse:
+    """Adapt a requests response to the Apify client's HttpResponse protocol."""
 
+    def __init__(self, response: requests.Response) -> None:
+        self._response = response
+        self._body: bytes | None = None
+
+    @property
+    def status_code(self) -> int:
+        return self._response.status_code
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        return self._response.headers
+
+    @property
+    def content(self) -> bytes:
+        if self._body is None:
+            raise RuntimeError(
+                'The streamed response has not been read yet; use read() or iter_bytes()'
+            )
+        return self._body
+
+    @property
+    def text(self) -> str:
+        encoding = self._response.encoding or 'utf-8'
+        return self.content.decode(encoding, errors='replace')
+
+    def json(self) -> Any:
+        return jsonlib.loads(self.text)
+
+    def read(self) -> bytes:
+        if self._body is None:
+            self._body = self._response.content
+        return self._body
+
+    async def aread(self) -> bytes:
+        return self.read()
+
+    def close(self) -> None:
+        self._response.close()
+
+    async def aclose(self) -> None:
+        self.close()
+
+    def iter_bytes(self) -> Iterator[bytes]:
+        if self._body is not None:
+            if self._body:
+                yield self._body
+            return
+        yield from self._response.iter_content(64 * 1024)
+
+    async def aiter_bytes(self) -> AsyncIterator[bytes]:
+        for chunk in self.iter_bytes():
+            yield chunk
+
+
+class RequestsHttpClient(HttpClient):
+    """Minimal custom synchronous HTTP client backed by requests."""
+
+    @override
     def __init__(self) -> None:
         super().__init__()
-        self._client = httpx.Client()
+        self._session = requests.Session()
 
-    def call(
+    @override
+    def is_timeout_error(self, exc: Exception) -> bool:
+        return super().is_timeout_error(exc) or isinstance(exc, requests.Timeout)
+
+    @override
+    def close(self) -> None:
+        self._session.close()
+
+    @override
+    def send_request(
         self,
         *,
         method: str,
         url: str,
-        headers: dict[str, str] | None = None,
-        params: dict[str, Any] | None = None,
-        data: str | bytes | bytearray | None = None,
-        json: Any = None,
-        stream: bool | None = None,
-        timeout: Timeout = 'medium',
+        headers: dict[str, str],
+        content: bytes | None,
+        timeout: float | None,
+        stream: bool,
     ) -> HttpResponse:
-        timeout_secs = self._compute_timeout(timeout, attempt=1) or 0
-
-        # Merge the client's default headers (including authorization)
-        # with the per-request ones.
-        headers = self._merge_headers(self._headers, headers)
-
-        response = self._client.request(
+        response = self._session.request(
             method=method,
             url=url,
             headers=headers,
-            params=params,
-            content=data,
-            json=json,
-            timeout=timeout_secs,
+            data=content,
+            timeout=timeout,
+            stream=stream,
         )
+        adapted_response = RequestsResponse(response)
 
-        # Raising `ApifyApiError` for error responses is part of the `call`
-        # contract. The resource clients rely on it, e.g. to translate a 404
-        # into a `None` return value of `get` methods.
-        if response.status_code >= HTTPStatus.BAD_REQUEST:
-            raise ApifyApiError(response, attempt=1, method=method)
+        if not stream:
+            adapted_response.read()
 
-        # httpx.Response satisfies the HttpResponse protocol,
-        # so it can be returned directly.
-        return response
+        return adapted_response
+
+    @override
+    def is_retryable_transport_error(self, exc: Exception) -> bool:
+        return isinstance(
+            exc,
+            (
+                requests.ConnectionError,
+                requests.Timeout,
+                requests.exceptions.ChunkedEncodingError,
+            ),
+        )
 
 
 def main() -> None:
-    client = ApifyClient.with_custom_http_client(
-        token=TOKEN,
-        http_client=HttpxClient(),
-    )
-
-    actor = client.actor('apify/hello-world').get()
-    print(actor)
+    with RequestsHttpClient() as http_client:
+        client = ApifyClient.with_custom_http_client(
+            token=TOKEN,
+            http_client=http_client,
+        )
+        actor = client.actor('apify/hello-world').get()
+        print(actor)
 
 
 if __name__ == '__main__':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ dependencies = [
     "impit~=0.13.0",
     "more_itertools>=10.0.0",
     "pydantic[email]>=2.11.0",
+    # 4.6.0 is the first release whose runtime protocol checks look attributes up statically.
+    "typing-extensions>=4.6.0",
 ]
 
 [project.optional-dependencies]
@@ -206,12 +208,7 @@ include = ["docs/**/*.py", "website/**/*.py"]
 unresolved-import = "ignore"
 
 [[tool.ty.overrides]]
-include = ["docs/**/10_plugging_in_async.py", "docs/**/10_plugging_in_sync.py"]
-[tool.ty.overrides.rules]
-empty-body = "ignore"
-
-[[tool.ty.overrides]]
-include = ["docs/**/05_custom_http_client_async.py", "docs/**/05_custom_http_client_sync.py"]
+include = ["docs/**/05_custom_http_client_async.py"]
 [tool.ty.overrides.rules]
 invalid-argument-type = "ignore"
 

--- a/src/apify_client/_apify_client.py
+++ b/src/apify_client/_apify_client.py
@@ -595,7 +595,7 @@ class ApifyClientAsync:
 
         client = ApifyClientAsync.with_custom_http_client(
             token='MY-APIFY-TOKEN',
-            http_client=MyHttpClient(),
+            http_client=MyHttpClientAsync(),
         )
         ```
 

--- a/src/apify_client/_apify_client.py
+++ b/src/apify_client/_apify_client.py
@@ -226,18 +226,14 @@ class ApifyClient:
         """Create an `ApifyClient` instance with a custom HTTP client.
 
         Use this alternative constructor when you want to provide your own HTTP client implementation
-        instead of the default one. The custom client is responsible for its own configuration
-        (retries, timeouts, etc.); only the token is applied to it, as described below.
+        instead of the default one. The custom client controls its transport configuration; the shared
+        `HttpClient` pipeline handles request preparation, retries, timeouts, and API errors unless overridden.
 
         ### Usage
 
         ```python
         from apify_client import ApifyClient
-        from apify_client.http_clients import HttpClient, HttpResponse
-
-        class MyHttpClient(HttpClient):
-            def call(self, *, method, url, **kwargs) -> HttpResponse:
-                ...
+        from my_http_client import MyHttpClient
 
         client = ApifyClient.with_custom_http_client(
             token='MY-APIFY-TOKEN',
@@ -588,18 +584,14 @@ class ApifyClientAsync:
         """Create an `ApifyClientAsync` instance with a custom HTTP client.
 
         Use this alternative constructor when you want to provide your own HTTP client implementation
-        instead of the default one. The custom client is responsible for its own configuration
-        (retries, timeouts, etc.); only the token is applied to it, as described below.
+        instead of the default one. The custom client controls its transport configuration; the shared
+        `HttpClientAsync` pipeline handles request preparation, retries, timeouts, and API errors unless overridden.
 
         ### Usage
 
         ```python
         from apify_client import ApifyClientAsync
-        from apify_client.http_clients import HttpClientAsync, HttpResponse
-
-        class MyHttpClient(HttpClientAsync):
-            async def call(self, *, method, url, **kwargs) -> HttpResponse:
-                ...
+        from my_http_client import MyHttpClientAsync
 
         client = ApifyClientAsync.with_custom_http_client(
             token='MY-APIFY-TOKEN',

--- a/src/apify_client/_streamed_log.py
+++ b/src/apify_client/_streamed_log.py
@@ -161,7 +161,7 @@ class StreamedLog(StreamedLogBase):
                     self._log_buffer_content(include_last_part=True)
         except Exception as exc:
             if self._log_client._http_client.is_timeout_error(exc):  # noqa: SLF001
-                # The stream cannot continue, so warn and let the thread end instead of leaking a traceback (#1040).
+                # The stream cannot continue, so warn and let the thread end instead of leaking a traceback.
                 self._to_logger.warning('Log streaming stopped: the log stream request timed out.')
             else:
                 # Any other failure in log redirection must not escape the background thread; log it instead.

--- a/src/apify_client/_streamed_log.py
+++ b/src/apify_client/_streamed_log.py
@@ -9,8 +9,6 @@ from datetime import UTC, datetime
 from threading import Thread
 from typing import TYPE_CHECKING, ClassVar, Self, cast
 
-import impit
-
 from apify_client._docs import docs_group
 
 if TYPE_CHECKING:
@@ -29,9 +27,8 @@ class StreamedLogBase:
     _stream_timeout: ClassVar[Timeout] = 'no_timeout'
     """Timeout for the log-stream long-poll request, which stays open for the whole Actor run.
 
-    impit applies its `timeout` to the whole request including the streamed body, so any bounded value truncates a
-    longer run mid-stream and raises `impit.TimeoutException` (#1040). `no_timeout` maps to impit's ~24h cap, which
-    is effectively unbounded for real runs and mirrors the JS client.
+    A bounded transport timeout can truncate a longer run mid-stream. `no_timeout` keeps the connection open for the
+    duration of the run (Impit currently maps it to an effective 24-hour cap) and mirrors the JS client.
     """
 
     def __init__(self, to_logger: logging.Logger, *, from_start: bool = True) -> None:
@@ -162,13 +159,13 @@ class StreamedLog(StreamedLogBase):
                 finally:
                     # Flush the last buffered part even if the read timed out or was stopped.
                     self._log_buffer_content(include_last_part=True)
-        except impit.TimeoutException:
-            # With `no_timeout` this fires only if the run outlives impit's ~24h cap or the connection stalls.
-            # The stream cannot continue, so warn and let the thread end instead of leaking a traceback (#1040).
-            self._to_logger.warning('Log streaming stopped: the log stream request timed out.')
-        except Exception:
-            # Any other failure in log redirection must not escape the background thread; log it instead.
-            self._to_logger.exception('Log redirection stopped due to unexpected error:')
+        except Exception as exc:
+            if self._log_client._http_client.is_timeout_error(exc):  # noqa: SLF001
+                # The stream cannot continue, so warn and let the thread end instead of leaking a traceback (#1040).
+                self._to_logger.warning('Log streaming stopped: the log stream request timed out.')
+            else:
+                # Any other failure in log redirection must not escape the background thread; log it instead.
+                self._to_logger.exception('Log redirection stopped due to unexpected error:')
 
 
 @docs_group('Other')
@@ -241,10 +238,10 @@ class StreamedLogAsync(StreamedLogBase):
                 finally:
                     # Flush the last buffered part even if the task is cancelled by `stop()`.
                     self._log_buffer_content(include_last_part=True)
-        except impit.TimeoutException:
-            # As in `StreamedLog._stream_log`, impit's whole-request timeout on the long-lived stream is an
-            # expected terminal condition, not an error, so log a warning and end the task instead of a traceback.
-            self._to_logger.warning('Log streaming stopped: the log stream request timed out.')
-        except Exception:
-            # Exception in log redirection should not propagate further.
-            self._to_logger.exception('Log redirection stopped due to unexpected error:')
+        except Exception as exc:
+            if self._log_client._http_client.is_timeout_error(exc):  # noqa: SLF001
+                # A timeout on the long-lived stream is an expected terminal condition, not an error.
+                self._to_logger.warning('Log streaming stopped: the log stream request timed out.')
+            else:
+                # Exception in log redirection should not propagate further.
+                self._to_logger.exception('Log redirection stopped due to unexpected error:')

--- a/src/apify_client/_utils/errors.py
+++ b/src/apify_client/_utils/errors.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import impit
-
-from apify_client.errors import InvalidResponseBodyError, NotFoundError
+from apify_client.errors import NotFoundError
 
 if TYPE_CHECKING:
     from apify_client.errors import ApifyApiError
@@ -33,19 +31,3 @@ def catch_not_found_for_resource_or_throw(exc: ApifyApiError, resource_id: str |
     if resource_id is None:
         raise exc
     catch_not_found_or_throw(exc)
-
-
-def is_retryable_error(exc: Exception) -> bool:
-    """Check if the given error is retryable.
-
-    All `impit.HTTPError` subclasses are considered retryable because they represent transport-level failures
-    (network issues, timeouts, protocol errors, body decoding errors) that are typically transient. HTTP status
-    code errors are handled separately in `_make_request` based on the response status code, not here.
-    """
-    return isinstance(
-        exc,
-        (
-            InvalidResponseBodyError,
-            impit.HTTPError,
-        ),
-    )

--- a/src/apify_client/_utils/try_import.py
+++ b/src/apify_client/_utils/try_import.py
@@ -11,17 +11,29 @@ if TYPE_CHECKING:
     from typing import Any
 
 
+@dataclass
+class ImportState:
+    """Describe whether an optional import succeeded."""
+
+    available: bool = True
+
+
 @contextmanager
-def try_import(module_name: str, *symbol_names: str) -> Iterator[None]:
+def try_import(module_name: str, *symbol_names: str, dependency_name: str) -> Iterator[ImportState]:
     """Context manager to attempt importing symbols into a module.
 
-    If an `ImportError` is raised during the import, the symbol will be replaced with a `FailedImport` object.
+    If the named optional dependency is missing, the symbols are replaced with `FailedImport` objects. Import errors
+    caused by the importing module itself or by another dependency are propagated instead of being masked.
     """
+    state = ImportState()
     try:
-        yield
-    except ImportError as e:
+        yield state
+    except ModuleNotFoundError as exc:
+        if exc.name != dependency_name:
+            raise
+        state.available = False
         for symbol_name in symbol_names:
-            setattr(sys.modules[module_name], symbol_name, FailedImport(e.args[0]))
+            setattr(sys.modules[module_name], symbol_name, FailedImport(exc.args[0]))
 
 
 def install_import_hook(module_name: str) -> None:

--- a/src/apify_client/http_clients/__init__.py
+++ b/src/apify_client/http_clients/__init__.py
@@ -1,5 +1,5 @@
-from ._base import HttpClient, HttpClientAsync, HttpResponse
-from ._impit import ImpitHttpClient, ImpitHttpClientAsync
+from apify_client.http_clients._base import HttpClient, HttpClientAsync, HttpResponse
+from apify_client.http_clients._impit import ImpitHttpClient, ImpitHttpClientAsync
 
 __all__ = [
     'HttpClient',

--- a/src/apify_client/http_clients/_base.py
+++ b/src/apify_client/http_clients/_base.py
@@ -15,8 +15,8 @@ from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.parse import urlencode
 
 # `Protocol` comes from `typing_extensions`, not `typing`, because its runtime `isinstance` check looks attributes
-# up statically. The `typing` implementation on Python 3.11 calls `hasattr`, which evaluates properties: on an
-# unread streaming response that either raises or silently buffers the whole body.
+# up statically. The `typing` implementation on Python 3.11 calls `hasattr`, which evaluates properties. On an
+# unread streaming response, that either raises or silently buffers the whole body.
 from typing_extensions import Protocol, runtime_checkable
 
 from apify_client._consts import (
@@ -182,6 +182,15 @@ class HttpClientBase:
         library defines.
         """
         return isinstance(exc, TimeoutError)
+
+    def is_retryable_transport_error(self, exc: Exception) -> bool:
+        """Return whether an underlying HTTP-library exception is retryable.
+
+        The default classifies nothing as retryable, so a transport that doesn't override it gives up on the first
+        connection failure. Every transport adapter should map its own transient error types here.
+        """
+        _ = exc
+        return False
 
     @staticmethod
     def _merge_headers(base: dict[str, str] | None, override: dict[str, str] | None) -> dict[str, str]:
@@ -357,15 +366,6 @@ class HttpClientBase:
             logger.debug('Exception is not retryable', exc_info=exc)
             stop_retrying()
 
-    def is_retryable_transport_error(self, exc: Exception) -> bool:
-        """Return whether an underlying HTTP-library exception is retryable.
-
-        The default classifies nothing as retryable, so a transport that doesn't override it gives up on the first
-        connection failure. Every transport adapter should map its own transient error types here.
-        """
-        _ = exc
-        return False
-
     @staticmethod
     def _is_transient_transport_error(
         exc: Exception,
@@ -392,10 +392,23 @@ class HttpClient(HttpClientBase):
     defaults. Replacing `call` itself also remains supported, and then none of the hooks are used. Helper methods
     from `HttpClientBase` remain available for request preparation, URL building, and parameter parsing.
 
-    Implementations must send the client's default headers from `self._headers` with every request,
-    otherwise the `Authorization` header never reaches the API. The `_prepare_request_call` helper
-    merges them into the per-request headers automatically.
+    The client's default headers from `self._headers` have to go out with every request, otherwise the
+    `Authorization` header never reaches the API. The inherited `call` merges them into the per-request headers
+    through `_prepare_request_call`, so only a client that replaces `call` has to do it itself.
     """
+
+    def __enter__(self) -> Self:
+        """Return this client and close it when the context exits."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close resources owned by the HTTP client."""
+        self.close()
 
     def call(
         self,
@@ -464,18 +477,22 @@ class HttpClient(HttpClientBase):
         Transports that own a connection pool or a session override it. The default does nothing.
         """
 
-    def __enter__(self) -> Self:
-        """Return this client and close it when the context exits."""
-        return self
-
-    def __exit__(
+    def send_request(
         self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        traceback: TracebackType | None,
-    ) -> None:
-        """Close resources owned by the HTTP client."""
-        self.close()
+        *,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        content: bytes | None,
+        timeout: float | None,
+        stream: bool,
+    ) -> HttpResponse:
+        """Send one request through the underlying HTTP library.
+
+        Required by the inherited `call`, so a transport adapter must implement it. Overriding `call` itself
+        bypasses it entirely.
+        """
+        raise NotImplementedError
 
     @staticmethod
     def _retry_with_exp_backoff(
@@ -569,23 +586,6 @@ class HttpClient(HttpClientBase):
 
         raise ApifyApiError(response, attempt, method=method)
 
-    def send_request(
-        self,
-        *,
-        method: str,
-        url: str,
-        headers: dict[str, str],
-        content: bytes | None,
-        timeout: float | None,
-        stream: bool,
-    ) -> HttpResponse:
-        """Send one request through the underlying HTTP library.
-
-        Required by the inherited `call`, so a transport adapter must implement it. Overriding `call` itself
-        bypasses it entirely.
-        """
-        raise NotImplementedError
-
 
 @docs_group('HTTP clients')
 class HttpClientAsync(HttpClientBase):
@@ -594,6 +594,19 @@ class HttpClientAsync(HttpClientBase):
     Extend this class to create a custom asynchronous HTTP client. See `HttpClient`
     for details on the expected behavior.
     """
+
+    async def __aenter__(self) -> Self:
+        """Return this client and close it when the async context exits."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close resources owned by the asynchronous HTTP client."""
+        await self.aclose()
 
     async def call(
         self,
@@ -675,18 +688,22 @@ class HttpClientAsync(HttpClientBase):
         Transports that own a connection pool or a session override it. The default does nothing.
         """
 
-    async def __aenter__(self) -> Self:
-        """Return this client and close it when the async context exits."""
-        return self
-
-    async def __aexit__(
+    async def send_request(
         self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        traceback: TracebackType | None,
-    ) -> None:
-        """Close resources owned by the asynchronous HTTP client."""
-        await self.aclose()
+        *,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        content: bytes | None,
+        timeout: float | None,
+        stream: bool,
+    ) -> HttpResponse:
+        """Send one request through the underlying HTTP library.
+
+        Required by the inherited `call`, so a transport adapter must implement it. Overriding `call` itself
+        bypasses it entirely.
+        """
+        raise NotImplementedError
 
     @staticmethod
     async def _retry_with_exp_backoff(
@@ -779,20 +796,3 @@ class HttpClientAsync(HttpClientBase):
             raise
 
         raise ApifyApiError(response, attempt, method=method)
-
-    async def send_request(
-        self,
-        *,
-        method: str,
-        url: str,
-        headers: dict[str, str],
-        content: bytes | None,
-        timeout: float | None,
-        stream: bool,
-    ) -> HttpResponse:
-        """Send one request through the underlying HTTP library.
-
-        Required by the inherited `call`, so a transport adapter must implement it. Overriding `call` itself
-        bypasses it entirely.
-        """
-        raise NotImplementedError

--- a/src/apify_client/http_clients/_base.py
+++ b/src/apify_client/http_clients/_base.py
@@ -1,14 +1,23 @@
 from __future__ import annotations
 
+import asyncio
 import json as jsonlib
 import logging
 import os
+import random
 import sys
-from abc import ABC, abstractmethod
+import time
+from contextlib import suppress
 from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
 from importlib import metadata
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.parse import urlencode
+
+# `Protocol` comes from `typing_extensions`, not `typing`, because its runtime `isinstance` check looks attributes
+# up statically. The `typing` implementation on Python 3.11 calls `hasattr`, which evaluates properties: on an
+# unread streaming response that either raises or silently buffers the whole body.
+from typing_extensions import Protocol, runtime_checkable
 
 from apify_client._consts import (
     DEFAULT_MAX_RETRIES,
@@ -20,17 +29,22 @@ from apify_client._consts import (
     MIN_COMPRESSION_SIZE,
 )
 from apify_client._docs import docs_group
-from apify_client._logging import LoggerOnce, logger_name
+from apify_client._logging import LoggerOnce, log_context, logger_name
 from apify_client._statistics import ClientStatistics
 from apify_client._utils.http import is_compressible_content_type
 from apify_client._utils.time import to_seconds
+from apify_client.errors import ApifyApiError, InvalidResponseBodyError
 from apify_client.http_compressors._gzip import GzipHttpCompressor
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Iterator, Mapping
+    from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Mapping
+    from types import TracebackType
+    from typing import Self
 
     from apify_client.http_compressors._base import HttpCompressor
     from apify_client.types import JsonSerializable, Timeout
+
+T = TypeVar('T')
 
 logger = logging.getLogger(logger_name)
 logger_once = LoggerOnce(logger)
@@ -84,7 +98,6 @@ class HttpResponse(Protocol):
         """Iterate over the response body in bytes chunks asynchronously."""
 
 
-@docs_group('HTTP clients')
 class HttpClientBase:
     """Shared configuration and utilities for HTTP clients.
 
@@ -160,6 +173,14 @@ class HttpClientBase:
         """
         if self._get_header(self._headers, 'authorization') is None:
             self._headers['Authorization'] = f'Bearer {token}'
+
+    def is_timeout_error(self, exc: Exception) -> bool:
+        """Return whether an exception represents a transport timeout.
+
+        Recognizes Python's own `TimeoutError`. Transport adapters extend it with the timeout types their HTTP
+        library defines.
+        """
+        return isinstance(exc, TimeoutError)
 
     @staticmethod
     def _merge_headers(base: dict[str, str] | None, override: dict[str, str] | None) -> dict[str, str]:
@@ -328,21 +349,53 @@ class HttpClientBase:
 
         return f'{url}?{query_string}'
 
+    def _handle_request_exception(self, exc: Exception, *, stop_retrying: Callable[[], None]) -> None:
+        """Stop retrying when an exception is not a transient response or transport failure."""
+        logger.debug('Request threw exception', exc_info=exc)
+        if not isinstance(exc, InvalidResponseBodyError) and not self.is_retryable_transport_error(exc):
+            logger.debug('Exception is not retryable', exc_info=exc)
+            stop_retrying()
+
+    def is_retryable_transport_error(self, exc: Exception) -> bool:
+        """Return whether an underlying HTTP-library exception is retryable.
+
+        The default classifies nothing as retryable, so a transport that doesn't override it gives up on the first
+        connection failure. Every transport adapter should map its own transient error types here.
+        """
+        _ = exc
+        return False
+
+    @staticmethod
+    def _is_transient_transport_error(
+        exc: Exception,
+        *,
+        transport_errors: type[Exception] | tuple[type[Exception], ...],
+        permanent_errors: tuple[type[Exception], ...],
+    ) -> bool:
+        """Apply the shared retry policy to an exception raised by an HTTP library.
+
+        Every error from the library's own hierarchy counts as transient except the permanently-failing types the
+        adapter lists. Retrying is the default because transports also report genuinely transient failures through
+        their generic base class, e.g. Impit raises a bare `impit.HTTPError` for a body that ends mid-chunk. Sharing
+        one policy across adapters keeps a change of transport from changing which failures are retried.
+        """
+        return isinstance(exc, transport_errors) and not isinstance(exc, permanent_errors)
+
 
 @docs_group('HTTP clients')
-class HttpClient(HttpClientBase, ABC):
-    """Abstract base class for synchronous HTTP clients used by `ApifyClient`.
+class HttpClient(HttpClientBase):
+    """Base class for synchronous HTTP clients used by `ApifyClient`.
 
-    Extend this class to create a custom synchronous HTTP client. Override the `call` method
-    with your implementation. Helper methods from the base class are available for request
-    preparation, URL building, and parameter parsing.
+    Concrete clients inherit its request preparation, retry, and error handling, and implement the transport,
+    error-classification, and lifecycle hooks. Only `send_request` has to be implemented, the other hooks have
+    defaults. Replacing `call` itself also remains supported, and then none of the hooks are used. Helper methods
+    from `HttpClientBase` remain available for request preparation, URL building, and parameter parsing.
 
     Implementations must send the client's default headers from `self._headers` with every request,
     otherwise the `Authorization` header never reaches the API. The `_prepare_request_call` helper
     merges them into the per-request headers automatically.
     """
 
-    @abstractmethod
     def call(
         self,
         *,
@@ -351,16 +404,16 @@ class HttpClient(HttpClientBase, ABC):
         headers: dict[str, str] | None = None,
         params: dict[str, Any] | None = None,
         data: str | bytes | bytearray | None = None,
-        json: Any = None,
+        json: JsonSerializable | None = None,
         stream: bool | None = None,
         timeout: Timeout = 'medium',
     ) -> HttpResponse:
-        """Make an HTTP request.
+        """Make an HTTP request with automatic retry and exponential backoff.
 
         Args:
             method: HTTP method (GET, POST, PUT, DELETE, etc.).
             url: Full URL to make the request to.
-            headers: Additional headers to include in this request.
+            headers: Additional headers to include.
             params: Query parameters to append to the URL.
             data: Raw request body data. Cannot be used together with json.
             json: JSON-serializable data for the request body. Cannot be used together with data.
@@ -376,17 +429,171 @@ class HttpClient(HttpClientBase, ABC):
             ApifyApiError: If the request fails after all retries or returns a non-retryable error status.
             ValueError: If both json and data are provided.
         """
+        log_context.method.set(method)
+        log_context.url.set(url)
+
+        self._statistics.calls += 1
+
+        prepared_headers, prepared_params, content = self._prepare_request_call(
+            headers=headers,
+            params=params,
+            data=data,
+            json=json,
+        )
+
+        return self._retry_with_exp_backoff(
+            lambda stop_retrying, attempt: self._make_request(
+                stop_retrying=stop_retrying,
+                attempt=attempt,
+                method=method,
+                url=url,
+                headers=prepared_headers,
+                params=prepared_params,
+                content=content,
+                stream=stream,
+                timeout=timeout,
+            ),
+            max_retries=self._max_retries,
+            backoff_base=self._min_delay_between_retries,
+        )
+
+    def close(self) -> None:
+        """Close resources owned by the HTTP client.
+
+        Transports that own a connection pool or a session override it. The default does nothing.
+        """
+
+    def __enter__(self) -> Self:
+        """Return this client and close it when the context exits."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close resources owned by the HTTP client."""
+        self.close()
+
+    @staticmethod
+    def _retry_with_exp_backoff(
+        func: Callable[[Callable[[], None], int], T],
+        *,
+        max_retries: int = 8,
+        backoff_base: timedelta = timedelta(milliseconds=500),
+        backoff_factor: float = 2,
+        random_factor: float = 1,
+    ) -> T:
+        """Retry a function with exponential backoff and jitter."""
+        if max_retries < 1:
+            raise ValueError(f'max_retries must be at least 1, got {max_retries}')
+
+        random_factor = min(max(0, random_factor), 1)
+        backoff_factor = min(max(1, backoff_factor), 10)
+        swallow = True
+
+        def stop_retrying() -> None:
+            nonlocal swallow
+            swallow = False
+
+        for attempt in range(1, max_retries + 1):
+            try:
+                return func(stop_retrying, attempt)
+            except Exception:
+                if not swallow:
+                    raise
+
+            random_sleep_factor = random.uniform(1, 1 + random_factor)
+            backoff_base_secs = to_seconds(backoff_base)
+            backoff_exp_factor = backoff_factor ** (attempt - 1)
+            time.sleep(random_sleep_factor * backoff_base_secs * backoff_exp_factor)
+
+        return func(stop_retrying, max_retries + 1)
+
+    def _make_request(
+        self,
+        *,
+        stop_retrying: Callable[[], None],
+        attempt: int,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        params: dict[str, Any] | None,
+        content: bytes | None,
+        stream: bool | None,
+        timeout: Timeout,
+    ) -> HttpResponse:
+        """Execute one request attempt through the transport adapter."""
+        log_context.attempt.set(attempt)
+        logger.debug('Sending request')
+
+        self._statistics.requests += 1
+
+        try:
+            response = self.send_request(
+                method=method,
+                url=self._build_url_with_params(url, params=params),
+                headers=headers,
+                content=content,
+                timeout=self._compute_timeout(timeout, attempt=attempt),
+                stream=stream or False,
+            )
+        except Exception as exc:
+            self._handle_request_exception(exc, stop_retrying=stop_retrying)
+            raise
+
+        if response.status_code < HTTPStatus.MULTIPLE_CHOICES:
+            logger.debug('Request successful', extra={'status_code': response.status_code})
+            return response
+
+        if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
+            self._statistics.add_rate_limit_error(attempt)
+
+        logger.debug('Request unsuccessful', extra={'status_code': response.status_code})
+        if (
+            response.status_code < HTTPStatus.INTERNAL_SERVER_ERROR
+            and response.status_code != HTTPStatus.TOO_MANY_REQUESTS
+        ):
+            logger.debug('Status code is not retryable', extra={'status_code': response.status_code})
+            stop_retrying()
+
+        try:
+            response.read()
+        except Exception as exc:
+            with suppress(Exception):
+                response.close()
+            self._handle_request_exception(exc, stop_retrying=stop_retrying)
+            raise
+
+        raise ApifyApiError(response, attempt, method=method)
+
+    def send_request(
+        self,
+        *,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        content: bytes | None,
+        timeout: float | None,
+        stream: bool,
+    ) -> HttpResponse:
+        """Send one request through the underlying HTTP library.
+
+        Required by the inherited `call`, so a transport adapter must implement it. Overriding `call` itself
+        bypasses it entirely.
+        """
+        raise NotImplementedError
 
 
 @docs_group('HTTP clients')
-class HttpClientAsync(HttpClientBase, ABC):
-    """Abstract base class for asynchronous HTTP clients used by `ApifyClientAsync`.
+class HttpClientAsync(HttpClientBase):
+    """Base class for asynchronous HTTP clients used by `ApifyClientAsync`.
 
     Extend this class to create a custom asynchronous HTTP client. See `HttpClient`
     for details on the expected behavior.
     """
 
-    @abstractmethod
     async def call(
         self,
         *,
@@ -395,16 +602,16 @@ class HttpClientAsync(HttpClientBase, ABC):
         headers: dict[str, str] | None = None,
         params: dict[str, Any] | None = None,
         data: str | bytes | bytearray | None = None,
-        json: Any = None,
+        json: JsonSerializable | None = None,
         stream: bool | None = None,
         timeout: Timeout = 'medium',
     ) -> HttpResponse:
-        """Make an HTTP request.
+        """Make an HTTP request with automatic retry and exponential backoff.
 
         Args:
             method: HTTP method (GET, POST, PUT, DELETE, etc.).
             url: Full URL to make the request to.
-            headers: Additional headers to include in this request.
+            headers: Additional headers to include.
             params: Query parameters to append to the URL.
             data: Raw request body data. Cannot be used together with json.
             json: JSON-serializable data for the request body. Cannot be used together with data.
@@ -420,3 +627,171 @@ class HttpClientAsync(HttpClientBase, ABC):
             ApifyApiError: If the request fails after all retries or returns a non-retryable error status.
             ValueError: If both json and data are provided.
         """
+        log_context.method.set(method)
+        log_context.url.set(url)
+
+        self._statistics.calls += 1
+
+        # Serializing and compressing a request body is CPU-bound and would block the event loop, so
+        # offload preparation to a worker thread whenever there is something to compress. A body the
+        # client sends as it is costs less to prepare inline than the hop itself. A `json` body always
+        # hops, as its size is only known once serialized.
+        if json is not None or self._is_body_worth_compressing(data):
+            prepared_headers, prepared_params, content = await asyncio.to_thread(
+                self._prepare_request_call,
+                headers=headers,
+                params=params,
+                data=data,
+                json=json,
+            )
+        else:
+            prepared_headers, prepared_params, content = self._prepare_request_call(
+                headers=headers,
+                params=params,
+                data=data,
+                json=json,
+            )
+
+        return await self._retry_with_exp_backoff(
+            lambda stop_retrying, attempt: self._make_request(
+                stop_retrying=stop_retrying,
+                attempt=attempt,
+                method=method,
+                url=url,
+                headers=prepared_headers,
+                params=prepared_params,
+                content=content,
+                stream=stream,
+                timeout=timeout,
+            ),
+            max_retries=self._max_retries,
+            backoff_base=self._min_delay_between_retries,
+        )
+
+    async def aclose(self) -> None:
+        """Close resources owned by the asynchronous HTTP client.
+
+        Transports that own a connection pool or a session override it. The default does nothing.
+        """
+
+    async def __aenter__(self) -> Self:
+        """Return this client and close it when the async context exits."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close resources owned by the asynchronous HTTP client."""
+        await self.aclose()
+
+    @staticmethod
+    async def _retry_with_exp_backoff(
+        func: Callable[[Callable[[], None], int], Awaitable[T]],
+        *,
+        max_retries: int = 8,
+        backoff_base: timedelta = timedelta(milliseconds=500),
+        backoff_factor: float = 2,
+        random_factor: float = 1,
+    ) -> T:
+        """Retry an async function with exponential backoff and jitter."""
+        if max_retries < 1:
+            raise ValueError(f'max_retries must be at least 1, got {max_retries}')
+
+        random_factor = min(max(0, random_factor), 1)
+        backoff_factor = min(max(1, backoff_factor), 10)
+        swallow = True
+
+        def stop_retrying() -> None:
+            nonlocal swallow
+            swallow = False
+
+        for attempt in range(1, max_retries + 1):
+            try:
+                return await func(stop_retrying, attempt)
+            except Exception:
+                if not swallow:
+                    raise
+
+            random_sleep_factor = random.uniform(1, 1 + random_factor)
+            backoff_base_secs = to_seconds(backoff_base)
+            backoff_exp_factor = backoff_factor ** (attempt - 1)
+            await asyncio.sleep(random_sleep_factor * backoff_base_secs * backoff_exp_factor)
+
+        return await func(stop_retrying, max_retries + 1)
+
+    async def _make_request(
+        self,
+        *,
+        stop_retrying: Callable[[], None],
+        attempt: int,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        params: dict[str, Any] | None,
+        content: bytes | None,
+        stream: bool | None,
+        timeout: Timeout,
+    ) -> HttpResponse:
+        """Execute one request attempt through the transport adapter."""
+        log_context.attempt.set(attempt)
+        logger.debug('Sending request')
+
+        self._statistics.requests += 1
+
+        try:
+            response = await self.send_request(
+                method=method,
+                url=self._build_url_with_params(url, params=params),
+                headers=headers,
+                content=content,
+                timeout=self._compute_timeout(timeout, attempt=attempt),
+                stream=stream or False,
+            )
+        except Exception as exc:
+            self._handle_request_exception(exc, stop_retrying=stop_retrying)
+            raise
+
+        if response.status_code < HTTPStatus.MULTIPLE_CHOICES:
+            logger.debug('Request successful', extra={'status_code': response.status_code})
+            return response
+
+        if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
+            self._statistics.add_rate_limit_error(attempt)
+
+        logger.debug('Request unsuccessful', extra={'status_code': response.status_code})
+        if (
+            response.status_code < HTTPStatus.INTERNAL_SERVER_ERROR
+            and response.status_code != HTTPStatus.TOO_MANY_REQUESTS
+        ):
+            logger.debug('Status code is not retryable', extra={'status_code': response.status_code})
+            stop_retrying()
+
+        try:
+            await response.aread()
+        except Exception as exc:
+            with suppress(Exception):
+                await response.aclose()
+            self._handle_request_exception(exc, stop_retrying=stop_retrying)
+            raise
+
+        raise ApifyApiError(response, attempt, method=method)
+
+    async def send_request(
+        self,
+        *,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        content: bytes | None,
+        timeout: float | None,
+        stream: bool,
+    ) -> HttpResponse:
+        """Send one request through the underlying HTTP library.
+
+        Required by the inherited `call`, so a transport adapter must implement it. Overriding `call` itself
+        bypasses it entirely.
+        """
+        raise NotImplementedError

--- a/src/apify_client/http_clients/_base.py
+++ b/src/apify_client/http_clients/_base.py
@@ -98,6 +98,7 @@ class HttpResponse(Protocol):
         """Iterate over the response body in bytes chunks asynchronously."""
 
 
+@docs_group('HTTP clients')
 class HttpClientBase:
     """Shared configuration and utilities for HTTP clients.
 

--- a/src/apify_client/http_clients/_impit.py
+++ b/src/apify_client/http_clients/_impit.py
@@ -43,7 +43,6 @@ class ImpitHttpClient(HttpClient):
     with exponential backoff for rate-limited (HTTP 429) and server error (HTTP 5xx) responses.
     """
 
-    @override
     def __init__(
         self,
         *,
@@ -95,9 +94,9 @@ class ImpitHttpClient(HttpClient):
     def close(self) -> None:
         """Release resources owned by this client.
 
-        Impit doesn't expose a way to close its connection pool, and its `__exit__` keeps the client usable,
-        so there is nothing to release yet. The method exists so the lifecycle interface is the same for every
-        transport, and it will do real work once Impit supports it.
+        Delegates to Impit's own teardown, which releases nothing and leaves the client usable, because Impit
+        doesn't expose a way to close its connection pool. Routing through it keeps this client correct once
+        Impit does.
         """
         self._impit_client.__exit__(None, None, None)
 
@@ -143,7 +142,6 @@ class ImpitHttpClientAsync(HttpClientAsync):
     with exponential backoff for rate-limited (HTTP 429) and server error (HTTP 5xx) responses.
     """
 
-    @override
     def __init__(
         self,
         *,
@@ -195,7 +193,7 @@ class ImpitHttpClientAsync(HttpClientAsync):
     async def aclose(self) -> None:
         """Release resources owned by this client.
 
-        See `ImpitHttpClient.close` for why there is nothing to release yet.
+        See `ImpitHttpClient.close` for what Impit's teardown does.
         """
         await self._impit_async_client.__aexit__(None, None, None)
 

--- a/src/apify_client/http_clients/_impit.py
+++ b/src/apify_client/http_clients/_impit.py
@@ -1,14 +1,9 @@
 from __future__ import annotations
 
-import asyncio
-import logging
-import random
-import time
-from datetime import timedelta
-from http import HTTPStatus
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING
 
 import impit
+from typing_extensions import override
 
 from apify_client._consts import (
     DEFAULT_MAX_RETRIES,
@@ -19,38 +14,24 @@ from apify_client._consts import (
     DEFAULT_TIMEOUT_SHORT,
 )
 from apify_client._docs import docs_group
-from apify_client._logging import log_context, logger_name
-from apify_client._utils.time import to_seconds
-from apify_client.errors import ApifyApiError, InvalidResponseBodyError
 from apify_client.http_clients._base import HttpClient, HttpClientAsync
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from datetime import timedelta
 
     from apify_client._statistics import ClientStatistics
-    from apify_client.http_clients._base import HttpResponse
     from apify_client.http_compressors._base import HttpCompressor
-    from apify_client.types import JsonSerializable, Timeout
 
-T = TypeVar('T')
-
-logger = logging.getLogger(logger_name)
-
-
-def _is_retryable_error(exc: Exception) -> bool:
-    """Check if an exception represents a transient error that should be retried.
-
-    All `impit.HTTPError` subclasses are considered retryable because they represent transport-level failures
-    (network issues, timeouts, protocol errors, body decoding errors) that are typically transient. HTTP status
-    code errors are handled separately in `_make_request` based on the response status code, not here.
-    """
-    return isinstance(
-        exc,
-        (
-            InvalidResponseBodyError,
-            impit.HTTPError,
-        ),
-    )
+_PERMANENT_ERRORS = (
+    # A bad URL scheme or a request Impit itself rejects cannot succeed on a retry.
+    impit.UnsupportedProtocol,
+    impit.LocalProtocolError,
+    # An over-long redirect chain is a routing loop, which repeating the request cannot break.
+    impit.TooManyRedirects,
+    # Status codes are retried by `_make_request` based on the status itself, never as a transport error.
+    impit.HTTPStatusError,
+)
+"""Impit errors that a retry cannot fix. Everything else in the `impit.HTTPError` tree is treated as transient."""
 
 
 @docs_group('HTTP clients')
@@ -62,6 +43,7 @@ class ImpitHttpClient(HttpClient):
     with exponential backoff for rate-limited (HTTP 429) and server error (HTTP 5xx) responses.
     """
 
+    @override
     def __init__(
         self,
         *,
@@ -103,203 +85,53 @@ class ImpitHttpClient(HttpClient):
             http_compressor=http_compressor,
         )
 
-        self._impit_client = impit.Client(
-            follow_redirects=True,
-        )
+        self._impit_client = impit.Client(follow_redirects=True)
 
-    def call(
-        self,
-        *,
-        method: str,
-        url: str,
-        headers: dict[str, str] | None = None,
-        params: dict[str, Any] | None = None,
-        data: str | bytes | bytearray | None = None,
-        json: JsonSerializable | None = None,
-        stream: bool | None = None,
-        timeout: Timeout = 'medium',
-    ) -> HttpResponse:
-        """Make an HTTP request with automatic retry and exponential backoff.
+    @override
+    def is_timeout_error(self, exc: Exception) -> bool:
+        return super().is_timeout_error(exc) or isinstance(exc, impit.TimeoutException)
 
-        Args:
-            method: HTTP method (GET, POST, PUT, DELETE, etc.).
-            url: Full URL to make the request to.
-            headers: Additional headers to include.
-            params: Query parameters to append to the URL.
-            data: Raw request body data. Cannot be used together with json.
-            json: JSON-serializable data for the request body. Cannot be used together with data.
-            stream: Whether to stream the response body.
-            timeout: Timeout for the API HTTP request. Use `short`, `medium`, or `long` tier literals for
-                preconfigured timeouts. A `timedelta` overrides it for this call (capped at `timeout_max`), and
-                `no_timeout` disables the timeout entirely.
+    @override
+    def close(self) -> None:
+        """Release resources owned by this client.
 
-        Returns:
-            The HTTP response object.
-
-        Raises:
-            ApifyApiError: If the request fails after all retries or returns a non-retryable error status.
-            ValueError: If both json and data are provided.
+        Impit doesn't expose a way to close its connection pool, and its `__exit__` keeps the client usable,
+        so there is nothing to release yet. The method exists so the lifecycle interface is the same for every
+        transport, and it will do real work once Impit supports it.
         """
-        log_context.method.set(method)
-        log_context.url.set(url)
+        self._impit_client.__exit__(None, None, None)
 
-        self._statistics.calls += 1
-
-        prepared_headers, prepared_params, content = self._prepare_request_call(
-            headers=headers,
-            params=params,
-            data=data,
-            json=json,
-        )
-
-        return self._retry_with_exp_backoff(
-            lambda stop_retrying, attempt: self._make_request(
-                stop_retrying=stop_retrying,
-                attempt=attempt,
-                method=method,
-                url=url,
-                headers=prepared_headers,
-                params=prepared_params,
-                content=content,
-                stream=stream,
-                timeout=timeout,
-            ),
-            max_retries=self._max_retries,
-            backoff_base=self._min_delay_between_retries,
-        )
-
-    def _make_request(
+    @override
+    def send_request(
         self,
         *,
-        stop_retrying: Callable[[], None],
-        attempt: int,
         method: str,
         url: str,
         headers: dict[str, str],
-        params: dict[str, Any] | None,
         content: bytes | None,
-        stream: bool | None,
-        timeout: Timeout,
+        timeout: float | None,
+        stream: bool,
     ) -> impit.Response:
-        """Execute a single HTTP request attempt.
+        # Impit treats timeout=None as "use client default (30s)", not "no timeout".
+        # Use a large value (24 hours) to effectively disable the timeout.
+        # This can be removed once impit updates its behaviour: https://github.com/apify/impit/issues/401
+        impit_timeout = 86_400 if timeout is None else timeout
+        return self._impit_client.request(
+            method=method,
+            url=url,
+            headers=headers,
+            content=content,
+            timeout=impit_timeout,
+            stream=stream,
+        )
 
-        Args:
-            stop_retrying: Callback to signal that retries should stop.
-            attempt: Current attempt number (1-indexed).
-            method: HTTP method.
-            url: Request URL.
-            headers: Request headers.
-            params: Query parameters.
-            content: Request body content.
-            stream: Whether to stream the response.
-            timeout: Timeout for this request.
-
-        Returns:
-            The HTTP response object.
-
-        Raises:
-            ApifyApiError: If the request fails with an error status.
-        """
-        log_context.attempt.set(attempt)
-        logger.debug('Sending request')
-
-        self._statistics.requests += 1
-
-        try:
-            url_with_params = self._build_url_with_params(url, params=params)
-
-            # Impit treats timeout=None as "use client default (30s)", not "no timeout".
-            # Use a large value (24 hours) to effectively disable the timeout.
-            # This can be removed once impit updates its behaviour: https://github.com/apify/impit/issues/401
-            computed_timeout = self._compute_timeout(timeout, attempt=attempt)
-            impit_timeout = 86_400 if computed_timeout is None else computed_timeout
-
-            response = self._impit_client.request(
-                method=method,
-                url=url_with_params,
-                headers=headers,
-                content=content,
-                timeout=impit_timeout,
-                stream=stream or False,
-            )
-
-            if response.status_code < HTTPStatus.MULTIPLE_CHOICES:
-                logger.debug('Request successful', extra={'status_code': response.status_code})
-                return response
-
-            if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
-                self._statistics.add_rate_limit_error(attempt)
-
-        except Exception as exc:
-            logger.debug('Request threw exception', exc_info=exc)
-            if not _is_retryable_error(exc):
-                logger.debug('Exception is not retryable', exc_info=exc)
-                stop_retrying()
-            raise
-
-        # Retry only server errors (5xx) and rate limits (429).
-        logger.debug('Request unsuccessful', extra={'status_code': response.status_code})
-        if (
-            response.status_code < HTTPStatus.INTERNAL_SERVER_ERROR
-            and response.status_code != HTTPStatus.TOO_MANY_REQUESTS
-        ):
-            logger.debug('Status code is not retryable', extra={'status_code': response.status_code})
-            stop_retrying()
-
-        # Read the response in case it is a stream, so we can raise the error properly.
-        response.read()
-        raise ApifyApiError(response, attempt, method=method)
-
-    @staticmethod
-    def _retry_with_exp_backoff(
-        func: Callable[[Callable[[], None], int], T],
-        *,
-        max_retries: int = 8,
-        backoff_base: timedelta = timedelta(milliseconds=500),
-        backoff_factor: float = 2,
-        random_factor: float = 1,
-    ) -> T:
-        """Retry a function with exponential backoff and jitter.
-
-        Args:
-            func: Function to retry. Receives (stop_retrying callback, attempt number).
-            max_retries: Maximum retry attempts.
-            backoff_base: Base delay.
-            backoff_factor: Exponential multiplier (clamped to 1-10).
-            random_factor: Jitter factor (clamped to 0-1).
-
-        Returns:
-            The function's return value on success.
-
-        Raises:
-            Exception: Re-raises the last exception if all retries fail or stop_retrying is called.
-        """
-        if max_retries < 1:
-            raise ValueError(f'max_retries must be at least 1, got {max_retries}')
-
-        random_factor = min(max(0, random_factor), 1)
-        backoff_factor = min(max(1, backoff_factor), 10)
-        swallow = True
-
-        def stop_retrying() -> None:
-            nonlocal swallow
-            swallow = False
-
-        for attempt in range(1, max_retries + 1):
-            try:
-                return func(stop_retrying, attempt)
-            except Exception:
-                if not swallow:
-                    raise
-
-            random_sleep_factor = random.uniform(1, 1 + random_factor)
-            backoff_base_secs = to_seconds(backoff_base)
-            backoff_exp_factor = backoff_factor ** (attempt - 1)
-
-            sleep_time_secs = random_sleep_factor * backoff_base_secs * backoff_exp_factor
-            time.sleep(sleep_time_secs)
-
-        return func(stop_retrying, max_retries + 1)
+    @override
+    def is_retryable_transport_error(self, exc: Exception) -> bool:
+        return self._is_transient_transport_error(
+            exc,
+            transport_errors=impit.HTTPError,
+            permanent_errors=_PERMANENT_ERRORS,
+        )
 
 
 @docs_group('HTTP clients')
@@ -311,6 +143,7 @@ class ImpitHttpClientAsync(HttpClientAsync):
     with exponential backoff for rate-limited (HTTP 429) and server error (HTTP 5xx) responses.
     """
 
+    @override
     def __init__(
         self,
         *,
@@ -352,213 +185,46 @@ class ImpitHttpClientAsync(HttpClientAsync):
             http_compressor=http_compressor,
         )
 
-        self._impit_async_client = impit.AsyncClient(
-            follow_redirects=True,
-        )
+        self._impit_async_client = impit.AsyncClient(follow_redirects=True)
 
-    async def call(
-        self,
-        *,
-        method: str,
-        url: str,
-        headers: dict[str, str] | None = None,
-        params: dict[str, Any] | None = None,
-        data: str | bytes | bytearray | None = None,
-        json: JsonSerializable | None = None,
-        stream: bool | None = None,
-        timeout: Timeout = 'medium',
-    ) -> HttpResponse:
-        """Make an HTTP request with automatic retry and exponential backoff.
+    @override
+    def is_timeout_error(self, exc: Exception) -> bool:
+        return super().is_timeout_error(exc) or isinstance(exc, impit.TimeoutException)
 
-        Args:
-            method: HTTP method (GET, POST, PUT, DELETE, etc.).
-            url: Full URL to make the request to.
-            headers: Additional headers to include.
-            params: Query parameters to append to the URL.
-            data: Raw request body data. Cannot be used together with json.
-            json: JSON-serializable data for the request body. Cannot be used together with data.
-            stream: Whether to stream the response body.
-            timeout: Timeout for the API HTTP request. Use `short`, `medium`, or `long` tier literals for
-                preconfigured timeouts. A `timedelta` overrides it for this call (capped at `timeout_max`), and
-                `no_timeout` disables the timeout entirely.
+    @override
+    async def aclose(self) -> None:
+        """Release resources owned by this client.
 
-        Returns:
-            The HTTP response object.
-
-        Raises:
-            ApifyApiError: If the request fails after all retries or returns a non-retryable error status.
-            ValueError: If both json and data are provided.
+        See `ImpitHttpClient.close` for why there is nothing to release yet.
         """
-        log_context.method.set(method)
-        log_context.url.set(url)
+        await self._impit_async_client.__aexit__(None, None, None)
 
-        self._statistics.calls += 1
-
-        # Serializing and compressing a request body is CPU-bound and would block the event loop, so
-        # offload preparation to a worker thread whenever there is something to compress. A body the
-        # client sends as it is costs less to prepare inline than the hop itself. A `json` body always
-        # hops, as its size is only known once serialized.
-        if json is not None or self._is_body_worth_compressing(data):
-            prepared_headers, prepared_params, content = await asyncio.to_thread(
-                self._prepare_request_call,
-                headers=headers,
-                params=params,
-                data=data,
-                json=json,
-            )
-        else:
-            prepared_headers, prepared_params, content = self._prepare_request_call(
-                headers=headers,
-                params=params,
-                data=data,
-                json=json,
-            )
-
-        return await self._retry_with_exp_backoff(
-            lambda stop_retrying, attempt: self._make_request(
-                stop_retrying=stop_retrying,
-                attempt=attempt,
-                method=method,
-                url=url,
-                headers=prepared_headers,
-                params=prepared_params,
-                content=content,
-                stream=stream,
-                timeout=timeout,
-            ),
-            max_retries=self._max_retries,
-            backoff_base=self._min_delay_between_retries,
-        )
-
-    async def _make_request(
+    @override
+    async def send_request(
         self,
         *,
-        stop_retrying: Callable[[], None],
-        attempt: int,
         method: str,
         url: str,
         headers: dict[str, str],
-        params: dict[str, Any] | None,
         content: bytes | None,
-        stream: bool | None,
-        timeout: Timeout,
+        timeout: float | None,
+        stream: bool,
     ) -> impit.Response:
-        """Execute a single HTTP request attempt.
+        # See the synchronous implementation for why None maps to 24 hours.
+        impit_timeout = 86_400 if timeout is None else timeout
+        return await self._impit_async_client.request(
+            method=method,
+            url=url,
+            headers=headers,
+            content=content,
+            timeout=impit_timeout,
+            stream=stream,
+        )
 
-        Args:
-            stop_retrying: Callback to signal that retries should stop.
-            attempt: Current attempt number (1-indexed).
-            method: HTTP method.
-            url: Request URL.
-            headers: Request headers.
-            params: Query parameters.
-            content: Request body content.
-            stream: Whether to stream the response.
-            timeout: Timeout for this request.
-
-        Returns:
-            The HTTP response object.
-
-        Raises:
-            ApifyApiError: If the request fails with an error status.
-        """
-        log_context.attempt.set(attempt)
-        logger.debug('Sending request')
-
-        self._statistics.requests += 1
-
-        try:
-            url_with_params = self._build_url_with_params(url, params=params)
-
-            # Impit treats timeout=None as "use client default (30s)", not "no timeout".
-            # Use a large value (24 hours) to effectively disable the timeout.
-            # This can be removed once impit updates its behaviour: https://github.com/apify/impit/issues/401
-            computed_timeout = self._compute_timeout(timeout, attempt=attempt)
-            impit_timeout = 86_400 if computed_timeout is None else computed_timeout
-
-            response = await self._impit_async_client.request(
-                method=method,
-                url=url_with_params,
-                headers=headers,
-                content=content,
-                timeout=impit_timeout,
-                stream=stream or False,
-            )
-
-            if response.status_code < HTTPStatus.MULTIPLE_CHOICES:
-                logger.debug('Request successful', extra={'status_code': response.status_code})
-                return response
-
-            if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
-                self._statistics.add_rate_limit_error(attempt)
-
-        except Exception as exc:
-            logger.debug('Request threw exception', exc_info=exc)
-            if not _is_retryable_error(exc):
-                logger.debug('Exception is not retryable', exc_info=exc)
-                stop_retrying()
-            raise
-
-        # Retry only server errors (5xx) and rate limits (429).
-        logger.debug('Request unsuccessful', extra={'status_code': response.status_code})
-        if (
-            response.status_code < HTTPStatus.INTERNAL_SERVER_ERROR
-            and response.status_code != HTTPStatus.TOO_MANY_REQUESTS
-        ):
-            logger.debug('Status code is not retryable', extra={'status_code': response.status_code})
-            stop_retrying()
-
-        # Read the response in case it is a stream, so we can raise the error properly.
-        await response.aread()
-        raise ApifyApiError(response, attempt, method=method)
-
-    @staticmethod
-    async def _retry_with_exp_backoff(
-        func: Callable[[Callable[[], None], int], Awaitable[T]],
-        *,
-        max_retries: int = 8,
-        backoff_base: timedelta = timedelta(milliseconds=500),
-        backoff_factor: float = 2,
-        random_factor: float = 1,
-    ) -> T:
-        """Retry an async function with exponential backoff and jitter.
-
-        Args:
-            func: Async function to retry. Receives (stop_retrying callback, attempt number).
-            max_retries: Maximum retry attempts.
-            backoff_base: Base delay.
-            backoff_factor: Exponential multiplier (clamped to 1-10).
-            random_factor: Jitter factor (clamped to 0-1).
-
-        Returns:
-            The function's return value on success.
-
-        Raises:
-            Exception: Re-raises the last exception if all retries fail or stop_retrying is called.
-        """
-        if max_retries < 1:
-            raise ValueError(f'max_retries must be at least 1, got {max_retries}')
-
-        random_factor = min(max(0, random_factor), 1)
-        backoff_factor = min(max(1, backoff_factor), 10)
-        swallow = True
-
-        def stop_retrying() -> None:
-            nonlocal swallow
-            swallow = False
-
-        for attempt in range(1, max_retries + 1):
-            try:
-                return await func(stop_retrying, attempt)
-            except Exception:
-                if not swallow:
-                    raise
-
-            random_sleep_factor = random.uniform(1, 1 + random_factor)
-            backoff_base_secs = to_seconds(backoff_base)
-            backoff_exp_factor = backoff_factor ** (attempt - 1)
-
-            sleep_time_secs = random_sleep_factor * backoff_base_secs * backoff_exp_factor
-            await asyncio.sleep(sleep_time_secs)
-
-        return await func(stop_retrying, max_retries + 1)
+    @override
+    def is_retryable_transport_error(self, exc: Exception) -> bool:
+        return self._is_transient_transport_error(
+            exc,
+            transport_errors=impit.HTTPError,
+            permanent_errors=_PERMANENT_ERRORS,
+        )

--- a/src/apify_client/http_compressors/__init__.py
+++ b/src/apify_client/http_compressors/__init__.py
@@ -9,7 +9,10 @@ _install_import_hook(__name__)
 
 # `brotli` is an optional extra, so it's wrapped in try_import. Accessing `BrotliHttpCompressor`
 # without the extra installed raises a clear ImportError instead of failing at package import time.
-with _try_import(__name__, 'BrotliHttpCompressor'):
+with _try_import(__name__, 'BrotliHttpCompressor', dependency_name='brotli') as _brotli_import:
     from apify_client.http_compressors._brotli import BrotliHttpCompressor
 
-__all__ = ['BrotliHttpCompressor', 'GzipHttpCompressor', 'HttpCompressor']
+if _brotli_import.available:
+    __all__ = ['BrotliHttpCompressor', 'GzipHttpCompressor', 'HttpCompressor']
+else:
+    __all__ = ['GzipHttpCompressor', 'HttpCompressor']

--- a/tests/integration/test_dataset.py
+++ b/tests/integration/test_dataset.py
@@ -21,6 +21,7 @@ from .._utils import (
 from apify_client._models import Dataset, DatasetListItem, DatasetStatistics, ListOfDatasets
 from apify_client._resource_clients.dataset import DatasetItemsPage
 from apify_client.errors import ApifyApiError
+from apify_client.http_clients import HttpResponse
 
 if TYPE_CHECKING:
     from apify_client import ApifyClient, ApifyClientAsync
@@ -727,7 +728,7 @@ async def test_dataset_stream_items(client: ApifyClient | ApifyClientAsync, *, i
         if is_async:
             assert isinstance(stream_ctx, AbstractAsyncContextManager)
             async with stream_ctx as response:
-                assert isinstance(response, impit.Response)
+                assert isinstance(response, HttpResponse)
                 assert response.status_code == 200
                 content = await response.aread()
                 items = json.loads(content)
@@ -736,7 +737,7 @@ async def test_dataset_stream_items(client: ApifyClient | ApifyClientAsync, *, i
         else:
             assert isinstance(stream_ctx, AbstractContextManager)
             with stream_ctx as response:
-                assert isinstance(response, impit.Response)
+                assert isinstance(response, HttpResponse)
                 assert response.status_code == 200
                 content = response.read()
                 items = json.loads(content)

--- a/tests/integration/test_key_value_store.py
+++ b/tests/integration/test_key_value_store.py
@@ -21,6 +21,7 @@ from .._utils import (
 )
 from apify_client._models import KeyValueStore, KeyValueStoreKey, ListOfKeys, ListOfKeyValueStores
 from apify_client.errors import ApifyApiError
+from apify_client.http_clients import HttpResponse
 
 if TYPE_CHECKING:
     from apify_client import ApifyClient, ApifyClientAsync
@@ -198,14 +199,14 @@ async def test_stream_record_signature(
             signature=test_kvs_of_another_user.keys_signature[key],
         ) as stream:  # ty: ignore[invalid-context-manager]
             assert isinstance(stream, dict)
-            value = json.loads(stream['value'].content.decode('utf-8'))
+            value = json.loads((await stream['value'].aread()).decode('utf-8'))
     else:
         with kvs.stream_record(
             key,
             signature=test_kvs_of_another_user.keys_signature[key],
         ) as stream:  # ty: ignore[invalid-context-manager]
             assert isinstance(stream, dict)
-            value = json.loads(stream['value'].content.decode('utf-8'))
+            value = json.loads(stream['value'].read().decode('utf-8'))
 
     assert test_kvs_of_another_user.expected_content[key] == value
 
@@ -726,11 +727,15 @@ async def test_key_value_store_stream_record_own(client: ApifyClient | ApifyClie
         if is_async:
             async with store_client.stream_record('stream-key') as stream:  # ty: ignore[invalid-context-manager]
                 assert isinstance(stream, dict)
-                value = json.loads(stream['value'].content.decode('utf-8'))
+                response = stream['value']
+                assert isinstance(response, HttpResponse)
+                value = json.loads((await response.aread()).decode('utf-8'))
         else:
             with store_client.stream_record('stream-key') as stream:  # ty: ignore[invalid-context-manager]
                 assert isinstance(stream, dict)
-                value = json.loads(stream['value'].content.decode('utf-8'))
+                response = stream['value']
+                assert isinstance(response, HttpResponse)
+                value = json.loads(response.read().decode('utf-8'))
 
         assert value == {'data': 'streamed'}
     finally:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 import pytest
 from pytest_httpserver import HTTPServer
 
+from apify_client.http_clients import HttpClient, HttpClientAsync, ImpitHttpClient, ImpitHttpClientAsync
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
@@ -28,3 +30,15 @@ def httpserver(make_httpserver: HTTPServer) -> Iterable[HTTPServer]:
     server = make_httpserver
     yield server
     server.clear()
+
+
+@pytest.fixture(params=[pytest.param(ImpitHttpClient, id='impit')])
+def http_client_class(request: pytest.FixtureRequest) -> type[HttpClient]:
+    """Return each built-in synchronous HTTP client class."""
+    return request.param
+
+
+@pytest.fixture(params=[pytest.param(ImpitHttpClientAsync, id='impit')])
+def http_client_async_class(request: pytest.FixtureRequest) -> type[HttpClientAsync]:
+    """Return each built-in asynchronous HTTP client class."""
+    return request.param

--- a/tests/unit/test_client_errors.py
+++ b/tests/unit/test_client_errors.py
@@ -18,13 +18,14 @@ from apify_client.errors import (
     ServerError,
     UnauthorizedError,
 )
-from apify_client.http_clients import ImpitHttpClient, ImpitHttpClientAsync
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from pytest_httpserver import HTTPServer
     from werkzeug import Request
+
+    from apify_client.http_clients import HttpClient, HttpClientAsync
 
 _TEST_PATH = '/errors'
 _EXPECTED_MESSAGE = 'some_message'
@@ -84,13 +85,21 @@ def streaming_handler(_request: Request) -> Response:
 
 
 @pytest.fixture
-def sync_client(httpserver: HTTPServer) -> ApifyClient:
-    return ApifyClient(token='test', api_url=httpserver.url_for('/').removesuffix('/'))
+def sync_client(httpserver: HTTPServer, http_client_class: type[HttpClient]) -> ApifyClient:
+    return ApifyClient.with_custom_http_client(
+        token='test',
+        api_url=httpserver.url_for('/').removesuffix('/'),
+        http_client=http_client_class(),
+    )
 
 
 @pytest.fixture
-def async_client(httpserver: HTTPServer) -> ApifyClientAsync:
-    return ApifyClientAsync(token='test', api_url=httpserver.url_for('/').removesuffix('/'))
+def async_client(httpserver: HTTPServer, http_client_async_class: type[HttpClientAsync]) -> ApifyClientAsync:
+    return ApifyClientAsync.with_custom_http_client(
+        token='test',
+        api_url=httpserver.url_for('/').removesuffix('/'),
+        http_client=http_client_async_class(),
+    )
 
 
 @pytest.fixture
@@ -101,9 +110,9 @@ def test_endpoint(httpserver: HTTPServer) -> str:
     return str(httpserver.url_for(_TEST_PATH))
 
 
-def test_client_apify_api_error_with_data(test_endpoint: str) -> None:
+def test_client_apify_api_error_with_data(test_endpoint: str, http_client_class: type[HttpClient]) -> None:
     """Test that client correctly throws ApifyApiError with error data from response."""
-    client = ImpitHttpClient()
+    client = http_client_class()
 
     with pytest.raises(ApifyApiError) as exc:
         client.call(method='GET', url=test_endpoint)
@@ -113,9 +122,11 @@ def test_client_apify_api_error_with_data(test_endpoint: str) -> None:
     assert exc.value.data == _EXPECTED_DATA
 
 
-async def test_async_client_apify_api_error_with_data(test_endpoint: str) -> None:
+async def test_async_client_apify_api_error_with_data(
+    test_endpoint: str, http_client_async_class: type[HttpClientAsync]
+) -> None:
     """Test that async client correctly throws ApifyApiError with error data from response."""
-    client = ImpitHttpClientAsync()
+    client = http_client_async_class()
 
     with pytest.raises(ApifyApiError) as exc:
         await client.call(method='GET', url=test_endpoint)
@@ -125,12 +136,12 @@ async def test_async_client_apify_api_error_with_data(test_endpoint: str) -> Non
     assert exc.value.data == _EXPECTED_DATA
 
 
-def test_client_apify_api_error_streamed(httpserver: HTTPServer) -> None:
+def test_client_apify_api_error_streamed(httpserver: HTTPServer, http_client_class: type[HttpClient]) -> None:
     """Test that client correctly throws ApifyApiError when the response has stream."""
 
     error = json.loads(RAW_ERROR.decode())
 
-    client = ImpitHttpClient()
+    client = http_client_class()
 
     httpserver.expect_request('/stream_error').respond_with_handler(streaming_handler)
 
@@ -141,12 +152,14 @@ def test_client_apify_api_error_streamed(httpserver: HTTPServer) -> None:
     assert exc.value.type == error['error']['type']
 
 
-async def test_async_client_apify_api_error_streamed(httpserver: HTTPServer) -> None:
+async def test_async_client_apify_api_error_streamed(
+    httpserver: HTTPServer, http_client_async_class: type[HttpClientAsync]
+) -> None:
     """Test that async client correctly throws ApifyApiError when the response has stream."""
 
     error = json.loads(RAW_ERROR.decode())
 
-    client = ImpitHttpClientAsync()
+    client = http_client_async_class()
 
     httpserver.expect_request('/stream_error').respond_with_handler(streaming_handler)
 
@@ -157,12 +170,14 @@ async def test_async_client_apify_api_error_streamed(httpserver: HTTPServer) -> 
     assert exc.value.type == error['error']['type']
 
 
-def test_apify_api_error_dispatches_to_subclass_for_known_status(httpserver: HTTPServer) -> None:
+def test_apify_api_error_dispatches_to_subclass_for_known_status(
+    httpserver: HTTPServer, http_client_class: type[HttpClient]
+) -> None:
     """Mapped HTTP status codes dispatch to their matching subclass."""
     httpserver.expect_request('/dispatch').respond_with_json(
         {'error': {'type': 'record-not-found', 'message': 'nope'}}, status=404
     )
-    client = ImpitHttpClient()
+    client = http_client_class()
 
     with pytest.raises(NotFoundError) as exc:
         client.call(method='GET', url=str(httpserver.url_for('/dispatch')))
@@ -173,10 +188,12 @@ def test_apify_api_error_dispatches_to_subclass_for_known_status(httpserver: HTT
     assert exc.value.type == 'record-not-found'
 
 
-def test_apify_api_error_dispatches_streamed_response(httpserver: HTTPServer) -> None:
+def test_apify_api_error_dispatches_streamed_response(
+    httpserver: HTTPServer, http_client_class: type[HttpClient]
+) -> None:
     """Dispatch works even when the response body comes in as a stream (403 → ForbiddenError)."""
     httpserver.expect_request('/stream_dispatch').respond_with_handler(streaming_handler)
-    client = ImpitHttpClient()
+    client = http_client_class()
 
     with pytest.raises(ForbiddenError) as exc:
         client.call(method='GET', url=httpserver.url_for('/stream_dispatch'), stream=True)
@@ -186,12 +203,14 @@ def test_apify_api_error_dispatches_streamed_response(httpserver: HTTPServer) ->
     assert exc.value.type == 'insufficient-permissions'
 
 
-def test_apify_api_error_dispatches_5xx_to_server_error(httpserver: HTTPServer) -> None:
+def test_apify_api_error_dispatches_5xx_to_server_error(
+    httpserver: HTTPServer, http_client_class: type[HttpClient]
+) -> None:
     """Any 5xx status falls under the ServerError subclass."""
     httpserver.expect_request('/server_error').respond_with_json(
         {'error': {'type': 'internal-error', 'message': 'boom'}}, status=503
     )
-    client = ImpitHttpClient(max_retries=1)
+    client = http_client_class(max_retries=1)
 
     with pytest.raises(ServerError) as exc:
         client.call(method='GET', url=str(httpserver.url_for('/server_error')))
@@ -200,12 +219,14 @@ def test_apify_api_error_dispatches_5xx_to_server_error(httpserver: HTTPServer) 
     assert exc.value.status_code == 503
 
 
-def test_apify_api_error_falls_back_for_unmapped_status(httpserver: HTTPServer) -> None:
+def test_apify_api_error_falls_back_for_unmapped_status(
+    httpserver: HTTPServer, http_client_class: type[HttpClient]
+) -> None:
     """Statuses without a dedicated subclass fall back to the base ApifyApiError."""
     httpserver.expect_request('/unmapped').respond_with_json(
         {'error': {'type': 'whatever', 'message': 'nope'}}, status=418
     )
-    client = ImpitHttpClient()
+    client = http_client_class()
 
     with pytest.raises(ApifyApiError) as exc:
         client.call(method='GET', url=str(httpserver.url_for('/unmapped')))
@@ -227,14 +248,17 @@ def test_apify_api_error_falls_back_for_unmapped_status(httpserver: HTTPServer) 
     ],
 )
 def test_apify_api_error_dispatches_all_mapped_statuses(
-    httpserver: HTTPServer, status_code: int, expected_cls: type[ApifyApiError]
+    httpserver: HTTPServer,
+    http_client_class: type[HttpClient],
+    status_code: int,
+    expected_cls: type[ApifyApiError],
 ) -> None:
     """Every status in `_STATUS_TO_CLASS` dispatches to its matching subclass."""
     httpserver.expect_request('/dispatch_all').respond_with_json(
         {'error': {'type': 'some-type', 'message': 'msg'}}, status=status_code
     )
     # Use max_retries=1 so retryable statuses (429) don't loop during the test.
-    client = ImpitHttpClient(max_retries=1)
+    client = http_client_class(max_retries=1)
 
     with pytest.raises(expected_cls) as exc:
         client.call(method='GET', url=str(httpserver.url_for('/dispatch_all')))
@@ -258,10 +282,12 @@ def test_apify_api_error_subclass_constructed_directly_keeps_its_class() -> None
     assert error.type == 'record-not-found'
 
 
-def test_apify_api_error_falls_back_for_unparsable_body(httpserver: HTTPServer) -> None:
+def test_apify_api_error_falls_back_for_unparsable_body(
+    httpserver: HTTPServer, http_client_class: type[HttpClient]
+) -> None:
     """When the body can't be parsed, status-based dispatch still applies and `.type` is None."""
     httpserver.expect_request('/unparsable').respond_with_data('<not json>', status=418, content_type='text/html')
-    client = ImpitHttpClient(max_retries=1)
+    client = http_client_class(max_retries=1)
 
     with pytest.raises(ApifyApiError) as exc:
         client.call(method='GET', url=str(httpserver.url_for('/unparsable')))

--- a/tests/unit/test_client_headers.py
+++ b/tests/unit/test_client_headers.py
@@ -8,10 +8,10 @@ from typing import TYPE_CHECKING
 
 from werkzeug import Request, Response
 
-from apify_client.http_clients import ImpitHttpClient, ImpitHttpClientAsync
-
 if TYPE_CHECKING:
     from pytest_httpserver import HTTPServer
+
+    from apify_client.http_clients import HttpClient, HttpClientAsync
 
 
 def _parse_accept_encoding(header: str) -> set[str]:
@@ -34,9 +34,9 @@ def _get_user_agent() -> str:
     return f'ApifyClient/{client_version} ({sys.platform}; Python/{python_version}); isAtHome/{is_at_home}'
 
 
-async def test_default_headers_async(httpserver: HTTPServer) -> None:
+async def test_default_headers_async(httpserver: HTTPServer, http_client_async_class: type[HttpClientAsync]) -> None:
     """Test that default headers are sent with each request."""
-    client = ImpitHttpClientAsync(token='placeholder_token')
+    client = http_client_async_class(token='placeholder_token')
     httpserver.expect_request('/').respond_with_handler(_header_handler)
     api_url = httpserver.url_for('/').removesuffix('/')
 
@@ -54,9 +54,9 @@ async def test_default_headers_async(httpserver: HTTPServer) -> None:
     assert _parse_accept_encoding(request_headers['Accept-Encoding']) == {'gzip', 'br', 'zstd', 'deflate'}
 
 
-def test_default_headers_sync(httpserver: HTTPServer) -> None:
+def test_default_headers_sync(httpserver: HTTPServer, http_client_class: type[HttpClient]) -> None:
     """Test that default headers are sent with each request."""
-    client = ImpitHttpClient(token='placeholder_token')
+    client = http_client_class(token='placeholder_token')
     httpserver.expect_request('/').respond_with_handler(_header_handler)
     api_url = httpserver.url_for('/').removesuffix('/')
 
@@ -74,9 +74,9 @@ def test_default_headers_sync(httpserver: HTTPServer) -> None:
     assert _parse_accept_encoding(request_headers['Accept-Encoding']) == {'gzip', 'br', 'zstd', 'deflate'}
 
 
-async def test_headers_async(httpserver: HTTPServer) -> None:
+async def test_headers_async(httpserver: HTTPServer, http_client_async_class: type[HttpClientAsync]) -> None:
     """Test that custom headers are sent with each request."""
-    client = ImpitHttpClientAsync(
+    client = http_client_async_class(
         token='placeholder_token',
         headers={'Test-Header': 'blah', 'User-Agent': 'CustomUserAgent/1.0', 'Authorization': 'strange_value'},
     )
@@ -98,9 +98,9 @@ async def test_headers_async(httpserver: HTTPServer) -> None:
     assert _parse_accept_encoding(request_headers['Accept-Encoding']) == {'gzip', 'br', 'zstd', 'deflate'}
 
 
-def test_headers_sync(httpserver: HTTPServer) -> None:
+def test_headers_sync(httpserver: HTTPServer, http_client_class: type[HttpClient]) -> None:
     """Test that custom headers are sent with each request."""
-    client = ImpitHttpClient(
+    client = http_client_class(
         token='placeholder_token',
         headers={
             'Test-Header': 'blah',
@@ -126,9 +126,11 @@ def test_headers_sync(httpserver: HTTPServer) -> None:
     assert _parse_accept_encoding(request_headers['Accept-Encoding']) == {'gzip', 'br', 'zstd', 'deflate'}
 
 
-async def test_per_request_headers_override_defaults_async(httpserver: HTTPServer) -> None:
+async def test_per_request_headers_override_defaults_async(
+    httpserver: HTTPServer, http_client_async_class: type[HttpClientAsync]
+) -> None:
     """Test that a per-request header overrides a same-named default header on the wire, without duplication."""
-    client = ImpitHttpClientAsync(token='placeholder_token')
+    client = http_client_async_class(token='placeholder_token')
     httpserver.expect_request('/').respond_with_handler(_header_handler)
     api_url = httpserver.url_for('/').removesuffix('/')
 
@@ -141,9 +143,11 @@ async def test_per_request_headers_override_defaults_async(httpserver: HTTPServe
     assert request_headers['Authorization'] == 'Bearer per-request'
 
 
-def test_per_request_headers_override_defaults_sync(httpserver: HTTPServer) -> None:
+def test_per_request_headers_override_defaults_sync(
+    httpserver: HTTPServer, http_client_class: type[HttpClient]
+) -> None:
     """Test that a per-request header overrides a same-named default header on the wire, without duplication."""
-    client = ImpitHttpClient(token='placeholder_token')
+    client = http_client_class(token='placeholder_token')
     httpserver.expect_request('/').respond_with_handler(_header_handler)
     api_url = httpserver.url_for('/').removesuffix('/')
 

--- a/tests/unit/test_client_streaming.py
+++ b/tests/unit/test_client_streaming.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from apify_client import ApifyClient, ApifyClientAsync
+from apify_client.http_clients import HttpResponse
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from pytest_httpserver import HTTPServer
+
+    from apify_client.http_clients import HttpClient, HttpClientAsync
+
+
+DATASET_ID = 'test-dataset-id'
+KVS_ID = 'test-kvs-id'
+RECORD_KEY = 'test-record-key'
+STREAM_CONTENT = b'[{"id": 1}]'
+
+
+def test_dataset_stream_items_sync(
+    httpserver: HTTPServer,
+    http_client_class: type[HttpClient],
+) -> None:
+    """Dataset streams expose a transport-independent response that can be read synchronously."""
+    httpserver.expect_request(f'/v2/datasets/{DATASET_ID}/items').respond_with_data(STREAM_CONTENT)
+    api_url = httpserver.url_for('/').removesuffix('/')
+    client = ApifyClient.with_custom_http_client(
+        api_url=api_url,
+        http_client=http_client_class(),
+    )
+
+    with client.dataset(DATASET_ID).stream_items(item_format='json') as response:
+        assert isinstance(response, HttpResponse)
+        assert response.read() == STREAM_CONTENT
+
+
+async def test_dataset_stream_items_async(
+    httpserver: HTTPServer,
+    http_client_async_class: type[HttpClientAsync],
+) -> None:
+    """Dataset streams expose a transport-independent response that can be read asynchronously."""
+    httpserver.expect_request(f'/v2/datasets/{DATASET_ID}/items').respond_with_data(STREAM_CONTENT)
+    api_url = httpserver.url_for('/').removesuffix('/')
+    client = ApifyClientAsync.with_custom_http_client(
+        api_url=api_url,
+        http_client=http_client_async_class(),
+    )
+
+    async with client.dataset(DATASET_ID).stream_items(item_format='json') as response:
+        assert isinstance(response, HttpResponse)
+        assert await response.aread() == STREAM_CONTENT
+
+
+def test_key_value_store_stream_record_sync(
+    httpserver: HTTPServer,
+    http_client_class: type[HttpClient],
+) -> None:
+    """KVS streams require reading the generic response before consuming its content."""
+    httpserver.expect_request(f'/v2/key-value-stores/{KVS_ID}/records/{RECORD_KEY}').respond_with_data(STREAM_CONTENT)
+    api_url = httpserver.url_for('/').removesuffix('/')
+    client = ApifyClient.with_custom_http_client(
+        api_url=api_url,
+        http_client=http_client_class(),
+    )
+
+    with client.key_value_store(KVS_ID).stream_record(RECORD_KEY) as record:
+        assert isinstance(record, dict)
+        response = record['value']
+        assert isinstance(response, HttpResponse)
+        assert response.read() == STREAM_CONTENT
+
+
+async def test_key_value_store_stream_record_async(
+    httpserver: HTTPServer,
+    http_client_async_class: type[HttpClientAsync],
+) -> None:
+    """KVS streams require asynchronously reading the generic response before consuming its content."""
+    httpserver.expect_request(f'/v2/key-value-stores/{KVS_ID}/records/{RECORD_KEY}').respond_with_data(STREAM_CONTENT)
+    api_url = httpserver.url_for('/').removesuffix('/')
+    client = ApifyClientAsync.with_custom_http_client(
+        api_url=api_url,
+        http_client=http_client_async_class(),
+    )
+
+    async with client.key_value_store(KVS_ID).stream_record(RECORD_KEY) as record:
+        assert isinstance(record, dict)
+        response = record['value']
+        assert isinstance(response, HttpResponse)
+        assert await response.aread() == STREAM_CONTENT
+
+
+def test_protocol_check_leaves_stream_unread_sync(
+    httpserver: HTTPServer,
+    http_client_class: type[HttpClient],
+) -> None:
+    """Checking a streaming response against the protocol inspects it without pulling the body off the wire."""
+    httpserver.expect_request(f'/v2/datasets/{DATASET_ID}/items').respond_with_data(STREAM_CONTENT)
+    api_url = httpserver.url_for('/').removesuffix('/')
+    client = ApifyClient.with_custom_http_client(
+        api_url=api_url,
+        http_client=http_client_class(),
+    )
+
+    with client.dataset(DATASET_ID).stream_items(item_format='json') as response:
+        assert isinstance(response, HttpResponse)
+        # `is_stream_consumed` is transport state, not part of the protocol, but the built-in client exposes it.
+        raw: Any = response
+        assert raw.is_stream_consumed is False
+
+
+async def test_protocol_check_leaves_stream_unread_async(
+    httpserver: HTTPServer,
+    http_client_async_class: type[HttpClientAsync],
+) -> None:
+    """Checking a streaming response against the protocol inspects it without pulling the body off the wire."""
+    httpserver.expect_request(f'/v2/datasets/{DATASET_ID}/items').respond_with_data(STREAM_CONTENT)
+    api_url = httpserver.url_for('/').removesuffix('/')
+    client = ApifyClientAsync.with_custom_http_client(
+        api_url=api_url,
+        http_client=http_client_async_class(),
+    )
+
+    async with client.dataset(DATASET_ID).stream_items(item_format='json') as response:
+        assert isinstance(response, HttpResponse)
+        # `is_stream_consumed` is transport state, not part of the protocol, but the built-in client exposes it.
+        raw: Any = response
+        assert raw.is_stream_consumed is False

--- a/tests/unit/test_client_timeouts.py
+++ b/tests/unit/test_client_timeouts.py
@@ -3,40 +3,17 @@ from __future__ import annotations
 import logging
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
+import impit
 import pytest
-from impit import HTTPError, Response, TimeoutException
 
 from apify_client._logging import LoggerOnce, logger_name
-from apify_client.http_clients import ImpitHttpClient, ImpitHttpClientAsync
+from apify_client.http_clients import HttpClient, HttpClientAsync, ImpitHttpClient, ImpitHttpClientAsync
 from apify_client.http_clients import _base as http_client_base
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-
     from _pytest.logging import LogCaptureFixture
-
-
-class EndOfTestError(Exception):
-    """Custom exception that is raised after the relevant part of the code is executed to stop the test."""
-
-
-@pytest.fixture
-def patch_request(monkeypatch: pytest.MonkeyPatch) -> Iterator[list]:
-    timeouts = []
-
-    def mock_request(*_args: Any, **kwargs: Any) -> None:
-        timeouts.append(kwargs.get('timeout'))
-        raise EndOfTestError
-
-    async def mock_request_async(*args: Any, **kwargs: Any) -> None:
-        return mock_request(*args, **kwargs)
-
-    monkeypatch.setattr('impit.Client.request', mock_request)
-    monkeypatch.setattr('impit.AsyncClient.request', mock_request_async)
-    yield timeouts
-    monkeypatch.undo()
 
 
 @pytest.fixture
@@ -45,125 +22,93 @@ def fresh_logger_once(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(http_client_base, 'logger_once', LoggerOnce(http_client_base.logger))
 
 
-def test_no_timeout_passes_large_value_to_impit_sync(patch_request: list) -> None:
-    """Test that `no_timeout` passes a large timeout to impit to effectively disable the timeout."""
-    client = ImpitHttpClient(timeout_short=timedelta(seconds=10))
-
-    with pytest.raises(EndOfTestError):
-        client.call(method='GET', url='http://placeholder.url/no_timeout', timeout='no_timeout')
-
-    assert patch_request == [86_400]
+def successful_response() -> Mock:
+    return Mock(status_code=200)
 
 
-async def test_no_timeout_passes_large_value_to_impit_async(patch_request: list) -> None:
-    """Test that `no_timeout` passes a large timeout to impit to effectively disable the timeout."""
-    client = ImpitHttpClientAsync(timeout_short=timedelta(seconds=10))
+@pytest.mark.parametrize(
+    ('timeout', 'expected'),
+    [
+        pytest.param('no_timeout', None, id='no-timeout'),
+        pytest.param(None, 30.0, id='default-medium'),
+        pytest.param('short', 5.0, id='short'),
+        pytest.param('medium', 30.0, id='medium'),
+        pytest.param('long', 300.0, id='long'),
+    ],
+)
+def test_timeout_resolves_for_sync_clients(
+    http_client_class: type[HttpClient],
+    monkeypatch: pytest.MonkeyPatch,
+    timeout: str | None,
+    expected: float | None,
+) -> None:
+    """Every synchronous client resolves timeout tiers at the shared transport boundary."""
+    client = http_client_class(
+        timeout_short=timedelta(seconds=5),
+        timeout_medium=timedelta(seconds=30),
+        timeout_long=timedelta(seconds=300),
+    )
+    send_request = Mock(return_value=successful_response())
+    monkeypatch.setattr(client, 'send_request', send_request)
 
-    with pytest.raises(EndOfTestError):
-        await client.call(method='GET', url='http://placeholder.url/no_timeout', timeout='no_timeout')
+    kwargs: dict[str, Any] = {'method': 'GET', 'url': 'https://example.com'}
+    if timeout is not None:
+        kwargs['timeout'] = timeout
+    client.call(**kwargs)
 
-    assert patch_request == [86_400]
-
-
-def test_default_timeout_uses_medium_tier_sync(patch_request: list) -> None:
-    """Test that omitting timeout uses the 'medium' tier (sync client)."""
-    client = ImpitHttpClient(timeout_medium=timedelta(seconds=30))
-
-    with pytest.raises(EndOfTestError):
-        client.call(method='GET', url='http://placeholder.url/default_timeout')
-
-    assert patch_request == [30.0]
-
-
-async def test_default_timeout_uses_medium_tier_async(patch_request: list) -> None:
-    """Test that omitting timeout uses the 'medium' tier (async client)."""
-    client = ImpitHttpClientAsync(timeout_medium=timedelta(seconds=30))
-
-    with pytest.raises(EndOfTestError):
-        await client.call(method='GET', url='http://placeholder.url/default_timeout')
-
-    assert patch_request == [30.0]
-
-
-def test_short_tier_resolves_correctly_sync(patch_request: list) -> None:
-    """Test that `'short'` tier resolves to timeout_short value."""
-    client = ImpitHttpClient(timeout_short=timedelta(seconds=5))
-
-    with pytest.raises(EndOfTestError):
-        client.call(method='GET', url='http://placeholder.url/short_tier', timeout='short')
-
-    assert patch_request == [5.0]
+    assert send_request.call_args.kwargs['timeout'] == expected
 
 
-def test_medium_tier_resolves_correctly_sync(patch_request: list) -> None:
-    """Test that `'medium'` tier resolves to the configured timeout value."""
-    client = ImpitHttpClient(timeout_medium=timedelta(seconds=30))
+@pytest.mark.parametrize(
+    ('timeout', 'expected'),
+    [
+        pytest.param('no_timeout', None, id='no-timeout'),
+        pytest.param(None, 30.0, id='default-medium'),
+        pytest.param('short', 5.0, id='short'),
+        pytest.param('medium', 30.0, id='medium'),
+        pytest.param('long', 300.0, id='long'),
+    ],
+)
+async def test_timeout_resolves_for_async_clients(
+    http_client_async_class: type[HttpClientAsync],
+    monkeypatch: pytest.MonkeyPatch,
+    timeout: str | None,
+    expected: float | None,
+) -> None:
+    """Every asynchronous client resolves timeout tiers at the shared transport boundary."""
+    client = http_client_async_class(
+        timeout_short=timedelta(seconds=5),
+        timeout_medium=timedelta(seconds=30),
+        timeout_long=timedelta(seconds=300),
+    )
+    send_request = AsyncMock(return_value=successful_response())
+    monkeypatch.setattr(client, 'send_request', send_request)
 
-    with pytest.raises(EndOfTestError):
-        client.call(method='GET', url='http://placeholder.url/timeout_tier', timeout='medium')
+    kwargs: dict[str, Any] = {'method': 'GET', 'url': 'https://example.com'}
+    if timeout is not None:
+        kwargs['timeout'] = timeout
+    await client.call(**kwargs)
 
-    assert patch_request == [30.0]
-
-
-def test_long_tier_resolves_correctly_sync(patch_request: list) -> None:
-    """Test that `'long'` tier resolves to timeout_long value."""
-    client = ImpitHttpClient(timeout_long=timedelta(seconds=300))
-
-    with pytest.raises(EndOfTestError):
-        client.call(method='GET', url='http://placeholder.url/long_tier', timeout='long')
-
-    assert patch_request == [300.0]
-
-
-async def test_medium_tier_resolves_correctly_async(patch_request: list) -> None:
-    """Test that `'medium'` tier resolves to the configured timeout value (async)."""
-    client = ImpitHttpClientAsync(timeout_medium=timedelta(seconds=30))
-
-    with pytest.raises(EndOfTestError):
-        await client.call(method='GET', url='http://placeholder.url/timeout_tier', timeout='medium')
-
-    assert patch_request == [30.0]
-
-
-async def test_long_tier_resolves_correctly_async(patch_request: list) -> None:
-    """Test that `'long'` tier resolves to timeout_long value (async)."""
-    client = ImpitHttpClientAsync(timeout_long=timedelta(seconds=300))
-
-    with pytest.raises(EndOfTestError):
-        await client.call(method='GET', url='http://placeholder.url/long_tier', timeout='long')
-
-    assert patch_request == [300.0]
+    assert send_request.call_args.kwargs['timeout'] == expected
 
 
-def test_compute_timeout_with_timedelta() -> None:
-    """Test _compute_timeout with a concrete timedelta doubles per attempt, capped at max."""
-    client = ImpitHttpClient(timeout_max=timedelta(seconds=600))
+def test_compute_timeout_with_timedelta(http_client_class: type[HttpClient]) -> None:
+    """Concrete timedeltas double per attempt and are capped at the configured maximum."""
+    client = http_client_class(timeout_max=timedelta(seconds=20))
 
     assert client._compute_timeout(timedelta(seconds=5), attempt=1) == 5.0
     assert client._compute_timeout(timedelta(seconds=5), attempt=2) == 10.0
     assert client._compute_timeout(timedelta(seconds=5), attempt=3) == 20.0
-    assert client._compute_timeout(timedelta(seconds=5), attempt=4) == 40.0
-
-
-def test_compute_timeout_caps_at_max() -> None:
-    """Test _compute_timeout caps at timeout_max."""
-    client = ImpitHttpClient(timeout_max=timedelta(seconds=10))
-
-    assert client._compute_timeout(timedelta(seconds=5), attempt=1) == 5.0
-    assert client._compute_timeout(timedelta(seconds=5), attempt=2) == 10.0
-    assert client._compute_timeout(timedelta(seconds=5), attempt=3) == 10.0  # capped
-
-
-def test_compute_timeout_no_timeout_returns_none() -> None:
-    """Test _compute_timeout with 'no_timeout' returns None."""
-    client = ImpitHttpClient()
+    assert client._compute_timeout(timedelta(seconds=5), attempt=4) == 20.0
     assert client._compute_timeout('no_timeout', attempt=1) is None
 
 
 @pytest.mark.usefixtures('fresh_logger_once')
-def test_compute_timeout_explicit_timedelta_above_max_warns(caplog: LogCaptureFixture) -> None:
-    """Test an explicit timedelta larger than timeout_max is capped, and the cut-off is logged once."""
-    client = ImpitHttpClient(timeout_max=timedelta(seconds=360))
+def test_compute_timeout_explicit_timedelta_above_max_warns(
+    http_client_class: type[HttpClient], caplog: LogCaptureFixture
+) -> None:
+    """An explicit timedelta larger than timeout_max is capped, and the cut-off is logged once."""
+    client = http_client_class(timeout_max=timedelta(seconds=360))
 
     with caplog.at_level(logging.WARNING, logger=logger_name):
         assert client._compute_timeout(timedelta(minutes=30), attempt=1) == 360.0
@@ -176,9 +121,9 @@ def test_compute_timeout_explicit_timedelta_above_max_warns(caplog: LogCaptureFi
 
 
 @pytest.mark.usefixtures('fresh_logger_once')
-def test_compute_timeout_tier_above_max_warns(caplog: LogCaptureFixture) -> None:
-    """Test a tier configured larger than timeout_max is capped, and the cut-off is logged too."""
-    client = ImpitHttpClient(timeout_long=timedelta(seconds=600), timeout_max=timedelta(seconds=360))
+def test_compute_timeout_tier_above_max_warns(http_client_class: type[HttpClient], caplog: LogCaptureFixture) -> None:
+    """A tier configured larger than timeout_max is capped, and the cut-off is logged too."""
+    client = http_client_class(timeout_long=timedelta(seconds=600), timeout_max=timedelta(seconds=360))
 
     with caplog.at_level(logging.WARNING, logger=logger_name):
         assert client._compute_timeout('long', attempt=1) == 360.0
@@ -188,9 +133,11 @@ def test_compute_timeout_tier_above_max_warns(caplog: LogCaptureFixture) -> None
 
 
 @pytest.mark.usefixtures('fresh_logger_once')
-def test_compute_timeout_within_max_does_not_warn(caplog: LogCaptureFixture) -> None:
-    """Test a base timeout within timeout_max is used as-is, without a warning."""
-    client = ImpitHttpClient(timeout_long=timedelta(seconds=300), timeout_max=timedelta(seconds=360))
+def test_compute_timeout_within_max_does_not_warn(
+    http_client_class: type[HttpClient], caplog: LogCaptureFixture
+) -> None:
+    """A base timeout within timeout_max is used as-is, without a warning."""
+    client = http_client_class(timeout_long=timedelta(seconds=300), timeout_max=timedelta(seconds=360))
 
     with caplog.at_level(logging.WARNING, logger=logger_name):
         assert client._compute_timeout(timedelta(seconds=120), attempt=1) == 120.0
@@ -201,103 +148,71 @@ def test_compute_timeout_within_max_does_not_warn(caplog: LogCaptureFixture) -> 
     assert caplog.records == []
 
 
-async def test_dynamic_timeout_async_client(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Tests timeout values for request with retriable errors.
+def test_dynamic_timeout_sync_client(http_client_class: type[HttpClient], monkeypatch: pytest.MonkeyPatch) -> None:
+    """Synchronous clients increase timeout values after retryable transport errors."""
+    client = http_client_class(
+        timeout_short=timedelta(seconds=1),
+        timeout_max=timedelta(seconds=5),
+        min_delay_between_retries=timedelta(0),
+    )
+    timeouts: list[float | None] = []
 
-    Values should increase with each attempt, starting from initial call value and bounded by timeout_max.
-    """
-    should_raise_error = iter((True, True, True, False))
-    call_timeout = 1
-    timeout_max = 5
-    expected_timeouts = [call_timeout, 2, 4, timeout_max]
-    retry_counter_mock = Mock()
+    def send_request(*_args: Any, **kwargs: Any) -> Mock:
+        timeouts.append(kwargs['timeout'])
+        if len(timeouts) < 4:
+            raise impit.TimeoutException('timeout')
+        return successful_response()
 
-    timeouts = []
+    monkeypatch.setattr(client, 'send_request', send_request)
 
-    async def mock_request(*_args: Any, **kwargs: Any) -> Response:
-        timeouts.append(kwargs.get('timeout'))
-        retry_counter_mock()
-        should_raise = next(should_raise_error)
-        if should_raise:
-            raise TimeoutException
+    response = client.call(method='GET', url='https://example.com', timeout=timedelta(seconds=1))
 
-        return Response(status_code=200)
-
-    monkeypatch.setattr('impit.AsyncClient.request', mock_request)
-
-    response = await ImpitHttpClientAsync(
-        timeout_short=timedelta(seconds=call_timeout),
-        timeout_max=timedelta(seconds=timeout_max),
-    ).call(method='GET', url='http://placeholder.url/async_timeout', timeout=timedelta(seconds=call_timeout))
-
-    # Check that the retry counter was called the expected number of times
-    # (4 times: 3 retries + 1 final successful call)
-    assert retry_counter_mock.call_count == 4
-    assert timeouts == expected_timeouts
-    # Check that the response is successful
+    assert timeouts == [1.0, 2.0, 4.0, 5.0]
     assert response.status_code == 200
 
 
-async def test_retry_on_http_error_async_client(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Tests that bare impit.HTTPError (e.g. body decode errors) are retried.
+async def test_dynamic_timeout_async_client(
+    http_client_async_class: type[HttpClientAsync], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Asynchronous clients increase timeout values after retryable transport errors."""
+    client = http_client_async_class(
+        timeout_short=timedelta(seconds=1),
+        timeout_max=timedelta(seconds=5),
+        min_delay_between_retries=timedelta(0),
+    )
+    timeouts: list[float | None] = []
 
-    This reproduces the scenario where the HTTP response body is truncated mid-stream
-    (e.g. "unexpected EOF during chunk size line"), which impit raises as a generic HTTPError.
-    """
-    should_raise_error = iter((True, True, False))
-    retry_counter_mock = Mock()
+    async def send_request(*_args: Any, **kwargs: Any) -> Mock:
+        timeouts.append(kwargs['timeout'])
+        if len(timeouts) < 4:
+            raise impit.TimeoutException('timeout')
+        return successful_response()
 
-    async def mock_request(*_args: Any, **_kwargs: Any) -> Response:
-        retry_counter_mock()
-        should_raise = next(should_raise_error)
-        if should_raise:
-            raise HTTPError('The internal HTTP library has thrown an error: unexpected EOF during chunk size line')
+    monkeypatch.setattr(client, 'send_request', send_request)
 
-        return Response(status_code=200)
+    response = await client.call(method='GET', url='https://example.com', timeout=timedelta(seconds=1))
 
-    monkeypatch.setattr('impit.AsyncClient.request', mock_request)
+    assert timeouts == [1.0, 2.0, 4.0, 5.0]
+    assert response.status_code == 200
 
-    response = await ImpitHttpClientAsync(timeout_short=timedelta(seconds=5)).call(
-        method='GET', url='http://placeholder.url/http_error'
+
+def test_no_timeout_mapping_for_sync_adapter() -> None:
+    """The synchronous adapter maps no-timeout to Impit's effectively unbounded value."""
+    client = ImpitHttpClient()
+    client._impit_client = Mock(request=Mock(return_value=successful_response()))
+
+    client.send_request(method='GET', url='https://example.com', headers={}, content=None, timeout=None, stream=False)
+
+    assert client._impit_client.request.call_args.kwargs['timeout'] == 86_400
+
+
+async def test_no_timeout_mapping_for_async_adapter() -> None:
+    """The asynchronous adapter maps no-timeout to Impit's effectively unbounded value."""
+    client = ImpitHttpClientAsync()
+    client._impit_async_client = Mock(request=AsyncMock(return_value=successful_response()))
+
+    await client.send_request(
+        method='GET', url='https://example.com', headers={}, content=None, timeout=None, stream=False
     )
 
-    # 3 attempts: 2 failures + 1 success
-    assert retry_counter_mock.call_count == 3
-    assert response.status_code == 200
-
-
-def test_dynamic_timeout_sync_client(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Tests timeout values for request with retriable errors.
-
-    Values should increase with each attempt, starting from initial call value and bounded by timeout_max.
-    """
-    should_raise_error = iter((True, True, True, False))
-    call_timeout = 1
-    timeout_max = 5
-    expected_timeouts = [call_timeout, 2, 4, timeout_max]
-    retry_counter_mock = Mock()
-
-    timeouts = []
-
-    def mock_request(*_args: Any, **kwargs: Any) -> Response:
-        timeouts.append(kwargs.get('timeout'))
-        retry_counter_mock()
-        should_raise = next(should_raise_error)
-        if should_raise:
-            raise TimeoutException
-
-        return Response(status_code=200)
-
-    monkeypatch.setattr('impit.Client.request', mock_request)
-
-    response = ImpitHttpClient(
-        timeout_short=timedelta(seconds=call_timeout),
-        timeout_max=timedelta(seconds=timeout_max),
-    ).call(method='GET', url='http://placeholder.url/sync_timeout', timeout=timedelta(seconds=call_timeout))
-
-    # Check that the retry counter was called the expected number of times
-    # (4 times: 3 retries + 1 final successful call)
-    assert retry_counter_mock.call_count == 4
-    assert timeouts == expected_timeouts
-    # Check that the response is successful
-    assert response.status_code == 200
+    assert client._impit_async_client.request.call_args.kwargs['timeout'] == 86_400

--- a/tests/unit/test_http_client_regressions.py
+++ b/tests/unit/test_http_client_regressions.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, Mock
+
+import impit
+import pytest
+
+from apify_client.http_clients import ImpitHttpClient, ImpitHttpClientAsync
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+
+def successful_response() -> Mock:
+    return Mock(status_code=200)
+
+
+def test_generic_http_error_is_retried(monkeypatch: MonkeyPatch) -> None:
+    """A bare Impit HTTPError from a truncated body remains retryable (regression coverage)."""
+    client = ImpitHttpClient(min_delay_between_retries=timedelta(0))
+    send_request = Mock(
+        side_effect=[impit.HTTPError('unexpected EOF'), impit.HTTPError('unexpected EOF'), successful_response()]
+    )
+    monkeypatch.setattr(client, 'send_request', send_request)
+
+    response = client.call(method='GET', url='https://example.com')
+
+    assert response.status_code == 200
+    assert send_request.call_count == 3
+
+
+async def test_generic_http_error_is_retried_async(monkeypatch: MonkeyPatch) -> None:
+    """The async Impit adapter retains the same generic HTTPError retry regression coverage."""
+    client = ImpitHttpClientAsync(min_delay_between_retries=timedelta(0))
+    send_request = AsyncMock(
+        side_effect=[impit.HTTPError('unexpected EOF'), impit.HTTPError('unexpected EOF'), successful_response()]
+    )
+    monkeypatch.setattr(client, 'send_request', send_request)
+
+    response = await client.call(method='GET', url='https://example.com')
+
+    assert response.status_code == 200
+    assert send_request.call_count == 3
+
+
+def test_permanent_transport_error_is_not_retried(monkeypatch: MonkeyPatch) -> None:
+    """A transport error a retry cannot fix must fail on the first attempt instead of burning the whole backoff."""
+    client = ImpitHttpClient(min_delay_between_retries=timedelta(0))
+    send_request = Mock(side_effect=impit.UnsupportedProtocol('unsupported scheme'))
+    monkeypatch.setattr(client, 'send_request', send_request)
+
+    with pytest.raises(impit.UnsupportedProtocol):
+        client.call(method='GET', url='https://example.com')
+
+    assert send_request.call_count == 1
+
+
+def test_error_response_read_failure_uses_transport_retry_policy(monkeypatch: MonkeyPatch) -> None:
+    """Failures while reading a streamed 5xx error body are classified and retried like send failures."""
+    client = ImpitHttpClient(max_retries=1, min_delay_between_retries=timedelta(0))
+    responses = [Mock(status_code=500, read=Mock(side_effect=impit.ReadError('truncated'))) for _ in range(2)]
+    send_request = Mock(side_effect=responses)
+    monkeypatch.setattr(client, 'send_request', send_request)
+
+    with pytest.raises(impit.ReadError):
+        client.call(method='GET', url='https://example.com', stream=True)
+
+    assert send_request.call_count == 2
+
+
+async def test_error_response_read_failure_uses_transport_retry_policy_async(monkeypatch: MonkeyPatch) -> None:
+    """The async base also classifies failures while buffering streamed error responses."""
+    client = ImpitHttpClientAsync(max_retries=1, min_delay_between_retries=timedelta(0))
+    responses = [Mock(status_code=500, aread=AsyncMock(side_effect=impit.ReadError('truncated'))) for _ in range(2)]
+    send_request = AsyncMock(side_effect=responses)
+    monkeypatch.setattr(client, 'send_request', send_request)
+
+    with pytest.raises(impit.ReadError):
+        await client.call(method='GET', url='https://example.com', stream=True)
+
+    assert send_request.call_count == 2

--- a/tests/unit/test_http_client_regressions.py
+++ b/tests/unit/test_http_client_regressions.py
@@ -18,7 +18,7 @@ def successful_response() -> Mock:
 
 
 def test_generic_http_error_is_retried(monkeypatch: MonkeyPatch) -> None:
-    """A bare Impit HTTPError from a truncated body remains retryable (regression coverage)."""
+    """A bare Impit HTTPError from a truncated body remains retryable."""
     client = ImpitHttpClient(min_delay_between_retries=timedelta(0))
     send_request = Mock(
         side_effect=[impit.HTTPError('unexpected EOF'), impit.HTTPError('unexpected EOF'), successful_response()]
@@ -32,7 +32,7 @@ def test_generic_http_error_is_retried(monkeypatch: MonkeyPatch) -> None:
 
 
 async def test_generic_http_error_is_retried_async(monkeypatch: MonkeyPatch) -> None:
-    """The async Impit adapter retains the same generic HTTPError retry regression coverage."""
+    """The async Impit adapter treats a bare HTTPError from a truncated body the same way."""
     client = ImpitHttpClientAsync(min_delay_between_retries=timedelta(0))
     send_request = AsyncMock(
         side_effect=[impit.HTTPError('unexpected EOF'), impit.HTTPError('unexpected EOF'), successful_response()]
@@ -60,7 +60,9 @@ def test_permanent_transport_error_is_not_retried(monkeypatch: MonkeyPatch) -> N
 def test_error_response_read_failure_uses_transport_retry_policy(monkeypatch: MonkeyPatch) -> None:
     """Failures while reading a streamed 5xx error body are classified and retried like send failures."""
     client = ImpitHttpClient(max_retries=1, min_delay_between_retries=timedelta(0))
-    responses = [Mock(status_code=500, read=Mock(side_effect=impit.ReadError('truncated'))) for _ in range(2)]
+    responses = [
+        Mock(status_code=500, read=Mock(side_effect=impit.ReadError('truncated')), close=Mock()) for _ in range(2)
+    ]
     send_request = Mock(side_effect=responses)
     monkeypatch.setattr(client, 'send_request', send_request)
 
@@ -68,12 +70,17 @@ def test_error_response_read_failure_uses_transport_retry_policy(monkeypatch: Mo
         client.call(method='GET', url='https://example.com', stream=True)
 
     assert send_request.call_count == 2
+    for response in responses:
+        response.close.assert_called_once()
 
 
 async def test_error_response_read_failure_uses_transport_retry_policy_async(monkeypatch: MonkeyPatch) -> None:
     """The async base also classifies failures while buffering streamed error responses."""
     client = ImpitHttpClientAsync(max_retries=1, min_delay_between_retries=timedelta(0))
-    responses = [Mock(status_code=500, aread=AsyncMock(side_effect=impit.ReadError('truncated'))) for _ in range(2)]
+    responses = [
+        Mock(status_code=500, aread=AsyncMock(side_effect=impit.ReadError('truncated')), aclose=AsyncMock())
+        for _ in range(2)
+    ]
     send_request = AsyncMock(side_effect=responses)
     monkeypatch.setattr(client, 'send_request', send_request)
 
@@ -81,3 +88,5 @@ async def test_error_response_read_failure_uses_transport_retry_policy_async(mon
         await client.call(method='GET', url='https://example.com', stream=True)
 
     assert send_request.call_count == 2
+    for response in responses:
+        response.aclose.assert_awaited_once()

--- a/tests/unit/test_http_clients.py
+++ b/tests/unit/test_http_clients.py
@@ -39,10 +39,6 @@ class ConcreteHttpClient(HttpClient):
     """Minimal concrete HttpClient for testing base class helpers, relying on the hook defaults."""
 
 
-class ConcreteHttpClientAsync(HttpClientAsync):
-    """Minimal concrete HttpClientAsync for testing base class helpers, relying on the hook defaults."""
-
-
 class CallOnlyHttpClient(HttpClient):
     """Custom client written against the pre-hook contract, overriding `call` and nothing else."""
 
@@ -74,29 +70,6 @@ async def test_call_only_http_client_async_keeps_working() -> None:
         assert response.status_code == 200
         assert client.is_timeout_error(TimeoutError('test'))
         assert not client.is_retryable_transport_error(TimeoutError('test'))
-
-
-@pytest.mark.parametrize(
-    ('client_class', 'overridden_methods'),
-    [
-        pytest.param(
-            ImpitHttpClient,
-            ('__init__', 'close', 'is_timeout_error', 'is_retryable_transport_error', 'send_request'),
-            id='impit-sync',
-        ),
-        pytest.param(
-            ImpitHttpClientAsync,
-            ('__init__', 'aclose', 'is_timeout_error', 'is_retryable_transport_error', 'send_request'),
-            id='impit-async',
-        ),
-    ],
-)
-def test_builtin_http_client_transport_methods_are_explicit_overrides(
-    client_class: type[HttpClient | HttpClientAsync], overridden_methods: tuple[str, ...]
-) -> None:
-    """Every hook a built-in adapter implements carries `@override`, so a renamed hook fails type checking."""
-    for method_name in overridden_methods:
-        assert getattr(getattr(client_class, method_name), '__override__', False)
 
 
 def test_retry_with_exp_backoff(http_client_class: type[HttpClient]) -> None:

--- a/tests/unit/test_http_clients.py
+++ b/tests/unit/test_http_clients.py
@@ -17,8 +17,13 @@ import pytest
 from apify_client._consts import MIN_COMPRESSION_SIZE
 from apify_client._statistics import ClientStatistics
 from apify_client.errors import InvalidResponseBodyError
-from apify_client.http_clients import HttpClient, HttpClientAsync, HttpResponse, ImpitHttpClient, ImpitHttpClientAsync
-from apify_client.http_clients._impit import _is_retryable_error
+from apify_client.http_clients import (
+    HttpClient,
+    HttpClientAsync,
+    HttpResponse,
+    ImpitHttpClient,
+    ImpitHttpClientAsync,
+)
 from apify_client.http_compressors._base import HttpCompressor
 from apify_client.http_compressors._brotli import BrotliHttpCompressor
 from apify_client.http_compressors._gzip import GzipHttpCompressor
@@ -30,21 +35,71 @@ if TYPE_CHECKING:
     from apify_client.types import JsonSerializable
 
 
-class _ConcreteHttpClient(HttpClient):
-    """Minimal concrete HttpClient for testing base class helpers."""
-
-    def call(self, *, method: str, url: str, **kwargs: Any) -> HttpResponse:
-        raise NotImplementedError
+class ConcreteHttpClient(HttpClient):
+    """Minimal concrete HttpClient for testing base class helpers, relying on the hook defaults."""
 
 
-class _ConcreteHttpClientAsync(HttpClientAsync):
-    """Minimal concrete HttpClientAsync for testing base class helpers."""
-
-    async def call(self, *, method: str, url: str, **kwargs: Any) -> HttpResponse:
-        raise NotImplementedError
+class ConcreteHttpClientAsync(HttpClientAsync):
+    """Minimal concrete HttpClientAsync for testing base class helpers, relying on the hook defaults."""
 
 
-def test_retry_with_exp_backoff() -> None:
+class CallOnlyHttpClient(HttpClient):
+    """Custom client written against the pre-hook contract, overriding `call` and nothing else."""
+
+    def call(self, **kwargs: Any) -> HttpResponse:
+        _ = kwargs
+        return Mock(status_code=200)
+
+
+class CallOnlyHttpClientAsync(HttpClientAsync):
+    """Asynchronous counterpart of `CallOnlyHttpClient`."""
+
+    async def call(self, **kwargs: Any) -> HttpResponse:
+        _ = kwargs
+        return Mock(status_code=200)
+
+
+def test_call_only_http_client_keeps_working() -> None:
+    """A client that only overrides `call` still instantiates and inherits the hook defaults."""
+    with CallOnlyHttpClient() as client:
+        assert client.call(method='GET', url='https://example.com').status_code == 200
+        assert client.is_timeout_error(TimeoutError('test'))
+        assert not client.is_retryable_transport_error(TimeoutError('test'))
+
+
+async def test_call_only_http_client_async_keeps_working() -> None:
+    """The asynchronous base is equally tolerant of a client that only overrides `call`."""
+    async with CallOnlyHttpClientAsync() as client:
+        response = await client.call(method='GET', url='https://example.com')
+        assert response.status_code == 200
+        assert client.is_timeout_error(TimeoutError('test'))
+        assert not client.is_retryable_transport_error(TimeoutError('test'))
+
+
+@pytest.mark.parametrize(
+    ('client_class', 'overridden_methods'),
+    [
+        pytest.param(
+            ImpitHttpClient,
+            ('__init__', 'close', 'is_timeout_error', 'is_retryable_transport_error', 'send_request'),
+            id='impit-sync',
+        ),
+        pytest.param(
+            ImpitHttpClientAsync,
+            ('__init__', 'aclose', 'is_timeout_error', 'is_retryable_transport_error', 'send_request'),
+            id='impit-async',
+        ),
+    ],
+)
+def test_builtin_http_client_transport_methods_are_explicit_overrides(
+    client_class: type[HttpClient | HttpClientAsync], overridden_methods: tuple[str, ...]
+) -> None:
+    """Every hook a built-in adapter implements carries `@override`, so a renamed hook fails type checking."""
+    for method_name in overridden_methods:
+        assert getattr(getattr(client_class, method_name), '__override__', False)
+
+
+def test_retry_with_exp_backoff(http_client_class: type[HttpClient]) -> None:
     attempt_counter = 0
 
     class RetryableError(Exception):
@@ -73,7 +128,7 @@ def test_retry_with_exp_backoff() -> None:
 
     # Returns the correct result after the correct time (should take 100 + 200 + 400 + 800 = 1500 ms)
     start = time.time()
-    result = ImpitHttpClient._retry_with_exp_backoff(
+    result = http_client_class._retry_with_exp_backoff(
         returns_on_fifth_attempt, backoff_base=timedelta(milliseconds=100), backoff_factor=2, random_factor=0
     )
     elapsed_time_seconds = time.time() - start
@@ -85,7 +140,7 @@ def test_retry_with_exp_backoff() -> None:
     # Stops retrying when failed for max_retries times
     attempt_counter = 0
     with pytest.raises(RetryableError):
-        ImpitHttpClient._retry_with_exp_backoff(
+        http_client_class._retry_with_exp_backoff(
             returns_on_fifth_attempt, max_retries=3, backoff_base=timedelta(milliseconds=1)
         )
     assert attempt_counter == 4
@@ -93,11 +148,13 @@ def test_retry_with_exp_backoff() -> None:
     # Bails when the bail function is called
     attempt_counter = 0
     with pytest.raises(NonRetryableError):
-        ImpitHttpClient._retry_with_exp_backoff(bails_on_third_attempt, backoff_base=timedelta(milliseconds=1))
+        http_client_class._retry_with_exp_backoff(bails_on_third_attempt, backoff_base=timedelta(milliseconds=1))
     assert attempt_counter == 3
 
 
-async def test_retry_with_exp_backoff_async() -> None:
+async def test_retry_with_exp_backoff_async(
+    http_client_async_class: type[HttpClientAsync],
+) -> None:
     attempt_counter = 0
 
     class RetryableError(Exception):
@@ -126,7 +183,7 @@ async def test_retry_with_exp_backoff_async() -> None:
 
     # Returns the correct result after the correct time (should take 100 + 200 + 400 + 800 = 1500 ms)
     start = time.time()
-    result = await ImpitHttpClientAsync._retry_with_exp_backoff(
+    result = await http_client_async_class._retry_with_exp_backoff(
         returns_on_fifth_attempt, backoff_base=timedelta(milliseconds=100), backoff_factor=2, random_factor=0
     )
     elapsed_time_seconds = time.time() - start
@@ -138,7 +195,7 @@ async def test_retry_with_exp_backoff_async() -> None:
     # Stops retrying when failed for max_retries times
     attempt_counter = 0
     with pytest.raises(RetryableError):
-        await ImpitHttpClientAsync._retry_with_exp_backoff(
+        await http_client_async_class._retry_with_exp_backoff(
             returns_on_fifth_attempt, max_retries=3, backoff_base=timedelta(milliseconds=1)
         )
     assert attempt_counter == 4
@@ -146,7 +203,7 @@ async def test_retry_with_exp_backoff_async() -> None:
     # Bails when the bail function is called
     attempt_counter = 0
     with pytest.raises(NonRetryableError):
-        await ImpitHttpClientAsync._retry_with_exp_backoff(
+        await http_client_async_class._retry_with_exp_backoff(
             bails_on_third_attempt, backoff_base=timedelta(milliseconds=1)
         )
     assert attempt_counter == 3
@@ -156,7 +213,7 @@ def test_base_http_client_initialization() -> None:
     """Test HttpClient initialization with various configurations."""
     statistics = ClientStatistics()
 
-    client = _ConcreteHttpClient(
+    client = ConcreteHttpClient(
         token='test_token',
         timeout_short=timedelta(seconds=30),
         max_retries=5,
@@ -171,13 +228,13 @@ def test_base_http_client_initialization() -> None:
     assert client._headers['Authorization'] == 'Bearer test_token'
 
     # Test without statistics (should create default)
-    client2 = _ConcreteHttpClient(token='test_token')
+    client2 = ConcreteHttpClient(token='test_token')
     assert isinstance(client2._statistics, ClientStatistics)
 
 
 def test_http_client_init_headers_override_defaults_case_insensitively() -> None:
     """Constructor headers replace same-named default headers even when their casings differ."""
-    client = _ConcreteHttpClient(token='default_token', headers={'authorization': 'Bearer custom'})
+    client = ConcreteHttpClient(token='default_token', headers={'authorization': 'Bearer custom'})
 
     auth_headers = {key: value for key, value in client._headers.items() if key.lower() == 'authorization'}
     assert auth_headers == {'authorization': 'Bearer custom'}
@@ -187,14 +244,14 @@ def test_http_client_init_workflow_key_header(monkeypatch: pytest.MonkeyPatch) -
     """The X-Apify-Workflow-Key default header is set from the APIFY_WORKFLOW_KEY env var."""
     monkeypatch.setenv('APIFY_WORKFLOW_KEY', 'workflow_key_123')
 
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     assert client._headers['X-Apify-Workflow-Key'] == 'workflow_key_123'
 
 
 def test_set_default_authorization_sets_token_when_missing() -> None:
     """set_default_authorization sets the Bearer token when no authorization header is configured."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     client.set_default_authorization('test_token')
 
@@ -223,21 +280,19 @@ def test_merge_headers(
 
 
 def test_http_client_creates_sync_impit_client() -> None:
-    """Test that ImpitHttpClient creates sync impit client correctly."""
+    """The synchronous adapter creates the underlying Impit client and releases it on close."""
     client = ImpitHttpClient(token='test_token_123')
 
-    # Check that sync impit client is created
-    assert client._impit_client is not None
     assert isinstance(client._impit_client, impit.Client)
+    client.close()
 
 
-def test_http_client_async_creates_async_impit_client() -> None:
-    """Test that ImpitHttpClientAsync creates async impit client correctly."""
+async def test_http_client_async_creates_async_impit_client() -> None:
+    """The asynchronous adapter creates the underlying Impit client and releases it on close."""
     client = ImpitHttpClientAsync(token='test_token_123')
 
-    # Check that async impit client is created
-    assert client._impit_async_client is not None
     assert isinstance(client._impit_async_client, impit.AsyncClient)
+    await client.aclose()
 
 
 def test_parse_params_none() -> None:
@@ -309,18 +364,58 @@ def test_parse_params_mixed() -> None:
     }
 
 
-def test_is_retryable_error() -> None:
-    """Test _is_retryable_error correctly identifies retryable errors."""
-    mock_response = Mock()
-    assert _is_retryable_error(InvalidResponseBodyError(mock_response))
-    assert _is_retryable_error(impit.NetworkError('test'))
-    assert _is_retryable_error(impit.TimeoutException('test'))
-    assert _is_retryable_error(impit.RemoteProtocolError('test'))
+RETRYABLE_TRANSPORT_ERRORS = (
+    # Impit raises a bare `HTTPError` for a body that ends mid-chunk, so even the generic base class is transient.
+    impit.HTTPError,
+    impit.TimeoutException,
+    impit.NetworkError,
+    impit.RemoteProtocolError,
+    impit.DecodingError,
+    # A proxy rejecting the tunnel is often transient, e.g. one that is overloaded or rate-limiting.
+    impit.ProxyError,
+)
+"""Transport errors that must stay retryable."""
 
-    # Non-retryable errors
-    assert not _is_retryable_error(ValueError('test'))
-    assert not _is_retryable_error(RuntimeError('test'))
-    assert not _is_retryable_error(Exception('test'))
+NON_RETRYABLE_TRANSPORT_ERRORS = (
+    impit.UnsupportedProtocol,
+    impit.LocalProtocolError,
+    impit.TooManyRedirects,
+)
+"""Transport errors that a retry cannot fix, so they must fail on the first attempt.
+
+`impit.HTTPStatusError` belongs here too, but no built-in adapter ever raises it, because `_make_request` decides on
+status codes from the response itself.
+"""
+
+
+def test_builtin_http_client_retry_policy() -> None:
+    """Transient transport failures are retried, and the ones a retry cannot fix stop the loop immediately."""
+    with ImpitHttpClient() as client:
+        for error_class in RETRYABLE_TRANSPORT_ERRORS:
+            assert client.is_retryable_transport_error(error_class('test')), error_class.__name__
+
+        for error_class in NON_RETRYABLE_TRANSPORT_ERRORS:
+            assert not client.is_retryable_transport_error(error_class('test')), error_class.__name__
+
+        # `InvalidResponseBodyError` is retried by `_handle_request_exception`, not as a transport failure.
+        assert not client.is_retryable_transport_error(InvalidResponseBodyError(Mock()))
+        assert not client.is_retryable_transport_error(ValueError('test'))
+
+
+def test_sync_http_client_classifies_timeout_errors() -> None:
+    """The built-in synchronous client exposes transport-neutral timeout classification."""
+    with ImpitHttpClient() as client:
+        assert client.is_timeout_error(TimeoutError('test'))
+        assert client.is_timeout_error(impit.TimeoutException('test'))
+        assert not client.is_timeout_error(ValueError('test'))
+
+
+async def test_async_http_client_classifies_timeout_errors() -> None:
+    """The built-in asynchronous client exposes transport-neutral timeout classification."""
+    async with ImpitHttpClientAsync() as client:
+        assert client.is_timeout_error(TimeoutError('test'))
+        assert client.is_timeout_error(impit.TimeoutException('test'))
+        assert not client.is_timeout_error(ValueError('test'))
 
 
 @pytest.fixture(
@@ -335,7 +430,7 @@ def compressor_case(request: pytest.FixtureRequest) -> tuple:
 
 def test_prepare_request_call_basic() -> None:
     """Test _prepare_request_call returns the client default headers when no per-request values are given."""
-    client = _ConcreteHttpClient(token='test_token')
+    client = ConcreteHttpClient(token='test_token')
 
     headers, params, data = client._prepare_request_call()
     assert headers == client._headers
@@ -347,7 +442,7 @@ def test_prepare_request_call_basic() -> None:
 
 def test_prepare_request_call_with_json() -> None:
     """A small JSON body is serialized and typed, but sent uncompressed and without a `Content-Encoding`."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     json_data = {'key': 'value', 'number': 42}
     headers, _params, data = client._prepare_request_call(json=json_data)
@@ -369,7 +464,7 @@ def test_prepare_request_call_with_json() -> None:
 )
 def test_prepare_request_call_with_falsy_json(json_body: JsonSerializable, expected: bytes) -> None:
     """A falsy but valid JSON body is still serialized and sent, rather than treated as no body at all."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     headers, _params, data = client._prepare_request_call(json=json_body)
 
@@ -387,7 +482,7 @@ def test_prepare_request_call_with_falsy_json(json_body: JsonSerializable, expec
 )
 def test_prepare_request_call_with_data(data: str | bytes | bytearray) -> None:
     """A raw body of any accepted type is normalized to bytes."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     _headers, _params, prepared = client._prepare_request_call(data=data)
 
@@ -409,7 +504,7 @@ def test_prepare_request_call_compresses_body_at_or_above_threshold(
 ) -> None:
     """A raw body of at least `MIN_COMPRESSION_SIZE` bytes is compressed and labeled with its encoding."""
     compressor, content_encoding, decompress = compressor_case
-    client = _ConcreteHttpClient(http_compressor=compressor)
+    client = ConcreteHttpClient(http_compressor=compressor)
     body = b'x' * body_size
 
     headers, _params, data = client._prepare_request_call(data=body)
@@ -429,7 +524,7 @@ def test_prepare_request_call_compresses_body_at_or_above_threshold(
 def test_prepare_request_call_skips_compression_below_threshold(compressor_case: tuple, body_size: int) -> None:
     """A raw body under `MIN_COMPRESSION_SIZE` is sent verbatim with no `Content-Encoding`, whichever compressor."""
     compressor, _content_encoding, _decompress = compressor_case
-    client = _ConcreteHttpClient(http_compressor=compressor)
+    client = ConcreteHttpClient(http_compressor=compressor)
     body = b'x' * body_size
 
     headers, _params, data = client._prepare_request_call(data=body)
@@ -441,7 +536,7 @@ def test_prepare_request_call_skips_compression_below_threshold(compressor_case:
 def test_prepare_request_call_compresses_bytearray_data(compressor_case: tuple) -> None:
     """A `bytearray` body above the threshold is compressed without error (regression: needs bytes conversion)."""
     compressor, content_encoding, decompress = compressor_case
-    client = _ConcreteHttpClient(http_compressor=compressor)
+    client = ConcreteHttpClient(http_compressor=compressor)
     body = bytearray(b'test bytearray' * 128)
 
     headers, _params, data = client._prepare_request_call(data=body)
@@ -453,7 +548,7 @@ def test_prepare_request_call_compresses_bytearray_data(compressor_case: tuple) 
 def test_prepare_request_call_compresses_json_above_threshold(compressor_case: tuple) -> None:
     """A JSON body that serializes to at least `MIN_COMPRESSION_SIZE` bytes is compressed."""
     compressor, content_encoding, decompress = compressor_case
-    client = _ConcreteHttpClient(http_compressor=compressor)
+    client = ConcreteHttpClient(http_compressor=compressor)
     json_data = {'key': 'x' * MIN_COMPRESSION_SIZE}
 
     headers, _params, data = client._prepare_request_call(json=json_data)
@@ -466,7 +561,7 @@ def test_prepare_request_call_compresses_json_above_threshold(compressor_case: t
 def test_prepare_request_call_measures_threshold_in_bytes_not_characters(compressor_case: tuple) -> None:
     """A `str` body under the threshold in characters but over it in UTF-8 bytes is still compressed."""
     compressor, content_encoding, decompress = compressor_case
-    client = _ConcreteHttpClient(http_compressor=compressor)
+    client = ConcreteHttpClient(http_compressor=compressor)
     # U+00E9 encodes to 2 bytes, so this body is under the threshold in characters but over it in bytes.
     body = '\u00e9' * (MIN_COMPRESSION_SIZE // 2 + 1)
 
@@ -487,7 +582,7 @@ def test_prepare_request_call_measures_threshold_in_bytes_not_characters(compres
 )
 def test_is_body_worth_compressing(data: Any) -> None:
     """The gate reports a body `_prepare_request_call` would compress, judging a `str` by its encoded bytes."""
-    assert _ConcreteHttpClient._is_body_worth_compressing(data)
+    assert ConcreteHttpClient._is_body_worth_compressing(data)
 
 
 @pytest.mark.parametrize(
@@ -502,7 +597,7 @@ def test_is_body_worth_compressing(data: Any) -> None:
 )
 def test_is_body_not_worth_compressing(data: Any) -> None:
     """A body below the threshold, or of a type the client sends as it is, needs no worker-thread hop."""
-    assert not _ConcreteHttpClient._is_body_worth_compressing(data)
+    assert not ConcreteHttpClient._is_body_worth_compressing(data)
 
 
 @pytest.mark.parametrize(
@@ -515,7 +610,7 @@ def test_is_body_not_worth_compressing(data: Any) -> None:
 )
 def test_prepare_request_call_skips_compression_for_already_compressed_content(content_type: str) -> None:
     """An already-compressed body is sent verbatim, carries no `Content-Encoding`, and keeps every other header."""
-    client = _ConcreteHttpClient(token='test_token', http_compressor=GzipHttpCompressor())
+    client = ConcreteHttpClient(token='test_token', http_compressor=GzipHttpCompressor())
     # Above the size threshold, so the content type is what skips compression here.
     payload = b'\x89PNG' + b'\xff' * MIN_COMPRESSION_SIZE
 
@@ -533,7 +628,7 @@ def test_prepare_request_call_skips_compression_for_already_compressed_content(c
 
 def test_prepare_request_call_keeps_caller_content_encoding_for_a_file_like_body() -> None:
     """A file-like body skips compression entirely, and its `Content-Encoding` reaches the transport untouched."""
-    client = _ConcreteHttpClient(http_compressor=GzipHttpCompressor())
+    client = ConcreteHttpClient(http_compressor=GzipHttpCompressor())
     stream = BytesIO(gzip.compress(b'raw payload'))
 
     headers, _params, data = client._prepare_request_call(
@@ -559,7 +654,7 @@ def test_prepare_request_call_compresses_exceptions_to_compressed_prefixes(
 ) -> None:
     """Types that are text or raw are compressed even when they sit under an already-compressed prefix."""
     compressor, content_encoding, decompress = compressor_case
-    client = _ConcreteHttpClient(http_compressor=compressor)
+    client = ConcreteHttpClient(http_compressor=compressor)
     payload = b'x' * MIN_COMPRESSION_SIZE
 
     headers, _params, data = client._prepare_request_call(
@@ -574,7 +669,7 @@ def test_prepare_request_call_compresses_exceptions_to_compressed_prefixes(
 
 def test_prepare_request_call_json_and_data_error() -> None:
     """Test _prepare_request_call raises error when both json and data are provided."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     with pytest.raises(ValueError, match='Cannot pass both "json" and "data" parameters'):
         client._prepare_request_call(json={'key': 'value'}, data='string')
@@ -582,7 +677,7 @@ def test_prepare_request_call_json_and_data_error() -> None:
 
 def test_prepare_request_call_with_params() -> None:
     """Test _prepare_request_call parses params correctly."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     _headers, params, _data = client._prepare_request_call(params={'limit': 10, 'flag': True})
 
@@ -595,7 +690,7 @@ def test_prepare_request_call_does_not_mutate_caller_headers() -> None:
     A caller that reuses a shared headers dict across calls must not see stale
     `Content-Type`/`Content-Encoding` headers leak in from a prior JSON/body call.
     """
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     caller_headers = {'x-trace-id': 'abc-123'}
     original = dict(caller_headers)
@@ -609,7 +704,7 @@ def test_prepare_request_call_does_not_mutate_caller_headers() -> None:
 
 def test_prepare_request_call_per_request_headers_override_defaults_case_insensitively() -> None:
     """A per-request header replaces a same-named default header even when their casings differ."""
-    client = _ConcreteHttpClient(token='default_token')
+    client = ConcreteHttpClient(token='default_token')
 
     headers, _params, _data = client._prepare_request_call(headers={'authorization': 'Bearer per-request'})
 
@@ -619,7 +714,7 @@ def test_prepare_request_call_per_request_headers_override_defaults_case_insensi
 
 def test_prepare_request_call_json_keeps_caller_content_type() -> None:
     """A caller-supplied content type is not overwritten by the JSON default, regardless of casing."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     headers, _params, _data = client._prepare_request_call(
         headers={'content-type': 'application/json; charset=utf-8'},
@@ -650,7 +745,7 @@ def test_prepare_request_call_json_keeps_caller_content_type() -> None:
 )
 def test_prepare_request_call_keeps_caller_content_encoding(caller_headers: dict[str, str], body: bytes) -> None:
     """A caller-supplied `Content-Encoding` marks the body as pre-encoded, so it goes out untouched and labeled."""
-    client = _ConcreteHttpClient(http_compressor=GzipHttpCompressor())
+    client = ConcreteHttpClient(http_compressor=GzipHttpCompressor())
 
     headers, _params, data = client._prepare_request_call(headers=caller_headers, data=body)
 
@@ -661,7 +756,7 @@ def test_prepare_request_call_keeps_caller_content_encoding(caller_headers: dict
 
 def test_prepare_request_call_keeps_client_wide_content_encoding() -> None:
     """A `Content-Encoding` configured on the client counts as caller-supplied on every request it sends."""
-    client = _ConcreteHttpClient(headers={'Content-Encoding': 'identity'}, http_compressor=GzipHttpCompressor())
+    client = ConcreteHttpClient(headers={'Content-Encoding': 'identity'}, http_compressor=GzipHttpCompressor())
     body = b'x' * MIN_COMPRESSION_SIZE
 
     headers, _params, data = client._prepare_request_call(data=body)
@@ -672,7 +767,7 @@ def test_prepare_request_call_keeps_client_wide_content_encoding() -> None:
 
 def test_build_url_with_params_none() -> None:
     """Test _build_url_with_params with None params."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     url = client._build_url_with_params('https://api.test.com/endpoint')
     assert url == 'https://api.test.com/endpoint'
@@ -680,7 +775,7 @@ def test_build_url_with_params_none() -> None:
 
 def test_build_url_with_params_simple() -> None:
     """Test _build_url_with_params with simple params."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     url = client._build_url_with_params('https://api.test.com/endpoint', params={'key': 'value', 'limit': 10})
     assert 'key=value' in url
@@ -690,7 +785,7 @@ def test_build_url_with_params_simple() -> None:
 
 def test_build_url_with_params_list() -> None:
     """Test _build_url_with_params with list values."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     url = client._build_url_with_params('https://api.test.com/endpoint', params={'tags': ['tag1', 'tag2', 'tag3']})
     assert 'tags=tag1' in url
@@ -700,7 +795,7 @@ def test_build_url_with_params_list() -> None:
 
 def test_build_url_with_params_mixed() -> None:
     """Test _build_url_with_params with mixed param types."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     url = client._build_url_with_params(
         'https://api.test.com/endpoint', params={'limit': 10, 'tags': ['a', 'b'], 'name': 'test'}
@@ -724,11 +819,13 @@ class _ThreadRecordingCompressor(HttpCompressor):
         return gzip.compress(data)
 
 
-async def test_async_call_compresses_request_body_off_the_event_loop() -> None:
+async def test_async_call_compresses_request_body_off_the_event_loop(
+    http_client_async_class: type[HttpClientAsync], monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Body serialization and compression must run in a worker thread, not block the event loop."""
     compressor = _ThreadRecordingCompressor()
-    client = ImpitHttpClientAsync(token='test_token', http_compressor=compressor)
-    client._impit_async_client = Mock(request=AsyncMock(return_value=Mock(status_code=200)))
+    client = http_client_async_class(token='test_token', http_compressor=compressor)
+    monkeypatch.setattr(client, 'send_request', AsyncMock(return_value=Mock(status_code=200)))
 
     await client.call(
         method='POST',
@@ -740,11 +837,13 @@ async def test_async_call_compresses_request_body_off_the_event_loop() -> None:
     assert compressor.compress_thread_id != threading.get_ident()
 
 
-async def test_async_call_compresses_a_multibyte_str_body_off_the_event_loop() -> None:
+async def test_async_call_compresses_a_multibyte_str_body_off_the_event_loop(
+    http_client_async_class: type[HttpClientAsync], monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A `str` body over the threshold only once encoded is still compressed, so it must be offloaded."""
     compressor = _ThreadRecordingCompressor()
-    client = ImpitHttpClientAsync(token='test_token', http_compressor=compressor)
-    client._impit_async_client = Mock(request=AsyncMock(return_value=Mock(status_code=200)))
+    client = http_client_async_class(token='test_token', http_compressor=compressor)
+    monkeypatch.setattr(client, 'send_request', AsyncMock(return_value=Mock(status_code=200)))
 
     await client.call(
         method='PUT',
@@ -763,10 +862,12 @@ def _to_thread_spy(monkeypatch: pytest.MonkeyPatch) -> Mock:
     return spy
 
 
-async def test_async_call_skips_thread_offload_without_a_body(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_async_call_skips_thread_offload_without_a_body(
+    http_client_async_class: type[HttpClientAsync], monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A bodyless request has nothing to compress, so it must not pay the worker-thread hop."""
-    client = ImpitHttpClientAsync(token='test_token')
-    client._impit_async_client = Mock(request=AsyncMock(return_value=Mock(status_code=200)))
+    client = http_client_async_class(token='test_token')
+    monkeypatch.setattr(client, 'send_request', AsyncMock(return_value=Mock(status_code=200)))
     spy = _to_thread_spy(monkeypatch)
 
     await client.call(method='GET', url='https://api.test.com/endpoint')
@@ -775,11 +876,12 @@ async def test_async_call_skips_thread_offload_without_a_body(monkeypatch: pytes
 
 
 async def test_async_call_skips_thread_offload_for_a_body_below_the_threshold(
+    http_client_async_class: type[HttpClientAsync],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A raw body too small to be compressed must not pay the worker-thread hop either."""
-    client = ImpitHttpClientAsync(token='test_token')
-    client._impit_async_client = Mock(request=AsyncMock(return_value=Mock(status_code=200)))
+    client = http_client_async_class(token='test_token')
+    monkeypatch.setattr(client, 'send_request', AsyncMock(return_value=Mock(status_code=200)))
     spy = _to_thread_spy(monkeypatch)
 
     await client.call(method='PUT', url='https://api.test.com/endpoint', data=b'x' * (MIN_COMPRESSION_SIZE - 1))
@@ -787,10 +889,12 @@ async def test_async_call_skips_thread_offload_for_a_body_below_the_threshold(
     spy.assert_not_called()
 
 
-async def test_async_call_offloads_a_body_at_the_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_async_call_offloads_a_body_at_the_threshold(
+    http_client_async_class: type[HttpClientAsync], monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A raw body large enough to be compressed is prepared in a worker thread."""
-    client = ImpitHttpClientAsync(token='test_token')
-    client._impit_async_client = Mock(request=AsyncMock(return_value=Mock(status_code=200)))
+    client = http_client_async_class(token='test_token')
+    monkeypatch.setattr(client, 'send_request', AsyncMock(return_value=Mock(status_code=200)))
     spy = _to_thread_spy(monkeypatch)
 
     await client.call(method='PUT', url='https://api.test.com/endpoint', data=b'x' * MIN_COMPRESSION_SIZE)
@@ -799,11 +903,12 @@ async def test_async_call_offloads_a_body_at_the_threshold(monkeypatch: pytest.M
 
 
 async def test_async_call_skips_thread_offload_for_a_body_it_cannot_compress(
+    http_client_async_class: type[HttpClientAsync],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A body of a type the client passes through needs no hop, and deciding that must not need its length."""
-    client = ImpitHttpClientAsync(token='test_token')
-    client._impit_async_client = Mock(request=AsyncMock(return_value=Mock(status_code=200)))
+    client = http_client_async_class(token='test_token')
+    monkeypatch.setattr(client, 'send_request', AsyncMock(return_value=Mock(status_code=200)))
     spy = _to_thread_spy(monkeypatch)
 
     # `encode_key_value_store_record_value` passes file-like bodies through, so the gate cannot assume a length.

--- a/tests/unit/test_http_compressors.py
+++ b/tests/unit/test_http_compressors.py
@@ -35,7 +35,7 @@ def _brotli_unavailable() -> Iterator[None]:
     class _Blocker:
         def find_spec(self, name: str, *_args: object) -> None:
             if name == 'brotli' or name.startswith('brotli.'):
-                raise ModuleNotFoundError(f"No module named '{name}'")
+                raise ModuleNotFoundError(f"No module named '{name}'", name='brotli')
 
     def _affected(name: str) -> bool:
         return name == 'brotli' or name.startswith(('brotli.', 'apify_client.http_compressors'))

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from pytest_httpserver import HTTPServer
 
     from apify_client._literals import ActorJobStatus
+    from apify_client.http_clients import HttpClient, HttpClientAsync
 
 _MOCKED_RUN_ID = 'mocked_run_id'
 _MOCKED_ACTOR_NAME = 'mocked_actor_name'
@@ -873,11 +874,10 @@ def test_streamed_log_sync_stop_unblocks_on_finite_stream_timeout(
 def test_streamed_log_sync_does_not_leak_exception_on_stream_timeout(
     caplog: LogCaptureFixture,
     httpserver: HTTPServer,
+    http_client_class: type[HttpClient],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The streaming thread ends quietly when the log-stream request hits its total timeout (regression #1040)."""
-    # impit enforces a whole-request timeout, so a still-running Actor whose run outlives the timeout makes
-    # `iter_bytes()` raise `impit.TimeoutException`. Shorten the timeout to trigger this quickly.
+    """The streaming thread ends quietly when either transport times out while reading the log stream."""
     monkeypatch.setattr(StreamedLog, '_stream_timeout', timedelta(seconds=1))
 
     release_server = threading.Event()
@@ -897,7 +897,10 @@ def test_streamed_log_sync_does_not_leak_exception_on_stream_timeout(
     _register_run_and_actor_endpoints(httpserver)
 
     api_url = httpserver.url_for('/').removesuffix('/')
-    run_client = ApifyClient(token='mocked_token', api_url=api_url).run(run_id=_MOCKED_RUN_ID)
+    http_client = http_client_class()
+    run_client = ApifyClient.with_custom_http_client(
+        token='mocked_token', api_url=api_url, http_client=http_client
+    ).run(run_id=_MOCKED_RUN_ID)
     streamed_log = run_client.get_streamed_log()
     logger_name = f'apify.{_MOCKED_ACTOR_NAME}-{_MOCKED_RUN_ID}'
 
@@ -913,6 +916,7 @@ def test_streamed_log_sync_does_not_leak_exception_on_stream_timeout(
     finally:
         release_server.set()
         streamed_log.stop()
+        http_client.close()
 
     leaked = [args.exc_type.__name__ for args in thread_exceptions]
     assert not leaked, f'streaming thread leaked an uncaught exception: {leaked}'
@@ -963,9 +967,10 @@ def test_streamed_log_sync_requests_stream_with_no_timeout(
 async def test_streamed_log_async_does_not_error_on_stream_timeout(
     caplog: LogCaptureFixture,
     httpserver: HTTPServer,
+    http_client_async_class: type[HttpClientAsync],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The async streaming task ends quietly on a stream-request timeout, matching the sync regression for #1040."""
+    """The async streaming task treats either transport's stream timeout as an expected terminal condition."""
     monkeypatch.setattr(StreamedLogAsync, '_stream_timeout', timedelta(seconds=1))
 
     release_server = threading.Event()
@@ -984,7 +989,10 @@ async def test_streamed_log_async_does_not_error_on_stream_timeout(
     _register_run_and_actor_endpoints(httpserver)
 
     api_url = httpserver.url_for('/').removesuffix('/')
-    run_client = ApifyClientAsync(token='mocked_token', api_url=api_url).run(run_id=_MOCKED_RUN_ID)
+    http_client = http_client_async_class()
+    run_client = ApifyClientAsync.with_custom_http_client(
+        token='mocked_token', api_url=api_url, http_client=http_client
+    ).run(run_id=_MOCKED_RUN_ID)
     streamed_log = await run_client.get_streamed_log()
     logger_name = f'apify.{_MOCKED_ACTOR_NAME}-{_MOCKED_RUN_ID}'
 
@@ -997,6 +1005,7 @@ async def test_streamed_log_async_does_not_error_on_stream_timeout(
     finally:
         release_server.set()
         await streamed_log.stop()
+        await http_client.aclose()
 
     assert not task.cancelled()
     assert task.exception() is None, f'async streaming task raised on stream timeout: {task.exception()!r}'

--- a/tests/unit/test_pluggable_http_client.py
+++ b/tests/unit/test_pluggable_http_client.py
@@ -77,8 +77,8 @@ def _make_fake_response() -> FakeResponse:
 class FakeHttpClient(HttpClient):
     """A custom sync HTTP client for testing."""
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, *, token: str | None = None) -> None:
+        super().__init__(token=token)
         self.calls: list[dict[str, Any]] = []
 
     def call(
@@ -92,7 +92,7 @@ class FakeHttpClient(HttpClient):
         json: Any = None,
         stream: bool | None = None,
         timeout: Timeout = 'medium',
-    ) -> FakeResponse:
+    ) -> HttpResponse:
         self.calls.append(
             {
                 'method': method,
@@ -111,8 +111,8 @@ class FakeHttpClient(HttpClient):
 class FakeHttpClientAsync(HttpClientAsync):
     """A custom async HTTP client for testing."""
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, *, token: str | None = None) -> None:
+        super().__init__(token=token)
         self.calls: list[dict[str, Any]] = []
 
     async def call(
@@ -126,7 +126,7 @@ class FakeHttpClientAsync(HttpClientAsync):
         json: Any = None,
         stream: bool | None = None,
         timeout: Timeout = 'medium',
-    ) -> FakeResponse:
+    ) -> HttpResponse:
         self.calls.append(
             {
                 'method': method,
@@ -142,7 +142,7 @@ class FakeHttpClientAsync(HttpClientAsync):
         return _make_fake_response()
 
 
-# -- Protocol / ABC conformance tests --
+# -- Protocol conformance tests --
 
 
 def test_fake_response_satisfies_http_response_protocol() -> None:
@@ -163,15 +163,15 @@ def test_fake_http_client_async_is_http_client_async() -> None:
     assert isinstance(client, HttpClientAsync)
 
 
-def test_apify_http_client_is_http_client() -> None:
-    """Test that ImpitHttpClient is an instance of HttpClient."""
-    client = ImpitHttpClient()
+def test_apify_http_client_is_http_client(http_client_class: type[HttpClient]) -> None:
+    """Test that each built-in synchronous client is an HttpClient."""
+    client = http_client_class()
     assert isinstance(client, HttpClient)
 
 
-def test_apify_http_client_async_is_http_client_async() -> None:
-    """Test that ImpitHttpClientAsync is an instance of HttpClientAsync."""
-    client = ImpitHttpClientAsync()
+def test_apify_http_client_async_is_http_client_async(http_client_async_class: type[HttpClientAsync]) -> None:
+    """Test that each built-in asynchronous client is an HttpClientAsync."""
+    client = http_client_async_class()
     assert isinstance(client, HttpClientAsync)
 
 
@@ -184,16 +184,16 @@ async def test_fake_response_async_methods() -> None:
     assert chunks == [b'hello']
 
 
-def test_http_client_abc_not_instantiable() -> None:
-    """Test that HttpClient cannot be instantiated directly (it's abstract)."""
-    with pytest.raises(TypeError, match='abstract method'):
-        HttpClient()
+def test_http_client_without_transport_fails_loudly() -> None:
+    """The sync base carries hook defaults, but its inherited `call` still needs a transport implementation."""
+    with pytest.raises(NotImplementedError):
+        HttpClient().call(method='GET', url='https://example.com')
 
 
-def test_http_client_async_abc_not_instantiable() -> None:
-    """Test that HttpClientAsync cannot be instantiated directly (it's abstract)."""
-    with pytest.raises(TypeError, match='abstract method'):
-        HttpClientAsync()
+async def test_http_client_async_without_transport_fails_loudly() -> None:
+    """The async base carries hook defaults, but its inherited `call` still needs a transport implementation."""
+    with pytest.raises(NotImplementedError):
+        await HttpClientAsync().call(method='GET', url='https://example.com')
 
 
 # -- ApifyClient with custom http_client via classmethod --
@@ -292,9 +292,17 @@ async def test_apify_client_async_with_custom_http_client_accepts_url_params() -
 
 def test_public_exports() -> None:
     """HTTP client types are exposed from `apify_client.http_clients`, not the root namespace."""
-    for name in ('HttpClient', 'HttpClientAsync', 'HttpResponse', 'ImpitHttpClient', 'ImpitHttpClientAsync'):
+    for name in (
+        'HttpClient',
+        'HttpClientAsync',
+        'HttpResponse',
+        'ImpitHttpClient',
+        'ImpitHttpClientAsync',
+    ):
         assert hasattr(http_clients_module, name)
         assert not hasattr(apify_client_module, name)
+
+    assert not hasattr(http_clients_module, 'HttpClientBase')
 
 
 # -- http_client property --
@@ -327,7 +335,7 @@ async def test_apify_client_async_http_client_property_returns_correct_type() ->
 # -- Error handling with custom http_client --
 
 
-class ErrorRaisingHttpClient(HttpClient):
+class ErrorRaisingHttpClient(FakeHttpClient):
     """A custom HTTP client that raises ApifyApiError."""
 
     def call(self, *, method: str, **_kwargs: Any) -> FakeResponse:
@@ -349,7 +357,7 @@ def test_custom_http_client_error_handling() -> None:
     assert result is None
 
 
-class ErrorRaisingHttpClientAsync(HttpClientAsync):
+class ErrorRaisingHttpClientAsync(FakeHttpClientAsync):
     """A custom async HTTP client that raises ApifyApiError."""
 
     async def call(self, *, method: str, **_kwargs: Any) -> FakeResponse:
@@ -374,16 +382,16 @@ async def test_custom_http_client_async_error_handling() -> None:
 # -- Integration with real HTTP server --
 
 
-def test_custom_http_client_with_real_server(httpserver: HTTPServer) -> None:
-    """Test that a custom HTTP client wrapping ImpitHttpClient works with a real server."""
+def test_custom_http_client_with_real_server(httpserver: HTTPServer, http_client_class: type[HttpClient]) -> None:
+    """Test that a custom HTTP client wrapping a built-in client works with a real server."""
     httpserver.expect_request('/v2/datasets/test-dataset').respond_with_json(
         {'data': {'id': 'test-dataset', 'name': 'My Dataset'}},
     )
 
     # Create a wrapping client that adds custom headers
-    inner_client = ImpitHttpClient(token='test_token')
+    inner_client = http_client_class(token='test_token')
 
-    class WrappingHttpClient(HttpClient):
+    class WrappingHttpClient(FakeHttpClient):
         def call(self, *, method: str, url: str, **kwargs: Any) -> HttpResponse:
             if kwargs.get('headers') is None:
                 kwargs['headers'] = {}
@@ -400,16 +408,18 @@ def test_custom_http_client_with_real_server(httpserver: HTTPServer) -> None:
     assert result['data']['id'] == 'test-dataset'
 
 
-async def test_custom_http_client_async_with_real_server(httpserver: HTTPServer) -> None:
-    """Test that a custom async HTTP client wrapping ImpitHttpClientAsync works with a real server."""
+async def test_custom_http_client_async_with_real_server(
+    httpserver: HTTPServer, http_client_async_class: type[HttpClientAsync]
+) -> None:
+    """Test that a custom async HTTP client wrapping a built-in client works with a real server."""
     httpserver.expect_request('/v2/datasets/test-dataset').respond_with_json(
         {'data': {'id': 'test-dataset', 'name': 'My Dataset'}},
     )
 
     # Create a wrapping client that adds custom headers
-    inner_client = ImpitHttpClientAsync(token='test_token')
+    inner_client = http_client_async_class(token='test_token')
 
-    class WrappingHttpClientAsync(HttpClientAsync):
+    class WrappingHttpClientAsync(FakeHttpClientAsync):
         async def call(self, *, method: str, url: str, **kwargs: Any) -> HttpResponse:
             if kwargs.get('headers') is None:
                 kwargs['headers'] = {}
@@ -428,7 +438,7 @@ async def test_custom_http_client_async_with_real_server(httpserver: HTTPServer)
     assert result['data']['id'] == 'test-dataset'
 
 
-class PreparingHttpClient(HttpClient):
+class PreparingHttpClient(FakeHttpClient):
     """A custom sync HTTP client that sends requests prepared by the base-class helpers."""
 
     def __init__(self, token: str | None = None) -> None:
@@ -451,7 +461,7 @@ class PreparingHttpClient(HttpClient):
         return self._impit_client.request(method=method, url=url, headers=headers, content=content)
 
 
-class PreparingHttpClientAsync(HttpClientAsync):
+class PreparingHttpClientAsync(FakeHttpClientAsync):
     """A custom async HTTP client that sends requests prepared by the base-class helpers."""
 
     def __init__(self, token: str | None = None) -> None:
@@ -517,12 +527,14 @@ async def test_custom_http_client_async_sends_token_from_classmethod(httpserver:
     assert result['received_headers']['Authorization'] == 'Bearer test_token'
 
 
-def test_custom_http_client_impit_instance_sends_token(httpserver: HTTPServer) -> None:
-    """Token from with_custom_http_client reaches the wire even for a pre-built tokenless ImpitHttpClient."""
+def test_custom_builtin_http_client_instance_sends_token(
+    httpserver: HTTPServer, http_client_class: type[HttpClient]
+) -> None:
+    """Token from with_custom_http_client reaches the wire for each pre-built tokenless client."""
     httpserver.expect_request('/v2/datasets/test-dataset').respond_with_handler(_echo_headers)
 
     api_url = httpserver.url_for('/').removesuffix('/')
-    client = ApifyClient.with_custom_http_client(token='test_token', api_url=api_url, http_client=ImpitHttpClient())
+    client = ApifyClient.with_custom_http_client(token='test_token', api_url=api_url, http_client=http_client_class())
 
     result = client.dataset('test-dataset')._get(timeout='short')
 

--- a/tests/unit/test_pluggable_http_client.py
+++ b/tests/unit/test_pluggable_http_client.py
@@ -77,8 +77,8 @@ def _make_fake_response() -> FakeResponse:
 class FakeHttpClient(HttpClient):
     """A custom sync HTTP client for testing."""
 
-    def __init__(self, *, token: str | None = None) -> None:
-        super().__init__(token=token)
+    def __init__(self) -> None:
+        super().__init__()
         self.calls: list[dict[str, Any]] = []
 
     def call(
@@ -111,8 +111,8 @@ class FakeHttpClient(HttpClient):
 class FakeHttpClientAsync(HttpClientAsync):
     """A custom async HTTP client for testing."""
 
-    def __init__(self, *, token: str | None = None) -> None:
-        super().__init__(token=token)
+    def __init__(self) -> None:
+        super().__init__()
         self.calls: list[dict[str, Any]] = []
 
     async def call(
@@ -335,7 +335,7 @@ async def test_apify_client_async_http_client_property_returns_correct_type() ->
 # -- Error handling with custom http_client --
 
 
-class ErrorRaisingHttpClient(FakeHttpClient):
+class ErrorRaisingHttpClient(HttpClient):
     """A custom HTTP client that raises ApifyApiError."""
 
     def call(self, *, method: str, **_kwargs: Any) -> FakeResponse:
@@ -357,7 +357,7 @@ def test_custom_http_client_error_handling() -> None:
     assert result is None
 
 
-class ErrorRaisingHttpClientAsync(FakeHttpClientAsync):
+class ErrorRaisingHttpClientAsync(HttpClientAsync):
     """A custom async HTTP client that raises ApifyApiError."""
 
     async def call(self, *, method: str, **_kwargs: Any) -> FakeResponse:
@@ -391,7 +391,7 @@ def test_custom_http_client_with_real_server(httpserver: HTTPServer, http_client
     # Create a wrapping client that adds custom headers
     inner_client = http_client_class(token='test_token')
 
-    class WrappingHttpClient(FakeHttpClient):
+    class WrappingHttpClient(HttpClient):
         def call(self, *, method: str, url: str, **kwargs: Any) -> HttpResponse:
             if kwargs.get('headers') is None:
                 kwargs['headers'] = {}
@@ -419,7 +419,7 @@ async def test_custom_http_client_async_with_real_server(
     # Create a wrapping client that adds custom headers
     inner_client = http_client_async_class(token='test_token')
 
-    class WrappingHttpClientAsync(FakeHttpClientAsync):
+    class WrappingHttpClientAsync(HttpClientAsync):
         async def call(self, *, method: str, url: str, **kwargs: Any) -> HttpResponse:
             if kwargs.get('headers') is None:
                 kwargs['headers'] = {}
@@ -438,7 +438,7 @@ async def test_custom_http_client_async_with_real_server(
     assert result['data']['id'] == 'test-dataset'
 
 
-class PreparingHttpClient(FakeHttpClient):
+class PreparingHttpClient(HttpClient):
     """A custom sync HTTP client that sends requests prepared by the base-class helpers."""
 
     def __init__(self, token: str | None = None) -> None:
@@ -461,7 +461,7 @@ class PreparingHttpClient(FakeHttpClient):
         return self._impit_client.request(method=method, url=url, headers=headers, content=content)
 
 
-class PreparingHttpClientAsync(FakeHttpClientAsync):
+class PreparingHttpClientAsync(HttpClientAsync):
     """A custom async HTTP client that sends requests prepared by the base-class helpers."""
 
     def __init__(self, token: str | None = None) -> None:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3,33 +3,63 @@ from __future__ import annotations
 import gzip
 import io
 import json
+import sys
 from base64 import b64decode
 from datetime import timedelta
 from http import HTTPStatus
+from types import ModuleType
 from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock
 
-import impit
 import pytest
 
 from apify_client._models import WebhookCondition, WebhookCreate
 from apify_client._resource_clients._resource_client import ResourceClientBase
 from apify_client._utils.crypto import create_hmac_signature, create_storage_content_signature, encode_base62
 from apify_client._utils.encoding import encode_key_value_store_record_value, encode_webhooks_to_base64
-from apify_client._utils.errors import catch_not_found_or_throw, is_retryable_error
+from apify_client._utils.errors import catch_not_found_or_throw
 from apify_client._utils.http import (
     is_compressible_content_type,
     response_to_dict,
     response_to_list,
     to_safe_id,
 )
-from apify_client.errors import ApifyApiError, InvalidResponseBodyError
+from apify_client._utils.try_import import FailedImport, try_import
+from apify_client.errors import ApifyApiError
 
 if TYPE_CHECKING:
     from apify_client._typeddicts import WebhookRepresentationDict
     from apify_client.types import WebhooksList
 
 _GZIPPED_DATA = gzip.compress(b'buffer data')
+
+
+def test_try_import_only_handles_the_named_missing_dependency() -> None:
+    """Optional-import handling must not hide a broken transitive dependency or module bug."""
+    module_name = 'test_optional_import_module'
+    sys.modules[module_name] = ModuleType(module_name)
+    try:
+        with (
+            pytest.raises(ModuleNotFoundError, match='broken-transitive'),
+            try_import(module_name, 'OptionalSymbol', dependency_name='optional-package'),
+        ):
+            raise ModuleNotFoundError('broken-transitive', name='broken-transitive')
+        assert not hasattr(sys.modules[module_name], 'OptionalSymbol')
+    finally:
+        del sys.modules[module_name]
+
+
+def test_try_import_records_the_named_missing_dependency() -> None:
+    """A genuinely missing optional dependency is converted to a failed-import placeholder."""
+    module_name = 'test_missing_optional_import_module'
+    sys.modules[module_name] = ModuleType(module_name)
+    try:
+        with try_import(module_name, 'OptionalSymbol', dependency_name='optional-package') as state:
+            raise ModuleNotFoundError("No module named 'optional-package'", name='optional-package')
+        assert state.available is False
+        assert isinstance(sys.modules[module_name].OptionalSymbol, FailedImport)
+    finally:
+        del sys.modules[module_name]
 
 
 def test_to_safe_id() -> None:
@@ -154,36 +184,6 @@ def test_encode_webhooks_to_base64_from_dicts() -> None:
     )
 
     assert result == result_from_models
-
-
-@pytest.mark.parametrize(
-    'exc',
-    [
-        InvalidResponseBodyError(impit.Response(status_code=200)),
-        impit.HTTPError('generic http error'),
-        impit.NetworkError('network error'),
-        impit.TimeoutException('timeout'),
-        impit.RemoteProtocolError('remote protocol error'),
-        impit.ReadError('read error'),
-        impit.ConnectError('connect error'),
-        impit.WriteError('write error'),
-        impit.DecodingError('decoding error'),
-    ],
-)
-def test__is_retryable_error(exc: Exception) -> None:
-    assert is_retryable_error(exc) is True
-
-
-@pytest.mark.parametrize(
-    'exc',
-    [
-        Exception('generic exception'),
-        ValueError('value error'),
-        RuntimeError('runtime error'),
-    ],
-)
-def test__is_not_retryable_error(exc: Exception) -> None:
-    assert is_retryable_error(exc) is False
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -47,6 +47,7 @@ dependencies = [
     { name = "impit" },
     { name = "more-itertools" },
     { name = "pydantic", extra = ["email"] },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -82,6 +83,7 @@ requires-dist = [
     { name = "impit", specifier = "~=0.13.0" },
     { name = "more-itertools", specifier = ">=10.0.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.11.0" },
+    { name = "typing-extensions", specifier = ">=4.6.0" },
 ]
 provides-extras = ["brotli"]
 


### PR DESCRIPTION
Moves `call`, the retry loop, and the per-attempt request handling from `ImpitHttpClient` into `HttpClient` and `HttpClientAsync`, leaving Impit as a thin adapter over the transport hooks: `send_request`, `is_retryable_transport_error`, `is_timeout_error`, and `close()` / `aclose()` plus context managers. A custom client that overrides `call` keeps working unchanged and opts out of the shared pipeline.

The same pass fixes:

- Transport errors a retry cannot fix (`UnsupportedProtocol`, `LocalProtocolError`, `TooManyRedirects`) fail on the first attempt instead of burning the whole backoff. Everything else in the `impit.HTTPError` tree stays retryable, including a bare `HTTPError` from a body that ends mid-chunk and a `ProxyError` from a proxy answering CONNECT with a transient status.
- A failure while reading a streamed error response is classified and retried like a send failure, and the response is closed instead of being left open.
- `HttpResponse` comes from `typing_extensions`, whose runtime protocol check looks attributes up statically, so `isinstance(response, HttpResponse)` no longer buffers or rejects an unread streaming body.
- `try_import` only substitutes failed imports for the optional dependency it names, so an `ImportError` from the importing module or another dependency is no longer masked, and `__all__` omits what a missing extra never provided.

Split out of #1004, which adds the built-in HTTPX client on top of this contract.

*✍️ Drafted by Claude Code*
