### PR TITLE
feat: Unify the request pipeline across HTTP clients

### DIFF
--- a/.rules.md
+++ b/.rules.md
@@ -60,7 +60,8 @@ Docstrings are written on sync clients and **automatically copied** to async cli
 
 ### HTTP Client Abstraction
 
-- `HttpClient`/`HttpClientAsync` — abstract base classes in `_http_clients/_base.py`
+- `HttpClient`/`HttpClientAsync` — base classes in `http_clients/_base.py` holding the shared request pipeline (retries,
+  timeouts, API errors); transports implement the `send_request`, error-classification, and lifecycle hooks
 - `ImpitHttpClient`/`ImpitHttpClientAsync` — default implementation (Rust-based Impit)
 - `HttpResponse` — Protocol (not a concrete class) for response objects
 - Users can plug in custom HTTP clients via `ApifyClient.with_custom_http_client()`

--- a/src/apify_client/_apify_client.py
+++ b/src/apify_client/_apify_client.py
@@ -226,8 +226,8 @@ class ApifyClient:
         """Create an `ApifyClient` instance with a custom HTTP client.
 
         Use this alternative constructor when you want to provide your own HTTP client implementation
-        instead of the default one. The custom client is responsible for its own configuration
-        (retries, timeouts, etc.); only the token is applied to it, as described below.
+        instead of the default one. The custom client controls its transport configuration; the shared
+        `HttpClient` pipeline handles request preparation, retries, timeouts, and API errors unless overridden.
 
         ### Usage
 
@@ -235,9 +235,11 @@ class ApifyClient:
         from apify_client import ApifyClient
         from apify_client.http_clients import HttpClient, HttpResponse
 
+
         class MyHttpClient(HttpClient):
-            def call(self, *, method, url, **kwargs) -> HttpResponse:
+            def send_request(self, *, method, url, headers, content, timeout, stream) -> HttpResponse:
                 ...
+
 
         client = ApifyClient.with_custom_http_client(
             token='MY-APIFY-TOKEN',
@@ -588,8 +590,8 @@ class ApifyClientAsync:
         """Create an `ApifyClientAsync` instance with a custom HTTP client.
 
         Use this alternative constructor when you want to provide your own HTTP client implementation
-        instead of the default one. The custom client is responsible for its own configuration
-        (retries, timeouts, etc.); only the token is applied to it, as described below.
+        instead of the default one. The custom client controls its transport configuration; the shared
+        `HttpClientAsync` pipeline handles request preparation, retries, timeouts, and API errors unless overridden.
 
         ### Usage
 
@@ -597,13 +599,15 @@ class ApifyClientAsync:
         from apify_client import ApifyClientAsync
         from apify_client.http_clients import HttpClientAsync, HttpResponse
 
-        class MyHttpClient(HttpClientAsync):
-            async def call(self, *, method, url, **kwargs) -> HttpResponse:
+
+        class MyHttpClientAsync(HttpClientAsync):
+            async def send_request(self, *, method, url, headers, content, timeout, stream) -> HttpResponse:
                 ...
+
 
         client = ApifyClientAsync.with_custom_http_client(
             token='MY-APIFY-TOKEN',
-            http_client=MyHttpClient(),
+            http_client=MyHttpClientAsync(),
         )
         ```
 

--- a/src/apify_client/_streamed_log.py
+++ b/src/apify_client/_streamed_log.py
@@ -9,8 +9,6 @@ from datetime import UTC, datetime
 from threading import Thread
 from typing import TYPE_CHECKING, ClassVar, Self, cast
 
-import impit
-
 from apify_client._docs import docs_group
 
 if TYPE_CHECKING:
@@ -29,9 +27,8 @@ class StreamedLogBase:
     _stream_timeout: ClassVar[Timeout] = 'no_timeout'
     """Timeout for the log-stream long-poll request, which stays open for the whole Actor run.
 
-    impit applies its `timeout` to the whole request including the streamed body, so any bounded value truncates a
-    longer run mid-stream and raises `impit.TimeoutException` (#1040). `no_timeout` maps to impit's ~24h cap, which
-    is effectively unbounded for real runs and mirrors the JS client.
+    A bounded transport timeout can truncate a longer run mid-stream. `no_timeout` keeps the connection open for the
+    duration of the run (Impit currently maps it to an effective 24-hour cap) and mirrors the JS client.
     """
 
     def __init__(self, to_logger: logging.Logger, *, from_start: bool = True) -> None:
@@ -162,13 +159,13 @@ class StreamedLog(StreamedLogBase):
                 finally:
                     # Flush the last buffered part even if the read timed out or was stopped.
                     self._log_buffer_content(include_last_part=True)
-        except impit.TimeoutException:
-            # With `no_timeout` this fires only if the run outlives impit's ~24h cap or the connection stalls.
-            # The stream cannot continue, so warn and let the thread end instead of leaking a traceback (#1040).
-            self._to_logger.warning('Log streaming stopped: the log stream request timed out.')
-        except Exception:
-            # Any other failure in log redirection must not escape the background thread; log it instead.
-            self._to_logger.exception('Log redirection stopped due to unexpected error:')
+        except Exception as exc:
+            if self._log_client._http_client.is_timeout_error(exc):  # noqa: SLF001
+                # The stream cannot continue, so warn and let the thread end instead of leaking a traceback.
+                self._to_logger.warning('Log streaming stopped: the log stream request timed out.')
+            else:
+                # Any other failure in log redirection must not escape the background thread; log it instead.
+                self._to_logger.exception('Log redirection stopped due to unexpected error:')
 
 
 @docs_group('Other')
@@ -241,10 +238,10 @@ class StreamedLogAsync(StreamedLogBase):
                 finally:
                     # Flush the last buffered part even if the task is cancelled by `stop()`.
                     self._log_buffer_content(include_last_part=True)
-        except impit.TimeoutException:
-            # As in `StreamedLog._stream_log`, impit's whole-request timeout on the long-lived stream is an
-            # expected terminal condition, not an error, so log a warning and end the task instead of a traceback.
-            self._to_logger.warning('Log streaming stopped: the log stream request timed out.')
-        except Exception:
-            # Exception in log redirection should not propagate further.
-            self._to_logger.exception('Log redirection stopped due to unexpected error:')
+        except Exception as exc:
+            if self._log_client._http_client.is_timeout_error(exc):  # noqa: SLF001
+                # A timeout on the long-lived stream is an expected terminal condition, not an error.
+                self._to_logger.warning('Log streaming stopped: the log stream request timed out.')
+            else:
+                # Exception in log redirection should not propagate further.
+                self._to_logger.exception('Log redirection stopped due to unexpected error:')

--- a/src/apify_client/_utils/errors.py
+++ b/src/apify_client/_utils/errors.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import impit
-
-from apify_client.errors import InvalidResponseBodyError, NotFoundError
+from apify_client.errors import NotFoundError
 
 if TYPE_CHECKING:
     from apify_client.errors import ApifyApiError
@@ -33,19 +31,3 @@ def catch_not_found_for_resource_or_throw(exc: ApifyApiError, resource_id: str |
     if resource_id is None:
         raise exc
     catch_not_found_or_throw(exc)
-
-
-def is_retryable_error(exc: Exception) -> bool:
-    """Check if the given error is retryable.
-
-    All `impit.HTTPError` subclasses are considered retryable because they represent transport-level failures
-    (network issues, timeouts, protocol errors, body decoding errors) that are typically transient. HTTP status
-    code errors are handled separately in `_make_request` based on the response status code, not here.
-    """
-    return isinstance(
-        exc,
-        (
-            InvalidResponseBodyError,
-            impit.HTTPError,
-        ),
-    )

--- a/src/apify_client/http_clients/__init__.py
+++ b/src/apify_client/http_clients/__init__.py
@@ -1,5 +1,5 @@
-from ._base import HttpClient, HttpClientAsync, HttpResponse
-from ._impit import ImpitHttpClient, ImpitHttpClientAsync
+from apify_client.http_clients._base import HttpClient, HttpClientAsync, HttpResponse
+from apify_client.http_clients._impit import ImpitHttpClient, ImpitHttpClientAsync
 
 __all__ = [
     'HttpClient',

--- a/src/apify_client/http_clients/_base.py
+++ b/src/apify_client/http_clients/_base.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import asyncio
 import json as jsonlib
 import logging
 import os
+import random
 import sys
-from abc import ABC, abstractmethod
+import time
 from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
 from importlib import metadata
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.parse import urlencode
 
 # `Protocol` comes from `typing_extensions`, not `typing`, because its runtime `isinstance` check looks attributes
@@ -25,17 +28,22 @@ from apify_client._consts import (
     MIN_COMPRESSION_SIZE,
 )
 from apify_client._docs import docs_group
-from apify_client._logging import LoggerOnce, logger_name
+from apify_client._logging import LoggerOnce, log_context, logger_name
 from apify_client._statistics import ClientStatistics
 from apify_client._utils.http import is_compressible_content_type
 from apify_client._utils.time import to_seconds
+from apify_client.errors import ApifyApiError, InvalidResponseBodyError
 from apify_client.http_compressors._gzip import GzipHttpCompressor
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Iterator, Mapping
+    from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Mapping
+    from types import TracebackType
+    from typing import Self
 
     from apify_client.http_compressors._base import HttpCompressor
     from apify_client.types import JsonSerializable, Timeout
+
+T = TypeVar('T')
 
 logger = logging.getLogger(logger_name)
 logger_once = LoggerOnce(logger)
@@ -93,12 +101,11 @@ class HttpResponse(Protocol):
 class HttpClientBase:
     """Shared configuration and utilities for HTTP clients.
 
-    Provides common functionality for both sync and async HTTP clients including:
-    header construction, parameter parsing, request body preparation, URL building,
-    and timeout calculation.
+    Provides common functionality for both sync and async HTTP clients including: header construction, parameter
+    parsing, request body preparation, URL building, timeout calculation, and error classification.
 
-    Subclasses should call `super().__init__()` to initialize shared configuration.
-    The helper methods are then available for use in the `call()` implementation.
+    Subclasses should call `super().__init__()` to initialize shared configuration. The helpers are then used by the
+    inherited `call`, and stay available to a client that replaces it.
     """
 
     def __init__(
@@ -165,6 +172,23 @@ class HttpClientBase:
         """
         if self._get_header(self._headers, 'authorization') is None:
             self._headers['Authorization'] = f'Bearer {token}'
+
+    def is_timeout_error(self, exc: Exception) -> bool:
+        """Return whether an exception represents a transport timeout.
+
+        Recognizes Python's own `TimeoutError`. Transport adapters extend it with the timeout types their HTTP
+        library defines.
+        """
+        return isinstance(exc, TimeoutError)
+
+    def is_retryable_transport_error(self, exc: Exception) -> bool:
+        """Return whether an underlying HTTP-library exception is retryable.
+
+        The default classifies nothing as retryable, so a transport that doesn't override it gives up on the first
+        connection failure. Every transport adapter should map its own transient error types here.
+        """
+        _ = exc
+        return False
 
     @staticmethod
     def _merge_headers(base: dict[str, str] | None, override: dict[str, str] | None) -> dict[str, str]:
@@ -333,21 +357,70 @@ class HttpClientBase:
 
         return f'{url}?{query_string}'
 
+    def _handle_request_exception(self, exc: Exception, *, stop_retrying: Callable[[], None]) -> None:
+        """Stop retrying when an exception is not a transient response or transport failure."""
+        logger.debug('Request threw exception', exc_info=exc)
+        if not isinstance(exc, InvalidResponseBodyError) and not self.is_retryable_transport_error(exc):
+            logger.debug('Exception is not retryable', exc_info=exc)
+            stop_retrying()
+
+    def _handle_response_status(
+        self,
+        response: HttpResponse,
+        *,
+        attempt: int,
+        stop_retrying: Callable[[], None],
+    ) -> bool:
+        """Record the response status and stop retrying unless it is a server error or a rate limit.
+
+        Returns whether the response is a success, so the caller can hand it back instead of raising.
+        """
+        if response.status_code < HTTPStatus.MULTIPLE_CHOICES:
+            logger.debug('Request successful', extra={'status_code': response.status_code})
+            return True
+
+        if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
+            self._statistics.add_rate_limit_error(attempt)
+
+        logger.debug('Request unsuccessful', extra={'status_code': response.status_code})
+        if (
+            response.status_code < HTTPStatus.INTERNAL_SERVER_ERROR
+            and response.status_code != HTTPStatus.TOO_MANY_REQUESTS
+        ):
+            logger.debug('Status code is not retryable', extra={'status_code': response.status_code})
+            stop_retrying()
+
+        return False
+
 
 @docs_group('HTTP clients')
-class HttpClient(HttpClientBase, ABC):
-    """Abstract base class for synchronous HTTP clients used by `ApifyClient`.
+class HttpClient(HttpClientBase):
+    """Base class for synchronous HTTP clients used by `ApifyClient`.
 
-    Extend this class to create a custom synchronous HTTP client. Override the `call` method
-    with your implementation. Helper methods from the base class are available for request
-    preparation, URL building, and parameter parsing.
+    Concrete clients inherit its request preparation, retry, and error handling, and implement the transport,
+    error-classification, and lifecycle hooks. Only `send_request` has to be implemented, the other hooks have
+    defaults. Replacing `call` itself also remains supported, and then the transport and retry-classification hooks
+    are bypassed. Helper methods from `HttpClientBase` remain available for request preparation, URL building, and
+    parameter parsing.
 
-    Implementations must send the client's default headers from `self._headers` with every request,
-    otherwise the `Authorization` header never reaches the API. The `_prepare_request_call` helper
-    merges them into the per-request headers automatically.
+    The client's default headers from `self._headers` have to go out with every request, otherwise the
+    `Authorization` header never reaches the API. The inherited `call` merges them into the per-request headers
+    through `_prepare_request_call`, so only a client that replaces `call` has to do it itself.
     """
 
-    @abstractmethod
+    def __enter__(self) -> Self:
+        """Return this client and close it when the context exits."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close resources owned by the HTTP client."""
+        self.close()
+
     def call(
         self,
         *,
@@ -356,16 +429,16 @@ class HttpClient(HttpClientBase, ABC):
         headers: dict[str, str] | None = None,
         params: dict[str, Any] | None = None,
         data: str | bytes | bytearray | None = None,
-        json: Any = None,
+        json: JsonSerializable | None = None,
         stream: bool | None = None,
         timeout: Timeout = 'medium',
     ) -> HttpResponse:
-        """Make an HTTP request.
+        """Make an HTTP request with automatic retry and exponential backoff.
 
         Args:
             method: HTTP method (GET, POST, PUT, DELETE, etc.).
             url: Full URL to make the request to.
-            headers: Additional headers to include in this request.
+            headers: Additional headers to include.
             params: Query parameters to append to the URL.
             data: Raw request body data. Cannot be used together with json.
             json: JSON-serializable data for the request body. Cannot be used together with data.
@@ -381,17 +454,165 @@ class HttpClient(HttpClientBase, ABC):
             ApifyApiError: If the request fails after all retries or returns a non-retryable error status.
             ValueError: If both json and data are provided.
         """
+        log_context.method.set(method)
+        log_context.url.set(url)
+
+        self._statistics.calls += 1
+
+        prepared_headers, prepared_params, content = self._prepare_request_call(
+            headers=headers,
+            params=params,
+            data=data,
+            json=json,
+        )
+
+        return self._retry_with_exp_backoff(
+            lambda stop_retrying, attempt: self._make_request(
+                stop_retrying=stop_retrying,
+                attempt=attempt,
+                method=method,
+                url=url,
+                headers=prepared_headers,
+                params=prepared_params,
+                content=content,
+                stream=stream,
+                timeout=timeout,
+            ),
+            max_retries=self._max_retries,
+            backoff_base=self._min_delay_between_retries,
+        )
+
+    def close(self) -> None:
+        """Close resources owned by the HTTP client.
+
+        Transports that own a connection pool or a session override it. The default does nothing.
+        """
+
+    def send_request(
+        self,
+        *,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        content: bytes | None,
+        timeout: float | None,
+        stream: bool,
+    ) -> HttpResponse:
+        """Send one request through the underlying HTTP library.
+
+        Required by the inherited `call`, so a transport adapter must implement it. Overriding `call` itself
+        bypasses it entirely. Let the HTTP library's exceptions propagate unwrapped: `call` classifies them
+        through `is_retryable_transport_error` and `is_timeout_error`.
+
+        Args:
+            method: HTTP method (GET, POST, PUT, DELETE, etc.).
+            url: Full request URL, with the query parameters already encoded into it.
+            headers: Final request headers, with the client's default headers already merged in.
+            content: Request body, already serialized and compressed, or None for a request without a body.
+            timeout: Timeout for this attempt in seconds, or None for no timeout at all.
+            stream: Whether to return the response with the body unread, so the caller can stream it.
+
+        Returns:
+            The HTTP response object.
+        """
+        raise NotImplementedError('Implement `send_request` to provide a transport, or override `call` entirely.')
+
+    @staticmethod
+    def _retry_with_exp_backoff(
+        func: Callable[[Callable[[], None], int], T],
+        *,
+        max_retries: int = 8,
+        backoff_base: timedelta = timedelta(milliseconds=500),
+        backoff_factor: float = 2,
+        random_factor: float = 1,
+    ) -> T:
+        """Retry a function with exponential backoff and jitter."""
+        if max_retries < 1:
+            raise ValueError(f'max_retries must be at least 1, got {max_retries}')
+
+        random_factor = min(max(0, random_factor), 1)
+        backoff_factor = min(max(1, backoff_factor), 10)
+        swallow = True
+
+        def stop_retrying() -> None:
+            nonlocal swallow
+            swallow = False
+
+        for attempt in range(1, max_retries + 1):
+            try:
+                return func(stop_retrying, attempt)
+            except Exception:
+                if not swallow:
+                    raise
+
+            random_sleep_factor = random.uniform(1, 1 + random_factor)
+            backoff_base_secs = to_seconds(backoff_base)
+            backoff_exp_factor = backoff_factor ** (attempt - 1)
+            time.sleep(random_sleep_factor * backoff_base_secs * backoff_exp_factor)
+
+        return func(stop_retrying, max_retries + 1)
+
+    def _make_request(
+        self,
+        *,
+        stop_retrying: Callable[[], None],
+        attempt: int,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        params: dict[str, Any] | None,
+        content: bytes | None,
+        stream: bool | None,
+        timeout: Timeout,
+    ) -> HttpResponse:
+        """Execute one request attempt through the transport adapter."""
+        log_context.attempt.set(attempt)
+        logger.debug('Sending request')
+
+        self._statistics.requests += 1
+
+        try:
+            response = self.send_request(
+                method=method,
+                url=self._build_url_with_params(url, params=params),
+                headers=headers,
+                content=content,
+                timeout=self._compute_timeout(timeout, attempt=attempt),
+                stream=stream or False,
+            )
+        except Exception as exc:
+            self._handle_request_exception(exc, stop_retrying=stop_retrying)
+            raise
+
+        if self._handle_response_status(response, attempt=attempt, stop_retrying=stop_retrying):
+            return response
+
+        # Read the response in case it is a stream, so the error can be raised properly.
+        response.read()
+        raise ApifyApiError(response, attempt, method=method)
 
 
 @docs_group('HTTP clients')
-class HttpClientAsync(HttpClientBase, ABC):
-    """Abstract base class for asynchronous HTTP clients used by `ApifyClientAsync`.
+class HttpClientAsync(HttpClientBase):
+    """Base class for asynchronous HTTP clients used by `ApifyClientAsync`.
 
     Extend this class to create a custom asynchronous HTTP client. See `HttpClient`
     for details on the expected behavior.
     """
 
-    @abstractmethod
+    async def __aenter__(self) -> Self:
+        """Return this client and close it when the async context exits."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close resources owned by the asynchronous HTTP client."""
+        await self.aclose()
+
     async def call(
         self,
         *,
@@ -400,16 +621,16 @@ class HttpClientAsync(HttpClientBase, ABC):
         headers: dict[str, str] | None = None,
         params: dict[str, Any] | None = None,
         data: str | bytes | bytearray | None = None,
-        json: Any = None,
+        json: JsonSerializable | None = None,
         stream: bool | None = None,
         timeout: Timeout = 'medium',
     ) -> HttpResponse:
-        """Make an HTTP request.
+        """Make an HTTP request with automatic retry and exponential backoff.
 
         Args:
             method: HTTP method (GET, POST, PUT, DELETE, etc.).
             url: Full URL to make the request to.
-            headers: Additional headers to include in this request.
+            headers: Additional headers to include.
             params: Query parameters to append to the URL.
             data: Raw request body data. Cannot be used together with json.
             json: JSON-serializable data for the request body. Cannot be used together with data.
@@ -425,3 +646,152 @@ class HttpClientAsync(HttpClientBase, ABC):
             ApifyApiError: If the request fails after all retries or returns a non-retryable error status.
             ValueError: If both json and data are provided.
         """
+        log_context.method.set(method)
+        log_context.url.set(url)
+
+        self._statistics.calls += 1
+
+        # Serializing and compressing a request body is CPU-bound and would block the event loop, so
+        # offload preparation to a worker thread whenever there is something to compress. A body the
+        # client sends as it is costs less to prepare inline than the hop itself. A `json` body always
+        # hops, as its size is only known once serialized.
+        if json is not None or self._is_body_worth_compressing(data):
+            prepared_headers, prepared_params, content = await asyncio.to_thread(
+                self._prepare_request_call,
+                headers=headers,
+                params=params,
+                data=data,
+                json=json,
+            )
+        else:
+            prepared_headers, prepared_params, content = self._prepare_request_call(
+                headers=headers,
+                params=params,
+                data=data,
+                json=json,
+            )
+
+        return await self._retry_with_exp_backoff(
+            lambda stop_retrying, attempt: self._make_request(
+                stop_retrying=stop_retrying,
+                attempt=attempt,
+                method=method,
+                url=url,
+                headers=prepared_headers,
+                params=prepared_params,
+                content=content,
+                stream=stream,
+                timeout=timeout,
+            ),
+            max_retries=self._max_retries,
+            backoff_base=self._min_delay_between_retries,
+        )
+
+    async def aclose(self) -> None:
+        """Close resources owned by the asynchronous HTTP client.
+
+        Transports that own a connection pool or a session override it. The default does nothing.
+        """
+
+    async def send_request(
+        self,
+        *,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        content: bytes | None,
+        timeout: float | None,
+        stream: bool,
+    ) -> HttpResponse:
+        """Send one request through the underlying HTTP library.
+
+        Required by the inherited `call`, so a transport adapter must implement it. Overriding `call` itself
+        bypasses it entirely. Let the HTTP library's exceptions propagate unwrapped: `call` classifies them
+        through `is_retryable_transport_error` and `is_timeout_error`.
+
+        Args:
+            method: HTTP method (GET, POST, PUT, DELETE, etc.).
+            url: Full request URL, with the query parameters already encoded into it.
+            headers: Final request headers, with the client's default headers already merged in.
+            content: Request body, already serialized and compressed, or None for a request without a body.
+            timeout: Timeout for this attempt in seconds, or None for no timeout at all.
+            stream: Whether to return the response with the body unread, so the caller can stream it.
+
+        Returns:
+            The HTTP response object.
+        """
+        raise NotImplementedError('Implement `send_request` to provide a transport, or override `call` entirely.')
+
+    @staticmethod
+    async def _retry_with_exp_backoff(
+        func: Callable[[Callable[[], None], int], Awaitable[T]],
+        *,
+        max_retries: int = 8,
+        backoff_base: timedelta = timedelta(milliseconds=500),
+        backoff_factor: float = 2,
+        random_factor: float = 1,
+    ) -> T:
+        """Retry an async function with exponential backoff and jitter."""
+        if max_retries < 1:
+            raise ValueError(f'max_retries must be at least 1, got {max_retries}')
+
+        random_factor = min(max(0, random_factor), 1)
+        backoff_factor = min(max(1, backoff_factor), 10)
+        swallow = True
+
+        def stop_retrying() -> None:
+            nonlocal swallow
+            swallow = False
+
+        for attempt in range(1, max_retries + 1):
+            try:
+                return await func(stop_retrying, attempt)
+            except Exception:
+                if not swallow:
+                    raise
+
+            random_sleep_factor = random.uniform(1, 1 + random_factor)
+            backoff_base_secs = to_seconds(backoff_base)
+            backoff_exp_factor = backoff_factor ** (attempt - 1)
+            await asyncio.sleep(random_sleep_factor * backoff_base_secs * backoff_exp_factor)
+
+        return await func(stop_retrying, max_retries + 1)
+
+    async def _make_request(
+        self,
+        *,
+        stop_retrying: Callable[[], None],
+        attempt: int,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        params: dict[str, Any] | None,
+        content: bytes | None,
+        stream: bool | None,
+        timeout: Timeout,
+    ) -> HttpResponse:
+        """Execute one request attempt through the transport adapter."""
+        log_context.attempt.set(attempt)
+        logger.debug('Sending request')
+
+        self._statistics.requests += 1
+
+        try:
+            response = await self.send_request(
+                method=method,
+                url=self._build_url_with_params(url, params=params),
+                headers=headers,
+                content=content,
+                timeout=self._compute_timeout(timeout, attempt=attempt),
+                stream=stream or False,
+            )
+        except Exception as exc:
+            self._handle_request_exception(exc, stop_retrying=stop_retrying)
+            raise
+
+        if self._handle_response_status(response, attempt=attempt, stop_retrying=stop_retrying):
+            return response
+
+        # Read the response in case it is a stream, so the error can be raised properly.
+        await response.aread()
+        raise ApifyApiError(response, attempt, method=method)

--- a/src/apify_client/http_clients/_impit.py
+++ b/src/apify_client/http_clients/_impit.py
@@ -1,14 +1,9 @@
 from __future__ import annotations
 
-import asyncio
-import logging
-import random
-import time
-from datetime import timedelta
-from http import HTTPStatus
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING
 
 import impit
+from typing_extensions import override
 
 from apify_client._consts import (
     DEFAULT_MAX_RETRIES,
@@ -19,38 +14,13 @@ from apify_client._consts import (
     DEFAULT_TIMEOUT_SHORT,
 )
 from apify_client._docs import docs_group
-from apify_client._logging import log_context, logger_name
-from apify_client._utils.time import to_seconds
-from apify_client.errors import ApifyApiError, InvalidResponseBodyError
 from apify_client.http_clients._base import HttpClient, HttpClientAsync
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from datetime import timedelta
 
     from apify_client._statistics import ClientStatistics
-    from apify_client.http_clients._base import HttpResponse
     from apify_client.http_compressors._base import HttpCompressor
-    from apify_client.types import JsonSerializable, Timeout
-
-T = TypeVar('T')
-
-logger = logging.getLogger(logger_name)
-
-
-def _is_retryable_error(exc: Exception) -> bool:
-    """Check if an exception represents a transient error that should be retried.
-
-    All `impit.HTTPError` subclasses are considered retryable because they represent transport-level failures
-    (network issues, timeouts, protocol errors, body decoding errors) that are typically transient. HTTP status
-    code errors are handled separately in `_make_request` based on the response status code, not here.
-    """
-    return isinstance(
-        exc,
-        (
-            InvalidResponseBodyError,
-            impit.HTTPError,
-        ),
-    )
 
 
 @docs_group('HTTP clients')
@@ -103,203 +73,51 @@ class ImpitHttpClient(HttpClient):
             http_compressor=http_compressor,
         )
 
-        self._impit_client = impit.Client(
-            follow_redirects=True,
-        )
+        self._impit_client = impit.Client(follow_redirects=True)
 
-    def call(
-        self,
-        *,
-        method: str,
-        url: str,
-        headers: dict[str, str] | None = None,
-        params: dict[str, Any] | None = None,
-        data: str | bytes | bytearray | None = None,
-        json: JsonSerializable | None = None,
-        stream: bool | None = None,
-        timeout: Timeout = 'medium',
-    ) -> HttpResponse:
-        """Make an HTTP request with automatic retry and exponential backoff.
+    @override
+    def is_timeout_error(self, exc: Exception) -> bool:
+        return super().is_timeout_error(exc) or isinstance(exc, impit.TimeoutException)
 
-        Args:
-            method: HTTP method (GET, POST, PUT, DELETE, etc.).
-            url: Full URL to make the request to.
-            headers: Additional headers to include.
-            params: Query parameters to append to the URL.
-            data: Raw request body data. Cannot be used together with json.
-            json: JSON-serializable data for the request body. Cannot be used together with data.
-            stream: Whether to stream the response body.
-            timeout: Timeout for the API HTTP request. Use `short`, `medium`, or `long` tier literals for
-                preconfigured timeouts. A `timedelta` overrides it for this call (capped at `timeout_max`), and
-                `no_timeout` disables the timeout entirely.
+    @override
+    def is_retryable_transport_error(self, exc: Exception) -> bool:
+        # All errors from Impit's own hierarchy count as transient - they represent transport-level failures
+        # (network issues, timeouts, protocol errors, body decoding errors) that are typically transient.
+        return isinstance(exc, impit.HTTPError)
 
-        Returns:
-            The HTTP response object.
+    @override
+    def close(self) -> None:
+        """Release resources owned by this client.
 
-        Raises:
-            ApifyApiError: If the request fails after all retries or returns a non-retryable error status.
-            ValueError: If both json and data are provided.
+        Delegates to Impit's own teardown, which releases nothing and leaves the client usable, because Impit
+        doesn't expose a way to close its connection pool. Routing through it keeps this client correct once
+        Impit does.
         """
-        log_context.method.set(method)
-        log_context.url.set(url)
+        self._impit_client.__exit__(None, None, None)
 
-        self._statistics.calls += 1
-
-        prepared_headers, prepared_params, content = self._prepare_request_call(
-            headers=headers,
-            params=params,
-            data=data,
-            json=json,
-        )
-
-        return self._retry_with_exp_backoff(
-            lambda stop_retrying, attempt: self._make_request(
-                stop_retrying=stop_retrying,
-                attempt=attempt,
-                method=method,
-                url=url,
-                headers=prepared_headers,
-                params=prepared_params,
-                content=content,
-                stream=stream,
-                timeout=timeout,
-            ),
-            max_retries=self._max_retries,
-            backoff_base=self._min_delay_between_retries,
-        )
-
-    def _make_request(
+    @override
+    def send_request(
         self,
         *,
-        stop_retrying: Callable[[], None],
-        attempt: int,
         method: str,
         url: str,
         headers: dict[str, str],
-        params: dict[str, Any] | None,
         content: bytes | None,
-        stream: bool | None,
-        timeout: Timeout,
+        timeout: float | None,
+        stream: bool,
     ) -> impit.Response:
-        """Execute a single HTTP request attempt.
-
-        Args:
-            stop_retrying: Callback to signal that retries should stop.
-            attempt: Current attempt number (1-indexed).
-            method: HTTP method.
-            url: Request URL.
-            headers: Request headers.
-            params: Query parameters.
-            content: Request body content.
-            stream: Whether to stream the response.
-            timeout: Timeout for this request.
-
-        Returns:
-            The HTTP response object.
-
-        Raises:
-            ApifyApiError: If the request fails with an error status.
-        """
-        log_context.attempt.set(attempt)
-        logger.debug('Sending request')
-
-        self._statistics.requests += 1
-
-        try:
-            url_with_params = self._build_url_with_params(url, params=params)
-
-            # Impit treats timeout=None as "use client default (30s)", not "no timeout".
-            # Use a large value (24 hours) to effectively disable the timeout.
-            # This can be removed once impit updates its behaviour: https://github.com/apify/impit/issues/401
-            computed_timeout = self._compute_timeout(timeout, attempt=attempt)
-            impit_timeout = 86_400 if computed_timeout is None else computed_timeout
-
-            response = self._impit_client.request(
-                method=method,
-                url=url_with_params,
-                headers=headers,
-                content=content,
-                timeout=impit_timeout,
-                stream=stream or False,
-            )
-
-            if response.status_code < HTTPStatus.MULTIPLE_CHOICES:
-                logger.debug('Request successful', extra={'status_code': response.status_code})
-                return response
-
-            if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
-                self._statistics.add_rate_limit_error(attempt)
-
-        except Exception as exc:
-            logger.debug('Request threw exception', exc_info=exc)
-            if not _is_retryable_error(exc):
-                logger.debug('Exception is not retryable', exc_info=exc)
-                stop_retrying()
-            raise
-
-        # Retry only server errors (5xx) and rate limits (429).
-        logger.debug('Request unsuccessful', extra={'status_code': response.status_code})
-        if (
-            response.status_code < HTTPStatus.INTERNAL_SERVER_ERROR
-            and response.status_code != HTTPStatus.TOO_MANY_REQUESTS
-        ):
-            logger.debug('Status code is not retryable', extra={'status_code': response.status_code})
-            stop_retrying()
-
-        # Read the response in case it is a stream, so we can raise the error properly.
-        response.read()
-        raise ApifyApiError(response, attempt, method=method)
-
-    @staticmethod
-    def _retry_with_exp_backoff(
-        func: Callable[[Callable[[], None], int], T],
-        *,
-        max_retries: int = 8,
-        backoff_base: timedelta = timedelta(milliseconds=500),
-        backoff_factor: float = 2,
-        random_factor: float = 1,
-    ) -> T:
-        """Retry a function with exponential backoff and jitter.
-
-        Args:
-            func: Function to retry. Receives (stop_retrying callback, attempt number).
-            max_retries: Maximum retry attempts.
-            backoff_base: Base delay.
-            backoff_factor: Exponential multiplier (clamped to 1-10).
-            random_factor: Jitter factor (clamped to 0-1).
-
-        Returns:
-            The function's return value on success.
-
-        Raises:
-            Exception: Re-raises the last exception if all retries fail or stop_retrying is called.
-        """
-        if max_retries < 1:
-            raise ValueError(f'max_retries must be at least 1, got {max_retries}')
-
-        random_factor = min(max(0, random_factor), 1)
-        backoff_factor = min(max(1, backoff_factor), 10)
-        swallow = True
-
-        def stop_retrying() -> None:
-            nonlocal swallow
-            swallow = False
-
-        for attempt in range(1, max_retries + 1):
-            try:
-                return func(stop_retrying, attempt)
-            except Exception:
-                if not swallow:
-                    raise
-
-            random_sleep_factor = random.uniform(1, 1 + random_factor)
-            backoff_base_secs = to_seconds(backoff_base)
-            backoff_exp_factor = backoff_factor ** (attempt - 1)
-
-            sleep_time_secs = random_sleep_factor * backoff_base_secs * backoff_exp_factor
-            time.sleep(sleep_time_secs)
-
-        return func(stop_retrying, max_retries + 1)
+        # Impit treats timeout=None as "use client default (30s)", not "no timeout".
+        # Use a large value (24 hours) to effectively disable the timeout.
+        # This can be removed once impit updates its behaviour: https://github.com/apify/impit/issues/401
+        impit_timeout = 86_400 if timeout is None else timeout
+        return self._impit_client.request(
+            method=method,
+            url=url,
+            headers=headers,
+            content=content,
+            timeout=impit_timeout,
+            stream=stream,
+        )
 
 
 @docs_group('HTTP clients')
@@ -352,213 +170,44 @@ class ImpitHttpClientAsync(HttpClientAsync):
             http_compressor=http_compressor,
         )
 
-        self._impit_async_client = impit.AsyncClient(
-            follow_redirects=True,
-        )
+        self._impit_async_client = impit.AsyncClient(follow_redirects=True)
 
-    async def call(
-        self,
-        *,
-        method: str,
-        url: str,
-        headers: dict[str, str] | None = None,
-        params: dict[str, Any] | None = None,
-        data: str | bytes | bytearray | None = None,
-        json: JsonSerializable | None = None,
-        stream: bool | None = None,
-        timeout: Timeout = 'medium',
-    ) -> HttpResponse:
-        """Make an HTTP request with automatic retry and exponential backoff.
+    @override
+    def is_timeout_error(self, exc: Exception) -> bool:
+        return super().is_timeout_error(exc) or isinstance(exc, impit.TimeoutException)
 
-        Args:
-            method: HTTP method (GET, POST, PUT, DELETE, etc.).
-            url: Full URL to make the request to.
-            headers: Additional headers to include.
-            params: Query parameters to append to the URL.
-            data: Raw request body data. Cannot be used together with json.
-            json: JSON-serializable data for the request body. Cannot be used together with data.
-            stream: Whether to stream the response body.
-            timeout: Timeout for the API HTTP request. Use `short`, `medium`, or `long` tier literals for
-                preconfigured timeouts. A `timedelta` overrides it for this call (capped at `timeout_max`), and
-                `no_timeout` disables the timeout entirely.
+    @override
+    def is_retryable_transport_error(self, exc: Exception) -> bool:
+        # All errors from Impit's own hierarchy count as transient - they represent transport-level failures
+        # (network issues, timeouts, protocol errors, body decoding errors) that are typically transient.
+        return isinstance(exc, impit.HTTPError)
 
-        Returns:
-            The HTTP response object.
+    @override
+    async def aclose(self) -> None:
+        """Release resources owned by this client.
 
-        Raises:
-            ApifyApiError: If the request fails after all retries or returns a non-retryable error status.
-            ValueError: If both json and data are provided.
+        See `ImpitHttpClient.close` for what Impit's teardown does.
         """
-        log_context.method.set(method)
-        log_context.url.set(url)
+        await self._impit_async_client.__aexit__(None, None, None)
 
-        self._statistics.calls += 1
-
-        # Serializing and compressing a request body is CPU-bound and would block the event loop, so
-        # offload preparation to a worker thread whenever there is something to compress. A body the
-        # client sends as it is costs less to prepare inline than the hop itself. A `json` body always
-        # hops, as its size is only known once serialized.
-        if json is not None or self._is_body_worth_compressing(data):
-            prepared_headers, prepared_params, content = await asyncio.to_thread(
-                self._prepare_request_call,
-                headers=headers,
-                params=params,
-                data=data,
-                json=json,
-            )
-        else:
-            prepared_headers, prepared_params, content = self._prepare_request_call(
-                headers=headers,
-                params=params,
-                data=data,
-                json=json,
-            )
-
-        return await self._retry_with_exp_backoff(
-            lambda stop_retrying, attempt: self._make_request(
-                stop_retrying=stop_retrying,
-                attempt=attempt,
-                method=method,
-                url=url,
-                headers=prepared_headers,
-                params=prepared_params,
-                content=content,
-                stream=stream,
-                timeout=timeout,
-            ),
-            max_retries=self._max_retries,
-            backoff_base=self._min_delay_between_retries,
-        )
-
-    async def _make_request(
+    @override
+    async def send_request(
         self,
         *,
-        stop_retrying: Callable[[], None],
-        attempt: int,
         method: str,
         url: str,
         headers: dict[str, str],
-        params: dict[str, Any] | None,
         content: bytes | None,
-        stream: bool | None,
-        timeout: Timeout,
+        timeout: float | None,
+        stream: bool,
     ) -> impit.Response:
-        """Execute a single HTTP request attempt.
-
-        Args:
-            stop_retrying: Callback to signal that retries should stop.
-            attempt: Current attempt number (1-indexed).
-            method: HTTP method.
-            url: Request URL.
-            headers: Request headers.
-            params: Query parameters.
-            content: Request body content.
-            stream: Whether to stream the response.
-            timeout: Timeout for this request.
-
-        Returns:
-            The HTTP response object.
-
-        Raises:
-            ApifyApiError: If the request fails with an error status.
-        """
-        log_context.attempt.set(attempt)
-        logger.debug('Sending request')
-
-        self._statistics.requests += 1
-
-        try:
-            url_with_params = self._build_url_with_params(url, params=params)
-
-            # Impit treats timeout=None as "use client default (30s)", not "no timeout".
-            # Use a large value (24 hours) to effectively disable the timeout.
-            # This can be removed once impit updates its behaviour: https://github.com/apify/impit/issues/401
-            computed_timeout = self._compute_timeout(timeout, attempt=attempt)
-            impit_timeout = 86_400 if computed_timeout is None else computed_timeout
-
-            response = await self._impit_async_client.request(
-                method=method,
-                url=url_with_params,
-                headers=headers,
-                content=content,
-                timeout=impit_timeout,
-                stream=stream or False,
-            )
-
-            if response.status_code < HTTPStatus.MULTIPLE_CHOICES:
-                logger.debug('Request successful', extra={'status_code': response.status_code})
-                return response
-
-            if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
-                self._statistics.add_rate_limit_error(attempt)
-
-        except Exception as exc:
-            logger.debug('Request threw exception', exc_info=exc)
-            if not _is_retryable_error(exc):
-                logger.debug('Exception is not retryable', exc_info=exc)
-                stop_retrying()
-            raise
-
-        # Retry only server errors (5xx) and rate limits (429).
-        logger.debug('Request unsuccessful', extra={'status_code': response.status_code})
-        if (
-            response.status_code < HTTPStatus.INTERNAL_SERVER_ERROR
-            and response.status_code != HTTPStatus.TOO_MANY_REQUESTS
-        ):
-            logger.debug('Status code is not retryable', extra={'status_code': response.status_code})
-            stop_retrying()
-
-        # Read the response in case it is a stream, so we can raise the error properly.
-        await response.aread()
-        raise ApifyApiError(response, attempt, method=method)
-
-    @staticmethod
-    async def _retry_with_exp_backoff(
-        func: Callable[[Callable[[], None], int], Awaitable[T]],
-        *,
-        max_retries: int = 8,
-        backoff_base: timedelta = timedelta(milliseconds=500),
-        backoff_factor: float = 2,
-        random_factor: float = 1,
-    ) -> T:
-        """Retry an async function with exponential backoff and jitter.
-
-        Args:
-            func: Async function to retry. Receives (stop_retrying callback, attempt number).
-            max_retries: Maximum retry attempts.
-            backoff_base: Base delay.
-            backoff_factor: Exponential multiplier (clamped to 1-10).
-            random_factor: Jitter factor (clamped to 0-1).
-
-        Returns:
-            The function's return value on success.
-
-        Raises:
-            Exception: Re-raises the last exception if all retries fail or stop_retrying is called.
-        """
-        if max_retries < 1:
-            raise ValueError(f'max_retries must be at least 1, got {max_retries}')
-
-        random_factor = min(max(0, random_factor), 1)
-        backoff_factor = min(max(1, backoff_factor), 10)
-        swallow = True
-
-        def stop_retrying() -> None:
-            nonlocal swallow
-            swallow = False
-
-        for attempt in range(1, max_retries + 1):
-            try:
-                return await func(stop_retrying, attempt)
-            except Exception:
-                if not swallow:
-                    raise
-
-            random_sleep_factor = random.uniform(1, 1 + random_factor)
-            backoff_base_secs = to_seconds(backoff_base)
-            backoff_exp_factor = backoff_factor ** (attempt - 1)
-
-            sleep_time_secs = random_sleep_factor * backoff_base_secs * backoff_exp_factor
-            await asyncio.sleep(sleep_time_secs)
-
-        return await func(stop_retrying, max_retries + 1)
+        # See the synchronous implementation for why None maps to 24 hours.
+        impit_timeout = 86_400 if timeout is None else timeout
+        return await self._impit_async_client.request(
+            method=method,
+            url=url,
+            headers=headers,
+            content=content,
+            timeout=impit_timeout,
+            stream=stream,
+        )

--- a/tests/unit/test_client_errors.py
+++ b/tests/unit/test_client_errors.py
@@ -18,13 +18,14 @@ from apify_client.errors import (
     ServerError,
     UnauthorizedError,
 )
-from apify_client.http_clients import ImpitHttpClient, ImpitHttpClientAsync
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from pytest_httpserver import HTTPServer
     from werkzeug import Request
+
+    from apify_client.http_clients import HttpClient, HttpClientAsync
 
 _TEST_PATH = '/errors'
 _EXPECTED_MESSAGE = 'some_message'
@@ -84,13 +85,21 @@ def streaming_handler(_request: Request) -> Response:
 
 
 @pytest.fixture
-def sync_client(httpserver: HTTPServer) -> ApifyClient:
-    return ApifyClient(token='test', api_url=httpserver.url_for('/').removesuffix('/'))
+def sync_client(httpserver: HTTPServer, http_client_class: type[HttpClient]) -> ApifyClient:
+    return ApifyClient.with_custom_http_client(
+        token='test',
+        api_url=httpserver.url_for('/').removesuffix('/'),
+        http_client=http_client_class(),
+    )
 
 
 @pytest.fixture
-def async_client(httpserver: HTTPServer) -> ApifyClientAsync:
-    return ApifyClientAsync(token='test', api_url=httpserver.url_for('/').removesuffix('/'))
+def async_client(httpserver: HTTPServer, http_client_async_class: type[HttpClientAsync]) -> ApifyClientAsync:
+    return ApifyClientAsync.with_custom_http_client(
+        token='test',
+        api_url=httpserver.url_for('/').removesuffix('/'),
+        http_client=http_client_async_class(),
+    )
 
 
 @pytest.fixture
@@ -101,9 +110,9 @@ def test_endpoint(httpserver: HTTPServer) -> str:
     return str(httpserver.url_for(_TEST_PATH))
 
 
-def test_client_apify_api_error_with_data(test_endpoint: str) -> None:
+def test_client_apify_api_error_with_data(test_endpoint: str, http_client_class: type[HttpClient]) -> None:
     """Test that client correctly throws ApifyApiError with error data from response."""
-    client = ImpitHttpClient()
+    client = http_client_class()
 
     with pytest.raises(ApifyApiError) as exc:
         client.call(method='GET', url=test_endpoint)
@@ -113,9 +122,11 @@ def test_client_apify_api_error_with_data(test_endpoint: str) -> None:
     assert exc.value.data == _EXPECTED_DATA
 
 
-async def test_async_client_apify_api_error_with_data(test_endpoint: str) -> None:
+async def test_async_client_apify_api_error_with_data(
+    test_endpoint: str, http_client_async_class: type[HttpClientAsync]
+) -> None:
     """Test that async client correctly throws ApifyApiError with error data from response."""
-    client = ImpitHttpClientAsync()
+    client = http_client_async_class()
 
     with pytest.raises(ApifyApiError) as exc:
         await client.call(method='GET', url=test_endpoint)
@@ -125,12 +136,12 @@ async def test_async_client_apify_api_error_with_data(test_endpoint: str) -> Non
     assert exc.value.data == _EXPECTED_DATA
 
 
-def test_client_apify_api_error_streamed(httpserver: HTTPServer) -> None:
+def test_client_apify_api_error_streamed(httpserver: HTTPServer, http_client_class: type[HttpClient]) -> None:
     """Test that client correctly throws ApifyApiError when the response has stream."""
 
     error = json.loads(RAW_ERROR.decode())
 
-    client = ImpitHttpClient()
+    client = http_client_class()
 
     httpserver.expect_request('/stream_error').respond_with_handler(streaming_handler)
 
@@ -141,12 +152,14 @@ def test_client_apify_api_error_streamed(httpserver: HTTPServer) -> None:
     assert exc.value.type == error['error']['type']
 
 
-async def test_async_client_apify_api_error_streamed(httpserver: HTTPServer) -> None:
+async def test_async_client_apify_api_error_streamed(
+    httpserver: HTTPServer, http_client_async_class: type[HttpClientAsync]
+) -> None:
     """Test that async client correctly throws ApifyApiError when the response has stream."""
 
     error = json.loads(RAW_ERROR.decode())
 
-    client = ImpitHttpClientAsync()
+    client = http_client_async_class()
 
     httpserver.expect_request('/stream_error').respond_with_handler(streaming_handler)
 
@@ -157,12 +170,14 @@ async def test_async_client_apify_api_error_streamed(httpserver: HTTPServer) -> 
     assert exc.value.type == error['error']['type']
 
 
-def test_apify_api_error_dispatches_to_subclass_for_known_status(httpserver: HTTPServer) -> None:
+def test_apify_api_error_dispatches_to_subclass_for_known_status(
+    httpserver: HTTPServer, http_client_class: type[HttpClient]
+) -> None:
     """Mapped HTTP status codes dispatch to their matching subclass."""
     httpserver.expect_request('/dispatch').respond_with_json(
         {'error': {'type': 'record-not-found', 'message': 'nope'}}, status=404
     )
-    client = ImpitHttpClient()
+    client = http_client_class()
 
     with pytest.raises(NotFoundError) as exc:
         client.call(method='GET', url=str(httpserver.url_for('/dispatch')))
@@ -173,10 +188,12 @@ def test_apify_api_error_dispatches_to_subclass_for_known_status(httpserver: HTT
     assert exc.value.type == 'record-not-found'
 
 
-def test_apify_api_error_dispatches_streamed_response(httpserver: HTTPServer) -> None:
+def test_apify_api_error_dispatches_streamed_response(
+    httpserver: HTTPServer, http_client_class: type[HttpClient]
+) -> None:
     """Dispatch works even when the response body comes in as a stream (403 → ForbiddenError)."""
     httpserver.expect_request('/stream_dispatch').respond_with_handler(streaming_handler)
-    client = ImpitHttpClient()
+    client = http_client_class()
 
     with pytest.raises(ForbiddenError) as exc:
         client.call(method='GET', url=httpserver.url_for('/stream_dispatch'), stream=True)
@@ -186,12 +203,14 @@ def test_apify_api_error_dispatches_streamed_response(httpserver: HTTPServer) ->
     assert exc.value.type == 'insufficient-permissions'
 
 
-def test_apify_api_error_dispatches_5xx_to_server_error(httpserver: HTTPServer) -> None:
+def test_apify_api_error_dispatches_5xx_to_server_error(
+    httpserver: HTTPServer, http_client_class: type[HttpClient]
+) -> None:
     """Any 5xx status falls under the ServerError subclass."""
     httpserver.expect_request('/server_error').respond_with_json(
         {'error': {'type': 'internal-error', 'message': 'boom'}}, status=503
     )
-    client = ImpitHttpClient(max_retries=1)
+    client = http_client_class(max_retries=1)
 
     with pytest.raises(ServerError) as exc:
         client.call(method='GET', url=str(httpserver.url_for('/server_error')))
@@ -200,12 +219,14 @@ def test_apify_api_error_dispatches_5xx_to_server_error(httpserver: HTTPServer) 
     assert exc.value.status_code == 503
 
 
-def test_apify_api_error_falls_back_for_unmapped_status(httpserver: HTTPServer) -> None:
+def test_apify_api_error_falls_back_for_unmapped_status(
+    httpserver: HTTPServer, http_client_class: type[HttpClient]
+) -> None:
     """Statuses without a dedicated subclass fall back to the base ApifyApiError."""
     httpserver.expect_request('/unmapped').respond_with_json(
         {'error': {'type': 'whatever', 'message': 'nope'}}, status=418
     )
-    client = ImpitHttpClient()
+    client = http_client_class()
 
     with pytest.raises(ApifyApiError) as exc:
         client.call(method='GET', url=str(httpserver.url_for('/unmapped')))
@@ -227,14 +248,17 @@ def test_apify_api_error_falls_back_for_unmapped_status(httpserver: HTTPServer) 
     ],
 )
 def test_apify_api_error_dispatches_all_mapped_statuses(
-    httpserver: HTTPServer, status_code: int, expected_cls: type[ApifyApiError]
+    httpserver: HTTPServer,
+    http_client_class: type[HttpClient],
+    status_code: int,
+    expected_cls: type[ApifyApiError],
 ) -> None:
     """Every status in `_STATUS_TO_CLASS` dispatches to its matching subclass."""
     httpserver.expect_request('/dispatch_all').respond_with_json(
         {'error': {'type': 'some-type', 'message': 'msg'}}, status=status_code
     )
     # Use max_retries=1 so retryable statuses (429) don't loop during the test.
-    client = ImpitHttpClient(max_retries=1)
+    client = http_client_class(max_retries=1)
 
     with pytest.raises(expected_cls) as exc:
         client.call(method='GET', url=str(httpserver.url_for('/dispatch_all')))
@@ -258,10 +282,12 @@ def test_apify_api_error_subclass_constructed_directly_keeps_its_class() -> None
     assert error.type == 'record-not-found'
 
 
-def test_apify_api_error_falls_back_for_unparsable_body(httpserver: HTTPServer) -> None:
+def test_apify_api_error_falls_back_for_unparsable_body(
+    httpserver: HTTPServer, http_client_class: type[HttpClient]
+) -> None:
     """When the body can't be parsed, status-based dispatch still applies and `.type` is None."""
     httpserver.expect_request('/unparsable').respond_with_data('<not json>', status=418, content_type='text/html')
-    client = ImpitHttpClient(max_retries=1)
+    client = http_client_class(max_retries=1)
 
     with pytest.raises(ApifyApiError) as exc:
         client.call(method='GET', url=str(httpserver.url_for('/unparsable')))

--- a/tests/unit/test_client_headers.py
+++ b/tests/unit/test_client_headers.py
@@ -8,10 +8,10 @@ from typing import TYPE_CHECKING
 
 from werkzeug import Request, Response
 
-from apify_client.http_clients import ImpitHttpClient, ImpitHttpClientAsync
-
 if TYPE_CHECKING:
     from pytest_httpserver import HTTPServer
+
+    from apify_client.http_clients import HttpClient, HttpClientAsync
 
 
 def _parse_accept_encoding(header: str) -> set[str]:
@@ -34,9 +34,9 @@ def _get_user_agent() -> str:
     return f'ApifyClient/{client_version} ({sys.platform}; Python/{python_version}); isAtHome/{is_at_home}'
 
 
-async def test_default_headers_async(httpserver: HTTPServer) -> None:
+async def test_default_headers_async(httpserver: HTTPServer, http_client_async_class: type[HttpClientAsync]) -> None:
     """Test that default headers are sent with each request."""
-    client = ImpitHttpClientAsync(token='placeholder_token')
+    client = http_client_async_class(token='placeholder_token')
     httpserver.expect_request('/').respond_with_handler(_header_handler)
     api_url = httpserver.url_for('/').removesuffix('/')
 
@@ -54,9 +54,9 @@ async def test_default_headers_async(httpserver: HTTPServer) -> None:
     assert _parse_accept_encoding(request_headers['Accept-Encoding']) == {'gzip', 'br', 'zstd', 'deflate'}
 
 
-def test_default_headers_sync(httpserver: HTTPServer) -> None:
+def test_default_headers_sync(httpserver: HTTPServer, http_client_class: type[HttpClient]) -> None:
     """Test that default headers are sent with each request."""
-    client = ImpitHttpClient(token='placeholder_token')
+    client = http_client_class(token='placeholder_token')
     httpserver.expect_request('/').respond_with_handler(_header_handler)
     api_url = httpserver.url_for('/').removesuffix('/')
 
@@ -74,9 +74,9 @@ def test_default_headers_sync(httpserver: HTTPServer) -> None:
     assert _parse_accept_encoding(request_headers['Accept-Encoding']) == {'gzip', 'br', 'zstd', 'deflate'}
 
 
-async def test_headers_async(httpserver: HTTPServer) -> None:
+async def test_headers_async(httpserver: HTTPServer, http_client_async_class: type[HttpClientAsync]) -> None:
     """Test that custom headers are sent with each request."""
-    client = ImpitHttpClientAsync(
+    client = http_client_async_class(
         token='placeholder_token',
         headers={'Test-Header': 'blah', 'User-Agent': 'CustomUserAgent/1.0', 'Authorization': 'strange_value'},
     )
@@ -98,9 +98,9 @@ async def test_headers_async(httpserver: HTTPServer) -> None:
     assert _parse_accept_encoding(request_headers['Accept-Encoding']) == {'gzip', 'br', 'zstd', 'deflate'}
 
 
-def test_headers_sync(httpserver: HTTPServer) -> None:
+def test_headers_sync(httpserver: HTTPServer, http_client_class: type[HttpClient]) -> None:
     """Test that custom headers are sent with each request."""
-    client = ImpitHttpClient(
+    client = http_client_class(
         token='placeholder_token',
         headers={
             'Test-Header': 'blah',
@@ -126,9 +126,11 @@ def test_headers_sync(httpserver: HTTPServer) -> None:
     assert _parse_accept_encoding(request_headers['Accept-Encoding']) == {'gzip', 'br', 'zstd', 'deflate'}
 
 
-async def test_per_request_headers_override_defaults_async(httpserver: HTTPServer) -> None:
+async def test_per_request_headers_override_defaults_async(
+    httpserver: HTTPServer, http_client_async_class: type[HttpClientAsync]
+) -> None:
     """Test that a per-request header overrides a same-named default header on the wire, without duplication."""
-    client = ImpitHttpClientAsync(token='placeholder_token')
+    client = http_client_async_class(token='placeholder_token')
     httpserver.expect_request('/').respond_with_handler(_header_handler)
     api_url = httpserver.url_for('/').removesuffix('/')
 
@@ -141,9 +143,11 @@ async def test_per_request_headers_override_defaults_async(httpserver: HTTPServe
     assert request_headers['Authorization'] == 'Bearer per-request'
 
 
-def test_per_request_headers_override_defaults_sync(httpserver: HTTPServer) -> None:
+def test_per_request_headers_override_defaults_sync(
+    httpserver: HTTPServer, http_client_class: type[HttpClient]
+) -> None:
     """Test that a per-request header overrides a same-named default header on the wire, without duplication."""
-    client = ImpitHttpClient(token='placeholder_token')
+    client = http_client_class(token='placeholder_token')
     httpserver.expect_request('/').respond_with_handler(_header_handler)
     api_url = httpserver.url_for('/').removesuffix('/')
 

--- a/tests/unit/test_client_timeouts.py
+++ b/tests/unit/test_client_timeouts.py
@@ -3,40 +3,17 @@ from __future__ import annotations
 import logging
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
+import impit
 import pytest
-from impit import HTTPError, Response, TimeoutException
 
 from apify_client._logging import LoggerOnce, logger_name
-from apify_client.http_clients import ImpitHttpClient, ImpitHttpClientAsync
+from apify_client.http_clients import HttpClient, HttpClientAsync, ImpitHttpClient, ImpitHttpClientAsync
 from apify_client.http_clients import _base as http_client_base
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-
     from _pytest.logging import LogCaptureFixture
-
-
-class EndOfTestError(Exception):
-    """Custom exception that is raised after the relevant part of the code is executed to stop the test."""
-
-
-@pytest.fixture
-def patch_request(monkeypatch: pytest.MonkeyPatch) -> Iterator[list]:
-    timeouts = []
-
-    def mock_request(*_args: Any, **kwargs: Any) -> None:
-        timeouts.append(kwargs.get('timeout'))
-        raise EndOfTestError
-
-    async def mock_request_async(*args: Any, **kwargs: Any) -> None:
-        return mock_request(*args, **kwargs)
-
-    monkeypatch.setattr('impit.Client.request', mock_request)
-    monkeypatch.setattr('impit.AsyncClient.request', mock_request_async)
-    yield timeouts
-    monkeypatch.undo()
 
 
 @pytest.fixture
@@ -45,125 +22,93 @@ def fresh_logger_once(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(http_client_base, 'logger_once', LoggerOnce(http_client_base.logger))
 
 
-def test_no_timeout_passes_large_value_to_impit_sync(patch_request: list) -> None:
-    """Test that `no_timeout` passes a large timeout to impit to effectively disable the timeout."""
-    client = ImpitHttpClient(timeout_short=timedelta(seconds=10))
-
-    with pytest.raises(EndOfTestError):
-        client.call(method='GET', url='http://placeholder.url/no_timeout', timeout='no_timeout')
-
-    assert patch_request == [86_400]
+def successful_response() -> Mock:
+    return Mock(status_code=200)
 
 
-async def test_no_timeout_passes_large_value_to_impit_async(patch_request: list) -> None:
-    """Test that `no_timeout` passes a large timeout to impit to effectively disable the timeout."""
-    client = ImpitHttpClientAsync(timeout_short=timedelta(seconds=10))
+@pytest.mark.parametrize(
+    ('timeout', 'expected'),
+    [
+        pytest.param('no_timeout', None, id='no-timeout'),
+        pytest.param(None, 30.0, id='default-medium'),
+        pytest.param('short', 5.0, id='short'),
+        pytest.param('medium', 30.0, id='medium'),
+        pytest.param('long', 300.0, id='long'),
+    ],
+)
+def test_timeout_resolves_for_sync_clients(
+    http_client_class: type[HttpClient],
+    monkeypatch: pytest.MonkeyPatch,
+    timeout: str | None,
+    expected: float | None,
+) -> None:
+    """Every synchronous client resolves timeout tiers at the shared transport boundary."""
+    client = http_client_class(
+        timeout_short=timedelta(seconds=5),
+        timeout_medium=timedelta(seconds=30),
+        timeout_long=timedelta(seconds=300),
+    )
+    send_request = Mock(return_value=successful_response())
+    monkeypatch.setattr(client, 'send_request', send_request)
 
-    with pytest.raises(EndOfTestError):
-        await client.call(method='GET', url='http://placeholder.url/no_timeout', timeout='no_timeout')
+    kwargs: dict[str, Any] = {'method': 'GET', 'url': 'https://example.com'}
+    if timeout is not None:
+        kwargs['timeout'] = timeout
+    client.call(**kwargs)
 
-    assert patch_request == [86_400]
-
-
-def test_default_timeout_uses_medium_tier_sync(patch_request: list) -> None:
-    """Test that omitting timeout uses the 'medium' tier (sync client)."""
-    client = ImpitHttpClient(timeout_medium=timedelta(seconds=30))
-
-    with pytest.raises(EndOfTestError):
-        client.call(method='GET', url='http://placeholder.url/default_timeout')
-
-    assert patch_request == [30.0]
-
-
-async def test_default_timeout_uses_medium_tier_async(patch_request: list) -> None:
-    """Test that omitting timeout uses the 'medium' tier (async client)."""
-    client = ImpitHttpClientAsync(timeout_medium=timedelta(seconds=30))
-
-    with pytest.raises(EndOfTestError):
-        await client.call(method='GET', url='http://placeholder.url/default_timeout')
-
-    assert patch_request == [30.0]
-
-
-def test_short_tier_resolves_correctly_sync(patch_request: list) -> None:
-    """Test that `'short'` tier resolves to timeout_short value."""
-    client = ImpitHttpClient(timeout_short=timedelta(seconds=5))
-
-    with pytest.raises(EndOfTestError):
-        client.call(method='GET', url='http://placeholder.url/short_tier', timeout='short')
-
-    assert patch_request == [5.0]
+    assert send_request.call_args.kwargs['timeout'] == expected
 
 
-def test_medium_tier_resolves_correctly_sync(patch_request: list) -> None:
-    """Test that `'medium'` tier resolves to the configured timeout value."""
-    client = ImpitHttpClient(timeout_medium=timedelta(seconds=30))
+@pytest.mark.parametrize(
+    ('timeout', 'expected'),
+    [
+        pytest.param('no_timeout', None, id='no-timeout'),
+        pytest.param(None, 30.0, id='default-medium'),
+        pytest.param('short', 5.0, id='short'),
+        pytest.param('medium', 30.0, id='medium'),
+        pytest.param('long', 300.0, id='long'),
+    ],
+)
+async def test_timeout_resolves_for_async_clients(
+    http_client_async_class: type[HttpClientAsync],
+    monkeypatch: pytest.MonkeyPatch,
+    timeout: str | None,
+    expected: float | None,
+) -> None:
+    """Every asynchronous client resolves timeout tiers at the shared transport boundary."""
+    client = http_client_async_class(
+        timeout_short=timedelta(seconds=5),
+        timeout_medium=timedelta(seconds=30),
+        timeout_long=timedelta(seconds=300),
+    )
+    send_request = AsyncMock(return_value=successful_response())
+    monkeypatch.setattr(client, 'send_request', send_request)
 
-    with pytest.raises(EndOfTestError):
-        client.call(method='GET', url='http://placeholder.url/timeout_tier', timeout='medium')
+    kwargs: dict[str, Any] = {'method': 'GET', 'url': 'https://example.com'}
+    if timeout is not None:
+        kwargs['timeout'] = timeout
+    await client.call(**kwargs)
 
-    assert patch_request == [30.0]
-
-
-def test_long_tier_resolves_correctly_sync(patch_request: list) -> None:
-    """Test that `'long'` tier resolves to timeout_long value."""
-    client = ImpitHttpClient(timeout_long=timedelta(seconds=300))
-
-    with pytest.raises(EndOfTestError):
-        client.call(method='GET', url='http://placeholder.url/long_tier', timeout='long')
-
-    assert patch_request == [300.0]
-
-
-async def test_medium_tier_resolves_correctly_async(patch_request: list) -> None:
-    """Test that `'medium'` tier resolves to the configured timeout value (async)."""
-    client = ImpitHttpClientAsync(timeout_medium=timedelta(seconds=30))
-
-    with pytest.raises(EndOfTestError):
-        await client.call(method='GET', url='http://placeholder.url/timeout_tier', timeout='medium')
-
-    assert patch_request == [30.0]
-
-
-async def test_long_tier_resolves_correctly_async(patch_request: list) -> None:
-    """Test that `'long'` tier resolves to timeout_long value (async)."""
-    client = ImpitHttpClientAsync(timeout_long=timedelta(seconds=300))
-
-    with pytest.raises(EndOfTestError):
-        await client.call(method='GET', url='http://placeholder.url/long_tier', timeout='long')
-
-    assert patch_request == [300.0]
+    assert send_request.call_args.kwargs['timeout'] == expected
 
 
-def test_compute_timeout_with_timedelta() -> None:
-    """Test _compute_timeout with a concrete timedelta doubles per attempt, capped at max."""
-    client = ImpitHttpClient(timeout_max=timedelta(seconds=600))
+def test_compute_timeout_with_timedelta(http_client_class: type[HttpClient]) -> None:
+    """Concrete timedeltas double per attempt, are capped at the maximum, and `no_timeout` stays unbounded."""
+    client = http_client_class(timeout_max=timedelta(seconds=20))
 
     assert client._compute_timeout(timedelta(seconds=5), attempt=1) == 5.0
     assert client._compute_timeout(timedelta(seconds=5), attempt=2) == 10.0
     assert client._compute_timeout(timedelta(seconds=5), attempt=3) == 20.0
-    assert client._compute_timeout(timedelta(seconds=5), attempt=4) == 40.0
-
-
-def test_compute_timeout_caps_at_max() -> None:
-    """Test _compute_timeout caps at timeout_max."""
-    client = ImpitHttpClient(timeout_max=timedelta(seconds=10))
-
-    assert client._compute_timeout(timedelta(seconds=5), attempt=1) == 5.0
-    assert client._compute_timeout(timedelta(seconds=5), attempt=2) == 10.0
-    assert client._compute_timeout(timedelta(seconds=5), attempt=3) == 10.0  # capped
-
-
-def test_compute_timeout_no_timeout_returns_none() -> None:
-    """Test _compute_timeout with 'no_timeout' returns None."""
-    client = ImpitHttpClient()
+    assert client._compute_timeout(timedelta(seconds=5), attempt=4) == 20.0
     assert client._compute_timeout('no_timeout', attempt=1) is None
 
 
 @pytest.mark.usefixtures('fresh_logger_once')
-def test_compute_timeout_explicit_timedelta_above_max_warns(caplog: LogCaptureFixture) -> None:
-    """Test an explicit timedelta larger than timeout_max is capped, and the cut-off is logged once."""
-    client = ImpitHttpClient(timeout_max=timedelta(seconds=360))
+def test_compute_timeout_explicit_timedelta_above_max_warns(
+    http_client_class: type[HttpClient], caplog: LogCaptureFixture
+) -> None:
+    """An explicit timedelta larger than timeout_max is capped, and the cut-off is logged once."""
+    client = http_client_class(timeout_max=timedelta(seconds=360))
 
     with caplog.at_level(logging.WARNING, logger=logger_name):
         assert client._compute_timeout(timedelta(minutes=30), attempt=1) == 360.0
@@ -176,9 +121,9 @@ def test_compute_timeout_explicit_timedelta_above_max_warns(caplog: LogCaptureFi
 
 
 @pytest.mark.usefixtures('fresh_logger_once')
-def test_compute_timeout_tier_above_max_warns(caplog: LogCaptureFixture) -> None:
-    """Test a tier configured larger than timeout_max is capped, and the cut-off is logged too."""
-    client = ImpitHttpClient(timeout_long=timedelta(seconds=600), timeout_max=timedelta(seconds=360))
+def test_compute_timeout_tier_above_max_warns(http_client_class: type[HttpClient], caplog: LogCaptureFixture) -> None:
+    """A tier configured larger than timeout_max is capped, and the cut-off is logged too."""
+    client = http_client_class(timeout_long=timedelta(seconds=600), timeout_max=timedelta(seconds=360))
 
     with caplog.at_level(logging.WARNING, logger=logger_name):
         assert client._compute_timeout('long', attempt=1) == 360.0
@@ -188,9 +133,11 @@ def test_compute_timeout_tier_above_max_warns(caplog: LogCaptureFixture) -> None
 
 
 @pytest.mark.usefixtures('fresh_logger_once')
-def test_compute_timeout_within_max_does_not_warn(caplog: LogCaptureFixture) -> None:
-    """Test a base timeout within timeout_max is used as-is, without a warning."""
-    client = ImpitHttpClient(timeout_long=timedelta(seconds=300), timeout_max=timedelta(seconds=360))
+def test_compute_timeout_within_max_does_not_warn(
+    http_client_class: type[HttpClient], caplog: LogCaptureFixture
+) -> None:
+    """A base timeout within timeout_max is used as-is, without a warning."""
+    client = http_client_class(timeout_long=timedelta(seconds=300), timeout_max=timedelta(seconds=360))
 
     with caplog.at_level(logging.WARNING, logger=logger_name):
         assert client._compute_timeout(timedelta(seconds=120), attempt=1) == 120.0
@@ -201,103 +148,71 @@ def test_compute_timeout_within_max_does_not_warn(caplog: LogCaptureFixture) -> 
     assert caplog.records == []
 
 
-async def test_dynamic_timeout_async_client(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Tests timeout values for request with retriable errors.
+def test_dynamic_timeout_sync_client(http_client_class: type[HttpClient], monkeypatch: pytest.MonkeyPatch) -> None:
+    """Synchronous clients increase timeout values after retryable transport errors."""
+    client = http_client_class(
+        timeout_short=timedelta(seconds=1),
+        timeout_max=timedelta(seconds=5),
+        min_delay_between_retries=timedelta(0),
+    )
+    timeouts: list[float | None] = []
 
-    Values should increase with each attempt, starting from initial call value and bounded by timeout_max.
-    """
-    should_raise_error = iter((True, True, True, False))
-    call_timeout = 1
-    timeout_max = 5
-    expected_timeouts = [call_timeout, 2, 4, timeout_max]
-    retry_counter_mock = Mock()
+    def send_request(*_args: Any, **kwargs: Any) -> Mock:
+        timeouts.append(kwargs['timeout'])
+        if len(timeouts) < 4:
+            raise impit.TimeoutException('timeout')
+        return successful_response()
 
-    timeouts = []
+    monkeypatch.setattr(client, 'send_request', send_request)
 
-    async def mock_request(*_args: Any, **kwargs: Any) -> Response:
-        timeouts.append(kwargs.get('timeout'))
-        retry_counter_mock()
-        should_raise = next(should_raise_error)
-        if should_raise:
-            raise TimeoutException
+    response = client.call(method='GET', url='https://example.com', timeout=timedelta(seconds=1))
 
-        return Response(status_code=200)
-
-    monkeypatch.setattr('impit.AsyncClient.request', mock_request)
-
-    response = await ImpitHttpClientAsync(
-        timeout_short=timedelta(seconds=call_timeout),
-        timeout_max=timedelta(seconds=timeout_max),
-    ).call(method='GET', url='http://placeholder.url/async_timeout', timeout=timedelta(seconds=call_timeout))
-
-    # Check that the retry counter was called the expected number of times
-    # (4 times: 3 retries + 1 final successful call)
-    assert retry_counter_mock.call_count == 4
-    assert timeouts == expected_timeouts
-    # Check that the response is successful
+    assert timeouts == [1.0, 2.0, 4.0, 5.0]
     assert response.status_code == 200
 
 
-async def test_retry_on_http_error_async_client(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Tests that bare impit.HTTPError (e.g. body decode errors) are retried.
+async def test_dynamic_timeout_async_client(
+    http_client_async_class: type[HttpClientAsync], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Asynchronous clients increase timeout values after retryable transport errors."""
+    client = http_client_async_class(
+        timeout_short=timedelta(seconds=1),
+        timeout_max=timedelta(seconds=5),
+        min_delay_between_retries=timedelta(0),
+    )
+    timeouts: list[float | None] = []
 
-    This reproduces the scenario where the HTTP response body is truncated mid-stream
-    (e.g. "unexpected EOF during chunk size line"), which impit raises as a generic HTTPError.
-    """
-    should_raise_error = iter((True, True, False))
-    retry_counter_mock = Mock()
+    async def send_request(*_args: Any, **kwargs: Any) -> Mock:
+        timeouts.append(kwargs['timeout'])
+        if len(timeouts) < 4:
+            raise impit.TimeoutException('timeout')
+        return successful_response()
 
-    async def mock_request(*_args: Any, **_kwargs: Any) -> Response:
-        retry_counter_mock()
-        should_raise = next(should_raise_error)
-        if should_raise:
-            raise HTTPError('The internal HTTP library has thrown an error: unexpected EOF during chunk size line')
+    monkeypatch.setattr(client, 'send_request', send_request)
 
-        return Response(status_code=200)
+    response = await client.call(method='GET', url='https://example.com', timeout=timedelta(seconds=1))
 
-    monkeypatch.setattr('impit.AsyncClient.request', mock_request)
+    assert timeouts == [1.0, 2.0, 4.0, 5.0]
+    assert response.status_code == 200
 
-    response = await ImpitHttpClientAsync(timeout_short=timedelta(seconds=5)).call(
-        method='GET', url='http://placeholder.url/http_error'
+
+def test_no_timeout_mapping_for_sync_adapter() -> None:
+    """The synchronous adapter maps no-timeout to Impit's effectively unbounded value."""
+    client = ImpitHttpClient()
+    client._impit_client = Mock(request=Mock(return_value=successful_response()))
+
+    client.send_request(method='GET', url='https://example.com', headers={}, content=None, timeout=None, stream=False)
+
+    assert client._impit_client.request.call_args.kwargs['timeout'] == 86_400
+
+
+async def test_no_timeout_mapping_for_async_adapter() -> None:
+    """The asynchronous adapter maps no-timeout to Impit's effectively unbounded value."""
+    client = ImpitHttpClientAsync()
+    client._impit_async_client = Mock(request=AsyncMock(return_value=successful_response()))
+
+    await client.send_request(
+        method='GET', url='https://example.com', headers={}, content=None, timeout=None, stream=False
     )
 
-    # 3 attempts: 2 failures + 1 success
-    assert retry_counter_mock.call_count == 3
-    assert response.status_code == 200
-
-
-def test_dynamic_timeout_sync_client(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Tests timeout values for request with retriable errors.
-
-    Values should increase with each attempt, starting from initial call value and bounded by timeout_max.
-    """
-    should_raise_error = iter((True, True, True, False))
-    call_timeout = 1
-    timeout_max = 5
-    expected_timeouts = [call_timeout, 2, 4, timeout_max]
-    retry_counter_mock = Mock()
-
-    timeouts = []
-
-    def mock_request(*_args: Any, **kwargs: Any) -> Response:
-        timeouts.append(kwargs.get('timeout'))
-        retry_counter_mock()
-        should_raise = next(should_raise_error)
-        if should_raise:
-            raise TimeoutException
-
-        return Response(status_code=200)
-
-    monkeypatch.setattr('impit.Client.request', mock_request)
-
-    response = ImpitHttpClient(
-        timeout_short=timedelta(seconds=call_timeout),
-        timeout_max=timedelta(seconds=timeout_max),
-    ).call(method='GET', url='http://placeholder.url/sync_timeout', timeout=timedelta(seconds=call_timeout))
-
-    # Check that the retry counter was called the expected number of times
-    # (4 times: 3 retries + 1 final successful call)
-    assert retry_counter_mock.call_count == 4
-    assert timeouts == expected_timeouts
-    # Check that the response is successful
-    assert response.status_code == 200
+    assert client._impit_async_client.request.call_args.kwargs['timeout'] == 86_400

--- a/tests/unit/test_http_clients.py
+++ b/tests/unit/test_http_clients.py
@@ -17,8 +17,13 @@ import pytest
 from apify_client._consts import MIN_COMPRESSION_SIZE
 from apify_client._statistics import ClientStatistics
 from apify_client.errors import InvalidResponseBodyError
-from apify_client.http_clients import HttpClient, HttpClientAsync, HttpResponse, ImpitHttpClient, ImpitHttpClientAsync
-from apify_client.http_clients._impit import _is_retryable_error
+from apify_client.http_clients import (
+    HttpClient,
+    HttpClientAsync,
+    HttpResponse,
+    ImpitHttpClient,
+    ImpitHttpClientAsync,
+)
 from apify_client.http_compressors._base import HttpCompressor
 from apify_client.http_compressors._brotli import BrotliHttpCompressor
 from apify_client.http_compressors._gzip import GzipHttpCompressor
@@ -30,18 +35,41 @@ if TYPE_CHECKING:
     from apify_client.types import JsonSerializable
 
 
-class _ConcreteHttpClient(HttpClient):
-    """Minimal concrete HttpClient for testing base class helpers."""
-
-    def call(self, *, method: str, url: str, **kwargs: Any) -> HttpResponse:
-        raise NotImplementedError
+class ConcreteHttpClient(HttpClient):
+    """Minimal concrete HttpClient for testing base class helpers, relying on the hook defaults."""
 
 
-class _ConcreteHttpClientAsync(HttpClientAsync):
-    """Minimal concrete HttpClientAsync for testing base class helpers."""
+class CallOnlyHttpClient(HttpClient):
+    """Custom client written against the pre-hook contract, overriding `call` and nothing else."""
 
-    async def call(self, *, method: str, url: str, **kwargs: Any) -> HttpResponse:
-        raise NotImplementedError
+    def call(self, **kwargs: Any) -> HttpResponse:
+        _ = kwargs
+        return Mock(status_code=200)
+
+
+class CallOnlyHttpClientAsync(HttpClientAsync):
+    """Asynchronous counterpart of `CallOnlyHttpClient`."""
+
+    async def call(self, **kwargs: Any) -> HttpResponse:
+        _ = kwargs
+        return Mock(status_code=200)
+
+
+def test_call_only_http_client_keeps_working() -> None:
+    """A client that only overrides `call` still instantiates and inherits the hook defaults."""
+    with CallOnlyHttpClient() as client:
+        assert client.call(method='GET', url='https://example.com').status_code == 200
+        assert client.is_timeout_error(TimeoutError('test'))
+        assert not client.is_retryable_transport_error(TimeoutError('test'))
+
+
+async def test_call_only_http_client_async_keeps_working() -> None:
+    """The asynchronous base is equally tolerant of a client that only overrides `call`."""
+    async with CallOnlyHttpClientAsync() as client:
+        response = await client.call(method='GET', url='https://example.com')
+        assert response.status_code == 200
+        assert client.is_timeout_error(TimeoutError('test'))
+        assert not client.is_retryable_transport_error(TimeoutError('test'))
 
 
 def test_retry_with_exp_backoff() -> None:
@@ -73,7 +101,7 @@ def test_retry_with_exp_backoff() -> None:
 
     # Returns the correct result after the correct time (should take 100 + 200 + 400 + 800 = 1500 ms)
     start = time.time()
-    result = ImpitHttpClient._retry_with_exp_backoff(
+    result = HttpClient._retry_with_exp_backoff(
         returns_on_fifth_attempt, backoff_base=timedelta(milliseconds=100), backoff_factor=2, random_factor=0
     )
     elapsed_time_seconds = time.time() - start
@@ -85,7 +113,7 @@ def test_retry_with_exp_backoff() -> None:
     # Stops retrying when failed for max_retries times
     attempt_counter = 0
     with pytest.raises(RetryableError):
-        ImpitHttpClient._retry_with_exp_backoff(
+        HttpClient._retry_with_exp_backoff(
             returns_on_fifth_attempt, max_retries=3, backoff_base=timedelta(milliseconds=1)
         )
     assert attempt_counter == 4
@@ -93,7 +121,7 @@ def test_retry_with_exp_backoff() -> None:
     # Bails when the bail function is called
     attempt_counter = 0
     with pytest.raises(NonRetryableError):
-        ImpitHttpClient._retry_with_exp_backoff(bails_on_third_attempt, backoff_base=timedelta(milliseconds=1))
+        HttpClient._retry_with_exp_backoff(bails_on_third_attempt, backoff_base=timedelta(milliseconds=1))
     assert attempt_counter == 3
 
 
@@ -126,7 +154,7 @@ async def test_retry_with_exp_backoff_async() -> None:
 
     # Returns the correct result after the correct time (should take 100 + 200 + 400 + 800 = 1500 ms)
     start = time.time()
-    result = await ImpitHttpClientAsync._retry_with_exp_backoff(
+    result = await HttpClientAsync._retry_with_exp_backoff(
         returns_on_fifth_attempt, backoff_base=timedelta(milliseconds=100), backoff_factor=2, random_factor=0
     )
     elapsed_time_seconds = time.time() - start
@@ -138,7 +166,7 @@ async def test_retry_with_exp_backoff_async() -> None:
     # Stops retrying when failed for max_retries times
     attempt_counter = 0
     with pytest.raises(RetryableError):
-        await ImpitHttpClientAsync._retry_with_exp_backoff(
+        await HttpClientAsync._retry_with_exp_backoff(
             returns_on_fifth_attempt, max_retries=3, backoff_base=timedelta(milliseconds=1)
         )
     assert attempt_counter == 4
@@ -146,9 +174,7 @@ async def test_retry_with_exp_backoff_async() -> None:
     # Bails when the bail function is called
     attempt_counter = 0
     with pytest.raises(NonRetryableError):
-        await ImpitHttpClientAsync._retry_with_exp_backoff(
-            bails_on_third_attempt, backoff_base=timedelta(milliseconds=1)
-        )
+        await HttpClientAsync._retry_with_exp_backoff(bails_on_third_attempt, backoff_base=timedelta(milliseconds=1))
     assert attempt_counter == 3
 
 
@@ -156,7 +182,7 @@ def test_base_http_client_initialization() -> None:
     """Test HttpClient initialization with various configurations."""
     statistics = ClientStatistics()
 
-    client = _ConcreteHttpClient(
+    client = ConcreteHttpClient(
         token='test_token',
         timeout_short=timedelta(seconds=30),
         max_retries=5,
@@ -171,13 +197,13 @@ def test_base_http_client_initialization() -> None:
     assert client._headers['Authorization'] == 'Bearer test_token'
 
     # Test without statistics (should create default)
-    client2 = _ConcreteHttpClient(token='test_token')
+    client2 = ConcreteHttpClient(token='test_token')
     assert isinstance(client2._statistics, ClientStatistics)
 
 
 def test_http_client_init_headers_override_defaults_case_insensitively() -> None:
     """Constructor headers replace same-named default headers even when their casings differ."""
-    client = _ConcreteHttpClient(token='default_token', headers={'authorization': 'Bearer custom'})
+    client = ConcreteHttpClient(token='default_token', headers={'authorization': 'Bearer custom'})
 
     auth_headers = {key: value for key, value in client._headers.items() if key.lower() == 'authorization'}
     assert auth_headers == {'authorization': 'Bearer custom'}
@@ -187,14 +213,14 @@ def test_http_client_init_workflow_key_header(monkeypatch: pytest.MonkeyPatch) -
     """The X-Apify-Workflow-Key default header is set from the APIFY_WORKFLOW_KEY env var."""
     monkeypatch.setenv('APIFY_WORKFLOW_KEY', 'workflow_key_123')
 
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     assert client._headers['X-Apify-Workflow-Key'] == 'workflow_key_123'
 
 
 def test_set_default_authorization_sets_token_when_missing() -> None:
     """set_default_authorization sets the Bearer token when no authorization header is configured."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     client.set_default_authorization('test_token')
 
@@ -223,21 +249,19 @@ def test_merge_headers(
 
 
 def test_http_client_creates_sync_impit_client() -> None:
-    """Test that ImpitHttpClient creates sync impit client correctly."""
+    """The synchronous adapter creates the underlying Impit client and closes it through the close hook."""
     client = ImpitHttpClient(token='test_token_123')
 
-    # Check that sync impit client is created
-    assert client._impit_client is not None
     assert isinstance(client._impit_client, impit.Client)
+    client.close()
 
 
-def test_http_client_async_creates_async_impit_client() -> None:
-    """Test that ImpitHttpClientAsync creates async impit client correctly."""
+async def test_http_client_async_creates_async_impit_client() -> None:
+    """The asynchronous adapter creates the underlying Impit client and closes it through the close hook."""
     client = ImpitHttpClientAsync(token='test_token_123')
 
-    # Check that async impit client is created
-    assert client._impit_async_client is not None
     assert isinstance(client._impit_async_client, impit.AsyncClient)
+    await client.aclose()
 
 
 def test_parse_params_none() -> None:
@@ -309,18 +333,41 @@ def test_parse_params_mixed() -> None:
     }
 
 
-def test_is_retryable_error() -> None:
-    """Test _is_retryable_error correctly identifies retryable errors."""
-    mock_response = Mock()
-    assert _is_retryable_error(InvalidResponseBodyError(mock_response))
-    assert _is_retryable_error(impit.NetworkError('test'))
-    assert _is_retryable_error(impit.TimeoutException('test'))
-    assert _is_retryable_error(impit.RemoteProtocolError('test'))
+TRANSPORT_ERRORS = (
+    impit.HTTPError,
+    impit.TimeoutException,
+    impit.NetworkError,
+    impit.RemoteProtocolError,
+    impit.DecodingError,
+)
+"""Transport errors from Impit's own hierarchy, all classified as retryable."""
 
-    # Non-retryable errors
-    assert not _is_retryable_error(ValueError('test'))
-    assert not _is_retryable_error(RuntimeError('test'))
-    assert not _is_retryable_error(Exception('test'))
+
+def test_builtin_http_client_retry_policy() -> None:
+    """Every transport-level Impit failure is classified as retryable, everything else is not."""
+    with ImpitHttpClient() as client:
+        for error_class in TRANSPORT_ERRORS:
+            assert client.is_retryable_transport_error(error_class('test')), error_class.__name__
+
+        # `InvalidResponseBodyError` is retried by `_handle_request_exception`, not as a transport failure.
+        assert not client.is_retryable_transport_error(InvalidResponseBodyError(Mock()))
+        assert not client.is_retryable_transport_error(ValueError('test'))
+
+
+def test_sync_http_client_classifies_timeout_errors() -> None:
+    """The built-in synchronous client exposes transport-neutral timeout classification."""
+    with ImpitHttpClient() as client:
+        assert client.is_timeout_error(TimeoutError('test'))
+        assert client.is_timeout_error(impit.TimeoutException('test'))
+        assert not client.is_timeout_error(ValueError('test'))
+
+
+async def test_async_http_client_classifies_timeout_errors() -> None:
+    """The built-in asynchronous client exposes transport-neutral timeout classification."""
+    async with ImpitHttpClientAsync() as client:
+        assert client.is_timeout_error(TimeoutError('test'))
+        assert client.is_timeout_error(impit.TimeoutException('test'))
+        assert not client.is_timeout_error(ValueError('test'))
 
 
 @pytest.fixture(
@@ -335,7 +382,7 @@ def compressor_case(request: pytest.FixtureRequest) -> tuple:
 
 def test_prepare_request_call_basic() -> None:
     """Test _prepare_request_call returns the client default headers when no per-request values are given."""
-    client = _ConcreteHttpClient(token='test_token')
+    client = ConcreteHttpClient(token='test_token')
 
     headers, params, data = client._prepare_request_call()
     assert headers == client._headers
@@ -347,7 +394,7 @@ def test_prepare_request_call_basic() -> None:
 
 def test_prepare_request_call_with_json() -> None:
     """A small JSON body is serialized and typed, but sent uncompressed and without a `Content-Encoding`."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     json_data = {'key': 'value', 'number': 42}
     headers, _params, data = client._prepare_request_call(json=json_data)
@@ -369,7 +416,7 @@ def test_prepare_request_call_with_json() -> None:
 )
 def test_prepare_request_call_with_falsy_json(json_body: JsonSerializable, expected: bytes) -> None:
     """A falsy but valid JSON body is still serialized and sent, rather than treated as no body at all."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     headers, _params, data = client._prepare_request_call(json=json_body)
 
@@ -387,7 +434,7 @@ def test_prepare_request_call_with_falsy_json(json_body: JsonSerializable, expec
 )
 def test_prepare_request_call_with_data(data: str | bytes | bytearray) -> None:
     """A raw body of any accepted type is normalized to bytes."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     _headers, _params, prepared = client._prepare_request_call(data=data)
 
@@ -409,7 +456,7 @@ def test_prepare_request_call_compresses_body_at_or_above_threshold(
 ) -> None:
     """A raw body of at least `MIN_COMPRESSION_SIZE` bytes is compressed and labeled with its encoding."""
     compressor, content_encoding, decompress = compressor_case
-    client = _ConcreteHttpClient(http_compressor=compressor)
+    client = ConcreteHttpClient(http_compressor=compressor)
     body = b'x' * body_size
 
     headers, _params, data = client._prepare_request_call(data=body)
@@ -429,7 +476,7 @@ def test_prepare_request_call_compresses_body_at_or_above_threshold(
 def test_prepare_request_call_skips_compression_below_threshold(compressor_case: tuple, body_size: int) -> None:
     """A raw body under `MIN_COMPRESSION_SIZE` is sent verbatim with no `Content-Encoding`, whichever compressor."""
     compressor, _content_encoding, _decompress = compressor_case
-    client = _ConcreteHttpClient(http_compressor=compressor)
+    client = ConcreteHttpClient(http_compressor=compressor)
     body = b'x' * body_size
 
     headers, _params, data = client._prepare_request_call(data=body)
@@ -441,7 +488,7 @@ def test_prepare_request_call_skips_compression_below_threshold(compressor_case:
 def test_prepare_request_call_compresses_bytearray_data(compressor_case: tuple) -> None:
     """A `bytearray` body above the threshold is compressed without error (regression: needs bytes conversion)."""
     compressor, content_encoding, decompress = compressor_case
-    client = _ConcreteHttpClient(http_compressor=compressor)
+    client = ConcreteHttpClient(http_compressor=compressor)
     body = bytearray(b'test bytearray' * 128)
 
     headers, _params, data = client._prepare_request_call(data=body)
@@ -453,7 +500,7 @@ def test_prepare_request_call_compresses_bytearray_data(compressor_case: tuple) 
 def test_prepare_request_call_compresses_json_above_threshold(compressor_case: tuple) -> None:
     """A JSON body that serializes to at least `MIN_COMPRESSION_SIZE` bytes is compressed."""
     compressor, content_encoding, decompress = compressor_case
-    client = _ConcreteHttpClient(http_compressor=compressor)
+    client = ConcreteHttpClient(http_compressor=compressor)
     json_data = {'key': 'x' * MIN_COMPRESSION_SIZE}
 
     headers, _params, data = client._prepare_request_call(json=json_data)
@@ -466,7 +513,7 @@ def test_prepare_request_call_compresses_json_above_threshold(compressor_case: t
 def test_prepare_request_call_measures_threshold_in_bytes_not_characters(compressor_case: tuple) -> None:
     """A `str` body under the threshold in characters but over it in UTF-8 bytes is still compressed."""
     compressor, content_encoding, decompress = compressor_case
-    client = _ConcreteHttpClient(http_compressor=compressor)
+    client = ConcreteHttpClient(http_compressor=compressor)
     # U+00E9 encodes to 2 bytes, so this body is under the threshold in characters but over it in bytes.
     body = '\u00e9' * (MIN_COMPRESSION_SIZE // 2 + 1)
 
@@ -487,7 +534,7 @@ def test_prepare_request_call_measures_threshold_in_bytes_not_characters(compres
 )
 def test_is_body_worth_compressing(data: Any) -> None:
     """The gate reports a body `_prepare_request_call` would compress, judging a `str` by its encoded bytes."""
-    assert _ConcreteHttpClient._is_body_worth_compressing(data)
+    assert ConcreteHttpClient._is_body_worth_compressing(data)
 
 
 @pytest.mark.parametrize(
@@ -502,7 +549,7 @@ def test_is_body_worth_compressing(data: Any) -> None:
 )
 def test_is_body_not_worth_compressing(data: Any) -> None:
     """A body below the threshold, or of a type the client sends as it is, needs no worker-thread hop."""
-    assert not _ConcreteHttpClient._is_body_worth_compressing(data)
+    assert not ConcreteHttpClient._is_body_worth_compressing(data)
 
 
 @pytest.mark.parametrize(
@@ -515,7 +562,7 @@ def test_is_body_not_worth_compressing(data: Any) -> None:
 )
 def test_prepare_request_call_skips_compression_for_already_compressed_content(content_type: str) -> None:
     """An already-compressed body is sent verbatim, carries no `Content-Encoding`, and keeps every other header."""
-    client = _ConcreteHttpClient(token='test_token', http_compressor=GzipHttpCompressor())
+    client = ConcreteHttpClient(token='test_token', http_compressor=GzipHttpCompressor())
     # Above the size threshold, so the content type is what skips compression here.
     payload = b'\x89PNG' + b'\xff' * MIN_COMPRESSION_SIZE
 
@@ -533,7 +580,7 @@ def test_prepare_request_call_skips_compression_for_already_compressed_content(c
 
 def test_prepare_request_call_keeps_caller_content_encoding_for_a_file_like_body() -> None:
     """A file-like body skips compression entirely, and its `Content-Encoding` reaches the transport untouched."""
-    client = _ConcreteHttpClient(http_compressor=GzipHttpCompressor())
+    client = ConcreteHttpClient(http_compressor=GzipHttpCompressor())
     stream = BytesIO(gzip.compress(b'raw payload'))
 
     headers, _params, data = client._prepare_request_call(
@@ -559,7 +606,7 @@ def test_prepare_request_call_compresses_exceptions_to_compressed_prefixes(
 ) -> None:
     """Types that are text or raw are compressed even when they sit under an already-compressed prefix."""
     compressor, content_encoding, decompress = compressor_case
-    client = _ConcreteHttpClient(http_compressor=compressor)
+    client = ConcreteHttpClient(http_compressor=compressor)
     payload = b'x' * MIN_COMPRESSION_SIZE
 
     headers, _params, data = client._prepare_request_call(
@@ -574,7 +621,7 @@ def test_prepare_request_call_compresses_exceptions_to_compressed_prefixes(
 
 def test_prepare_request_call_json_and_data_error() -> None:
     """Test _prepare_request_call raises error when both json and data are provided."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     with pytest.raises(ValueError, match='Cannot pass both "json" and "data" parameters'):
         client._prepare_request_call(json={'key': 'value'}, data='string')
@@ -582,7 +629,7 @@ def test_prepare_request_call_json_and_data_error() -> None:
 
 def test_prepare_request_call_with_params() -> None:
     """Test _prepare_request_call parses params correctly."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     _headers, params, _data = client._prepare_request_call(params={'limit': 10, 'flag': True})
 
@@ -595,7 +642,7 @@ def test_prepare_request_call_does_not_mutate_caller_headers() -> None:
     A caller that reuses a shared headers dict across calls must not see stale
     `Content-Type`/`Content-Encoding` headers leak in from a prior JSON/body call.
     """
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     caller_headers = {'x-trace-id': 'abc-123'}
     original = dict(caller_headers)
@@ -609,7 +656,7 @@ def test_prepare_request_call_does_not_mutate_caller_headers() -> None:
 
 def test_prepare_request_call_per_request_headers_override_defaults_case_insensitively() -> None:
     """A per-request header replaces a same-named default header even when their casings differ."""
-    client = _ConcreteHttpClient(token='default_token')
+    client = ConcreteHttpClient(token='default_token')
 
     headers, _params, _data = client._prepare_request_call(headers={'authorization': 'Bearer per-request'})
 
@@ -619,7 +666,7 @@ def test_prepare_request_call_per_request_headers_override_defaults_case_insensi
 
 def test_prepare_request_call_json_keeps_caller_content_type() -> None:
     """A caller-supplied content type is not overwritten by the JSON default, regardless of casing."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     headers, _params, _data = client._prepare_request_call(
         headers={'content-type': 'application/json; charset=utf-8'},
@@ -650,7 +697,7 @@ def test_prepare_request_call_json_keeps_caller_content_type() -> None:
 )
 def test_prepare_request_call_keeps_caller_content_encoding(caller_headers: dict[str, str], body: bytes) -> None:
     """A caller-supplied `Content-Encoding` marks the body as pre-encoded, so it goes out untouched and labeled."""
-    client = _ConcreteHttpClient(http_compressor=GzipHttpCompressor())
+    client = ConcreteHttpClient(http_compressor=GzipHttpCompressor())
 
     headers, _params, data = client._prepare_request_call(headers=caller_headers, data=body)
 
@@ -661,7 +708,7 @@ def test_prepare_request_call_keeps_caller_content_encoding(caller_headers: dict
 
 def test_prepare_request_call_keeps_client_wide_content_encoding() -> None:
     """A `Content-Encoding` configured on the client counts as caller-supplied on every request it sends."""
-    client = _ConcreteHttpClient(headers={'Content-Encoding': 'identity'}, http_compressor=GzipHttpCompressor())
+    client = ConcreteHttpClient(headers={'Content-Encoding': 'identity'}, http_compressor=GzipHttpCompressor())
     body = b'x' * MIN_COMPRESSION_SIZE
 
     headers, _params, data = client._prepare_request_call(data=body)
@@ -672,7 +719,7 @@ def test_prepare_request_call_keeps_client_wide_content_encoding() -> None:
 
 def test_build_url_with_params_none() -> None:
     """Test _build_url_with_params with None params."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     url = client._build_url_with_params('https://api.test.com/endpoint')
     assert url == 'https://api.test.com/endpoint'
@@ -680,7 +727,7 @@ def test_build_url_with_params_none() -> None:
 
 def test_build_url_with_params_simple() -> None:
     """Test _build_url_with_params with simple params."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     url = client._build_url_with_params('https://api.test.com/endpoint', params={'key': 'value', 'limit': 10})
     assert 'key=value' in url
@@ -690,7 +737,7 @@ def test_build_url_with_params_simple() -> None:
 
 def test_build_url_with_params_list() -> None:
     """Test _build_url_with_params with list values."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     url = client._build_url_with_params('https://api.test.com/endpoint', params={'tags': ['tag1', 'tag2', 'tag3']})
     assert 'tags=tag1' in url
@@ -700,7 +747,7 @@ def test_build_url_with_params_list() -> None:
 
 def test_build_url_with_params_mixed() -> None:
     """Test _build_url_with_params with mixed param types."""
-    client = _ConcreteHttpClient()
+    client = ConcreteHttpClient()
 
     url = client._build_url_with_params(
         'https://api.test.com/endpoint', params={'limit': 10, 'tags': ['a', 'b'], 'name': 'test'}
@@ -724,11 +771,13 @@ class _ThreadRecordingCompressor(HttpCompressor):
         return gzip.compress(data)
 
 
-async def test_async_call_compresses_request_body_off_the_event_loop() -> None:
+async def test_async_call_compresses_request_body_off_the_event_loop(
+    http_client_async_class: type[HttpClientAsync], monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Body serialization and compression must run in a worker thread, not block the event loop."""
     compressor = _ThreadRecordingCompressor()
-    client = ImpitHttpClientAsync(token='test_token', http_compressor=compressor)
-    client._impit_async_client = Mock(request=AsyncMock(return_value=Mock(status_code=200)))
+    client = http_client_async_class(token='test_token', http_compressor=compressor)
+    monkeypatch.setattr(client, 'send_request', AsyncMock(return_value=Mock(status_code=200)))
 
     await client.call(
         method='POST',
@@ -740,11 +789,13 @@ async def test_async_call_compresses_request_body_off_the_event_loop() -> None:
     assert compressor.compress_thread_id != threading.get_ident()
 
 
-async def test_async_call_compresses_a_multibyte_str_body_off_the_event_loop() -> None:
+async def test_async_call_compresses_a_multibyte_str_body_off_the_event_loop(
+    http_client_async_class: type[HttpClientAsync], monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A `str` body over the threshold only once encoded is still compressed, so it must be offloaded."""
     compressor = _ThreadRecordingCompressor()
-    client = ImpitHttpClientAsync(token='test_token', http_compressor=compressor)
-    client._impit_async_client = Mock(request=AsyncMock(return_value=Mock(status_code=200)))
+    client = http_client_async_class(token='test_token', http_compressor=compressor)
+    monkeypatch.setattr(client, 'send_request', AsyncMock(return_value=Mock(status_code=200)))
 
     await client.call(
         method='PUT',
@@ -763,10 +814,12 @@ def _to_thread_spy(monkeypatch: pytest.MonkeyPatch) -> Mock:
     return spy
 
 
-async def test_async_call_skips_thread_offload_without_a_body(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_async_call_skips_thread_offload_without_a_body(
+    http_client_async_class: type[HttpClientAsync], monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A bodyless request has nothing to compress, so it must not pay the worker-thread hop."""
-    client = ImpitHttpClientAsync(token='test_token')
-    client._impit_async_client = Mock(request=AsyncMock(return_value=Mock(status_code=200)))
+    client = http_client_async_class(token='test_token')
+    monkeypatch.setattr(client, 'send_request', AsyncMock(return_value=Mock(status_code=200)))
     spy = _to_thread_spy(monkeypatch)
 
     await client.call(method='GET', url='https://api.test.com/endpoint')
@@ -775,11 +828,12 @@ async def test_async_call_skips_thread_offload_without_a_body(monkeypatch: pytes
 
 
 async def test_async_call_skips_thread_offload_for_a_body_below_the_threshold(
+    http_client_async_class: type[HttpClientAsync],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A raw body too small to be compressed must not pay the worker-thread hop either."""
-    client = ImpitHttpClientAsync(token='test_token')
-    client._impit_async_client = Mock(request=AsyncMock(return_value=Mock(status_code=200)))
+    client = http_client_async_class(token='test_token')
+    monkeypatch.setattr(client, 'send_request', AsyncMock(return_value=Mock(status_code=200)))
     spy = _to_thread_spy(monkeypatch)
 
     await client.call(method='PUT', url='https://api.test.com/endpoint', data=b'x' * (MIN_COMPRESSION_SIZE - 1))
@@ -787,10 +841,12 @@ async def test_async_call_skips_thread_offload_for_a_body_below_the_threshold(
     spy.assert_not_called()
 
 
-async def test_async_call_offloads_a_body_at_the_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_async_call_offloads_a_body_at_the_threshold(
+    http_client_async_class: type[HttpClientAsync], monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A raw body large enough to be compressed is prepared in a worker thread."""
-    client = ImpitHttpClientAsync(token='test_token')
-    client._impit_async_client = Mock(request=AsyncMock(return_value=Mock(status_code=200)))
+    client = http_client_async_class(token='test_token')
+    monkeypatch.setattr(client, 'send_request', AsyncMock(return_value=Mock(status_code=200)))
     spy = _to_thread_spy(monkeypatch)
 
     await client.call(method='PUT', url='https://api.test.com/endpoint', data=b'x' * MIN_COMPRESSION_SIZE)
@@ -799,11 +855,12 @@ async def test_async_call_offloads_a_body_at_the_threshold(monkeypatch: pytest.M
 
 
 async def test_async_call_skips_thread_offload_for_a_body_it_cannot_compress(
+    http_client_async_class: type[HttpClientAsync],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A body of a type the client passes through needs no hop, and deciding that must not need its length."""
-    client = ImpitHttpClientAsync(token='test_token')
-    client._impit_async_client = Mock(request=AsyncMock(return_value=Mock(status_code=200)))
+    client = http_client_async_class(token='test_token')
+    monkeypatch.setattr(client, 'send_request', AsyncMock(return_value=Mock(status_code=200)))
     spy = _to_thread_spy(monkeypatch)
 
     # `encode_key_value_store_record_value` passes file-like bodies through, so the gate cannot assume a length.

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from pytest_httpserver import HTTPServer
 
     from apify_client._literals import ActorJobStatus
+    from apify_client.http_clients import HttpClient, HttpClientAsync
 
 _MOCKED_RUN_ID = 'mocked_run_id'
 _MOCKED_ACTOR_NAME = 'mocked_actor_name'
@@ -873,11 +874,10 @@ def test_streamed_log_sync_stop_unblocks_on_finite_stream_timeout(
 def test_streamed_log_sync_does_not_leak_exception_on_stream_timeout(
     caplog: LogCaptureFixture,
     httpserver: HTTPServer,
+    http_client_class: type[HttpClient],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The streaming thread ends quietly when the log-stream request hits its total timeout (regression #1040)."""
-    # impit enforces a whole-request timeout, so a still-running Actor whose run outlives the timeout makes
-    # `iter_bytes()` raise `impit.TimeoutException`. Shorten the timeout to trigger this quickly.
+    """The streaming thread ends quietly when the transport times out while reading the log stream."""
     monkeypatch.setattr(StreamedLog, '_stream_timeout', timedelta(seconds=1))
 
     release_server = threading.Event()
@@ -897,7 +897,10 @@ def test_streamed_log_sync_does_not_leak_exception_on_stream_timeout(
     _register_run_and_actor_endpoints(httpserver)
 
     api_url = httpserver.url_for('/').removesuffix('/')
-    run_client = ApifyClient(token='mocked_token', api_url=api_url).run(run_id=_MOCKED_RUN_ID)
+    http_client = http_client_class()
+    run_client = ApifyClient.with_custom_http_client(
+        token='mocked_token', api_url=api_url, http_client=http_client
+    ).run(run_id=_MOCKED_RUN_ID)
     streamed_log = run_client.get_streamed_log()
     logger_name = f'apify.{_MOCKED_ACTOR_NAME}-{_MOCKED_RUN_ID}'
 
@@ -913,6 +916,7 @@ def test_streamed_log_sync_does_not_leak_exception_on_stream_timeout(
     finally:
         release_server.set()
         streamed_log.stop()
+        http_client.close()
 
     leaked = [args.exc_type.__name__ for args in thread_exceptions]
     assert not leaked, f'streaming thread leaked an uncaught exception: {leaked}'
@@ -963,9 +967,10 @@ def test_streamed_log_sync_requests_stream_with_no_timeout(
 async def test_streamed_log_async_does_not_error_on_stream_timeout(
     caplog: LogCaptureFixture,
     httpserver: HTTPServer,
+    http_client_async_class: type[HttpClientAsync],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The async streaming task ends quietly on a stream-request timeout, matching the sync regression for #1040."""
+    """The async streaming task treats a transport stream timeout as an expected terminal condition."""
     monkeypatch.setattr(StreamedLogAsync, '_stream_timeout', timedelta(seconds=1))
 
     release_server = threading.Event()
@@ -984,7 +989,10 @@ async def test_streamed_log_async_does_not_error_on_stream_timeout(
     _register_run_and_actor_endpoints(httpserver)
 
     api_url = httpserver.url_for('/').removesuffix('/')
-    run_client = ApifyClientAsync(token='mocked_token', api_url=api_url).run(run_id=_MOCKED_RUN_ID)
+    http_client = http_client_async_class()
+    run_client = ApifyClientAsync.with_custom_http_client(
+        token='mocked_token', api_url=api_url, http_client=http_client
+    ).run(run_id=_MOCKED_RUN_ID)
     streamed_log = await run_client.get_streamed_log()
     logger_name = f'apify.{_MOCKED_ACTOR_NAME}-{_MOCKED_RUN_ID}'
 
@@ -997,6 +1005,7 @@ async def test_streamed_log_async_does_not_error_on_stream_timeout(
     finally:
         release_server.set()
         await streamed_log.stop()
+        await http_client.aclose()
 
     assert not task.cancelled()
     assert task.exception() is None, f'async streaming task raised on stream timeout: {task.exception()!r}'

--- a/tests/unit/test_pluggable_http_client.py
+++ b/tests/unit/test_pluggable_http_client.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import json as jsonlib
 from dataclasses import dataclass, field
+from datetime import timedelta
+from http.client import HTTPConnection
 from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, Mock
+from urllib.parse import urlsplit
 
 import impit
 import pytest
@@ -92,7 +97,7 @@ class FakeHttpClient(HttpClient):
         json: Any = None,
         stream: bool | None = None,
         timeout: Timeout = 'medium',
-    ) -> FakeResponse:
+    ) -> HttpResponse:
         self.calls.append(
             {
                 'method': method,
@@ -126,7 +131,7 @@ class FakeHttpClientAsync(HttpClientAsync):
         json: Any = None,
         stream: bool | None = None,
         timeout: Timeout = 'medium',
-    ) -> FakeResponse:
+    ) -> HttpResponse:
         self.calls.append(
             {
                 'method': method,
@@ -142,7 +147,74 @@ class FakeHttpClientAsync(HttpClientAsync):
         return _make_fake_response()
 
 
-# -- Protocol / ABC conformance tests --
+def _stdlib_fetch(
+    *,
+    method: str,
+    url: str,
+    headers: dict[str, str],
+    content: bytes | None,
+    timeout: float | None,
+) -> FakeResponse:
+    """Send one request over `http.client` and adapt the result to the `HttpResponse` protocol."""
+    parts = urlsplit(url)
+    connection = HTTPConnection(parts.hostname or 'localhost', parts.port, timeout=timeout)
+    try:
+        path = f'{parts.path}?{parts.query}' if parts.query else parts.path
+        connection.request(method, path, body=content, headers=headers)
+        raw = connection.getresponse()
+        body = raw.read()
+        try:
+            parsed = jsonlib.loads(body)
+        except ValueError:
+            parsed = None
+        return FakeResponse(
+            status_code=raw.status,
+            text=body.decode(),
+            content=body,
+            headers={key.lower(): value for key, value in raw.getheaders()},
+            _json=parsed,
+        )
+    finally:
+        connection.close()
+
+
+class StdlibHttpClient(HttpClient):
+    """A hooks-only custom sync client: implements `send_request` and inherits the shared pipeline."""
+
+    def send_request(
+        self,
+        *,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        content: bytes | None,
+        timeout: float | None,
+        stream: bool,
+    ) -> HttpResponse:
+        _ = stream
+        return _stdlib_fetch(method=method, url=url, headers=headers, content=content, timeout=timeout)
+
+
+class StdlibHttpClientAsync(HttpClientAsync):
+    """A hooks-only custom async client: implements `send_request` and inherits the shared pipeline."""
+
+    async def send_request(
+        self,
+        *,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        content: bytes | None,
+        timeout: float | None,
+        stream: bool,
+    ) -> HttpResponse:
+        _ = stream
+        return await asyncio.to_thread(
+            _stdlib_fetch, method=method, url=url, headers=headers, content=content, timeout=timeout
+        )
+
+
+# -- Protocol conformance tests --
 
 
 def test_fake_response_satisfies_http_response_protocol() -> None:
@@ -163,15 +235,15 @@ def test_fake_http_client_async_is_http_client_async() -> None:
     assert isinstance(client, HttpClientAsync)
 
 
-def test_apify_http_client_is_http_client() -> None:
-    """Test that ImpitHttpClient is an instance of HttpClient."""
-    client = ImpitHttpClient()
+def test_apify_http_client_is_http_client(http_client_class: type[HttpClient]) -> None:
+    """Test that each built-in synchronous client is an HttpClient."""
+    client = http_client_class()
     assert isinstance(client, HttpClient)
 
 
-def test_apify_http_client_async_is_http_client_async() -> None:
-    """Test that ImpitHttpClientAsync is an instance of HttpClientAsync."""
-    client = ImpitHttpClientAsync()
+def test_apify_http_client_async_is_http_client_async(http_client_async_class: type[HttpClientAsync]) -> None:
+    """Test that each built-in asynchronous client is an HttpClientAsync."""
+    client = http_client_async_class()
     assert isinstance(client, HttpClientAsync)
 
 
@@ -184,16 +256,16 @@ async def test_fake_response_async_methods() -> None:
     assert chunks == [b'hello']
 
 
-def test_http_client_abc_not_instantiable() -> None:
-    """Test that HttpClient cannot be instantiated directly (it's abstract)."""
-    with pytest.raises(TypeError, match='abstract method'):
-        HttpClient()
+def test_http_client_without_transport_fails_loudly() -> None:
+    """The sync base carries hook defaults, but its inherited `call` still needs a transport implementation."""
+    with pytest.raises(NotImplementedError, match='Implement `send_request`'):
+        HttpClient().call(method='GET', url='https://example.com')
 
 
-def test_http_client_async_abc_not_instantiable() -> None:
-    """Test that HttpClientAsync cannot be instantiated directly (it's abstract)."""
-    with pytest.raises(TypeError, match='abstract method'):
-        HttpClientAsync()
+async def test_http_client_async_without_transport_fails_loudly() -> None:
+    """The async base carries hook defaults, but its inherited `call` still needs a transport implementation."""
+    with pytest.raises(NotImplementedError, match='Implement `send_request`'):
+        await HttpClientAsync().call(method='GET', url='https://example.com')
 
 
 # -- ApifyClient with custom http_client via classmethod --
@@ -292,9 +364,17 @@ async def test_apify_client_async_with_custom_http_client_accepts_url_params() -
 
 def test_public_exports() -> None:
     """HTTP client types are exposed from `apify_client.http_clients`, not the root namespace."""
-    for name in ('HttpClient', 'HttpClientAsync', 'HttpResponse', 'ImpitHttpClient', 'ImpitHttpClientAsync'):
+    for name in (
+        'HttpClient',
+        'HttpClientAsync',
+        'HttpResponse',
+        'ImpitHttpClient',
+        'ImpitHttpClientAsync',
+    ):
         assert hasattr(http_clients_module, name)
         assert not hasattr(apify_client_module, name)
+
+    assert not hasattr(http_clients_module, 'HttpClientBase')
 
 
 # -- http_client property --
@@ -374,14 +454,14 @@ async def test_custom_http_client_async_error_handling() -> None:
 # -- Integration with real HTTP server --
 
 
-def test_custom_http_client_with_real_server(httpserver: HTTPServer) -> None:
-    """Test that a custom HTTP client wrapping ImpitHttpClient works with a real server."""
+def test_custom_http_client_with_real_server(httpserver: HTTPServer, http_client_class: type[HttpClient]) -> None:
+    """Test that a custom HTTP client wrapping a built-in client works with a real server."""
     httpserver.expect_request('/v2/datasets/test-dataset').respond_with_json(
         {'data': {'id': 'test-dataset', 'name': 'My Dataset'}},
     )
 
     # Create a wrapping client that adds custom headers
-    inner_client = ImpitHttpClient(token='test_token')
+    inner_client = http_client_class(token='test_token')
 
     class WrappingHttpClient(HttpClient):
         def call(self, *, method: str, url: str, **kwargs: Any) -> HttpResponse:
@@ -400,14 +480,16 @@ def test_custom_http_client_with_real_server(httpserver: HTTPServer) -> None:
     assert result['data']['id'] == 'test-dataset'
 
 
-async def test_custom_http_client_async_with_real_server(httpserver: HTTPServer) -> None:
-    """Test that a custom async HTTP client wrapping ImpitHttpClientAsync works with a real server."""
+async def test_custom_http_client_async_with_real_server(
+    httpserver: HTTPServer, http_client_async_class: type[HttpClientAsync]
+) -> None:
+    """Test that a custom async HTTP client wrapping a built-in client works with a real server."""
     httpserver.expect_request('/v2/datasets/test-dataset').respond_with_json(
         {'data': {'id': 'test-dataset', 'name': 'My Dataset'}},
     )
 
     # Create a wrapping client that adds custom headers
-    inner_client = ImpitHttpClientAsync(token='test_token')
+    inner_client = http_client_async_class(token='test_token')
 
     class WrappingHttpClientAsync(HttpClientAsync):
         async def call(self, *, method: str, url: str, **kwargs: Any) -> HttpResponse:
@@ -517,12 +599,14 @@ async def test_custom_http_client_async_sends_token_from_classmethod(httpserver:
     assert result['received_headers']['Authorization'] == 'Bearer test_token'
 
 
-def test_custom_http_client_impit_instance_sends_token(httpserver: HTTPServer) -> None:
-    """Token from with_custom_http_client reaches the wire even for a pre-built tokenless ImpitHttpClient."""
+def test_custom_builtin_http_client_instance_sends_token(
+    httpserver: HTTPServer, http_client_class: type[HttpClient]
+) -> None:
+    """Token from with_custom_http_client reaches the wire for each pre-built tokenless client."""
     httpserver.expect_request('/v2/datasets/test-dataset').respond_with_handler(_echo_headers)
 
     api_url = httpserver.url_for('/').removesuffix('/')
-    client = ApifyClient.with_custom_http_client(token='test_token', api_url=api_url, http_client=ImpitHttpClient())
+    client = ApifyClient.with_custom_http_client(token='test_token', api_url=api_url, http_client=http_client_class())
 
     result = client.dataset('test-dataset')._get(timeout='short')
 
@@ -548,3 +632,123 @@ def test_custom_http_client_keeps_differently_cased_authorization() -> None:
 
     assert 'Authorization' not in http_client._headers
     assert http_client._headers['authorization'] == 'Bearer client_token'
+
+
+def test_hooks_only_client_retries_and_sends_default_headers(httpserver: HTTPServer) -> None:
+    """A client implementing only `send_request` inherits header merging and 5xx retries from the shared `call`."""
+    auth_headers: list[str | None] = []
+
+    def handler(request: Request) -> Response:
+        auth_headers.append(request.headers.get('Authorization'))
+        if len(auth_headers) < 3:
+            return Response(
+                response='{"error": {"type": "internal-error", "message": "Server exploded."}}',
+                status=500,
+                content_type='application/json',
+            )
+        return Response(response='{"data": {"id": "abc"}}', status=200, content_type='application/json')
+
+    httpserver.expect_request('/v2/things/abc').respond_with_handler(handler)
+
+    client = StdlibHttpClient(token='hook_token', min_delay_between_retries=timedelta(milliseconds=1))
+    response = client.call(method='GET', url=httpserver.url_for('/v2/things/abc'))
+
+    assert response.status_code == 200
+    assert response.json() == {'data': {'id': 'abc'}}
+    assert auth_headers == ['Bearer hook_token'] * 3
+
+
+def test_hooks_only_client_raises_api_error_without_retry(httpserver: HTTPServer) -> None:
+    """A non-retryable error status reaches the caller as `ApifyApiError` after a single attempt."""
+    request_count = 0
+
+    def handler(_request: Request) -> Response:
+        nonlocal request_count
+        request_count += 1
+        return Response(
+            response='{"error": {"type": "record-not-found", "message": "Not there."}}',
+            status=404,
+            content_type='application/json',
+        )
+
+    httpserver.expect_request('/v2/things/missing').respond_with_handler(handler)
+
+    client = StdlibHttpClient(token='hook_token')
+    with pytest.raises(ApifyApiError) as exc_info:
+        client.call(method='GET', url=httpserver.url_for('/v2/things/missing'))
+
+    assert exc_info.value.status_code == 404
+    assert request_count == 1
+
+
+async def test_hooks_only_client_async_retries_and_sends_default_headers(httpserver: HTTPServer) -> None:
+    """The async shared `call` gives a `send_request`-only client header merging and 5xx retries too."""
+    auth_headers: list[str | None] = []
+
+    def handler(request: Request) -> Response:
+        auth_headers.append(request.headers.get('Authorization'))
+        if len(auth_headers) < 3:
+            return Response(
+                response='{"error": {"type": "internal-error", "message": "Server exploded."}}',
+                status=500,
+                content_type='application/json',
+            )
+        return Response(response='{"data": {"id": "abc"}}', status=200, content_type='application/json')
+
+    httpserver.expect_request('/v2/things/abc').respond_with_handler(handler)
+
+    client = StdlibHttpClientAsync(token='hook_token', min_delay_between_retries=timedelta(milliseconds=1))
+    response = await client.call(method='GET', url=httpserver.url_for('/v2/things/abc'))
+
+    assert response.status_code == 200
+    assert response.json() == {'data': {'id': 'abc'}}
+    assert auth_headers == ['Bearer hook_token'] * 3
+
+
+async def test_hooks_only_client_async_raises_api_error_without_retry(httpserver: HTTPServer) -> None:
+    """The async pipeline raises `ApifyApiError` without retrying a non-retryable status."""
+    request_count = 0
+
+    def handler(_request: Request) -> Response:
+        nonlocal request_count
+        request_count += 1
+        return Response(
+            response='{"error": {"type": "record-not-found", "message": "Not there."}}',
+            status=404,
+            content_type='application/json',
+        )
+
+    httpserver.expect_request('/v2/things/missing').respond_with_handler(handler)
+
+    client = StdlibHttpClientAsync(token='hook_token')
+    with pytest.raises(ApifyApiError) as exc_info:
+        await client.call(method='GET', url=httpserver.url_for('/v2/things/missing'))
+
+    assert exc_info.value.status_code == 404
+    assert request_count == 1
+
+
+def test_hooks_only_client_does_not_retry_an_unclassified_transport_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default `is_retryable_transport_error` classifies nothing, so a transport failure ends the call at once."""
+    client = StdlibHttpClient(token='hook_token', min_delay_between_retries=timedelta(milliseconds=1))
+    send_request = Mock(side_effect=OSError('connection reset'))
+    monkeypatch.setattr(client, 'send_request', send_request)
+
+    with pytest.raises(OSError, match='connection reset'):
+        client.call(method='GET', url='https://example.com')
+
+    send_request.assert_called_once()
+
+
+async def test_hooks_only_client_async_does_not_retry_an_unclassified_transport_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The asynchronous pipeline gives up on the first transport failure the client does not classify either."""
+    client = StdlibHttpClientAsync(token='hook_token', min_delay_between_retries=timedelta(milliseconds=1))
+    send_request = AsyncMock(side_effect=OSError('connection reset'))
+    monkeypatch.setattr(client, 'send_request', send_request)
+
+    with pytest.raises(OSError, match='connection reset'):
+        await client.call(method='GET', url='https://example.com')
+
+    send_request.assert_awaited_once()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -11,14 +11,13 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock
 
-import impit
 import pytest
 
 from apify_client._models import WebhookCondition, WebhookCreate
 from apify_client._resource_clients._resource_client import ResourceClientBase
 from apify_client._utils.crypto import create_hmac_signature, create_storage_content_signature, encode_base62
 from apify_client._utils.encoding import encode_key_value_store_record_value, encode_webhooks_to_base64
-from apify_client._utils.errors import catch_not_found_or_throw, is_retryable_error
+from apify_client._utils.errors import catch_not_found_or_throw
 from apify_client._utils.http import (
     is_compressible_content_type,
     response_to_dict,
@@ -26,7 +25,7 @@ from apify_client._utils.http import (
     to_safe_id,
 )
 from apify_client._utils.try_import import FailedImport, try_import
-from apify_client.errors import ApifyApiError, InvalidResponseBodyError
+from apify_client.errors import ApifyApiError
 
 if TYPE_CHECKING:
     from apify_client._typeddicts import WebhookRepresentationDict
@@ -185,36 +184,6 @@ def test_encode_webhooks_to_base64_from_dicts() -> None:
     )
 
     assert result == result_from_models
-
-
-@pytest.mark.parametrize(
-    'exc',
-    [
-        InvalidResponseBodyError(impit.Response(status_code=200)),
-        impit.HTTPError('generic http error'),
-        impit.NetworkError('network error'),
-        impit.TimeoutException('timeout'),
-        impit.RemoteProtocolError('remote protocol error'),
-        impit.ReadError('read error'),
-        impit.ConnectError('connect error'),
-        impit.WriteError('write error'),
-        impit.DecodingError('decoding error'),
-    ],
-)
-def test__is_retryable_error(exc: Exception) -> None:
-    assert is_retryable_error(exc) is True
-
-
-@pytest.mark.parametrize(
-    'exc',
-    [
-        Exception('generic exception'),
-        ValueError('value error'),
-        RuntimeError('runtime error'),
-    ],
-)
-def test__is_not_retryable_error(exc: Exception) -> None:
-    assert is_retryable_error(exc) is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Moves `call`, the retry loop, and the per-attempt request handling from `ImpitHttpClient` and `ImpitHttpClientAsync` into `HttpClient` and `HttpClientAsync`, leaving Impit as a thin adapter over the transport hooks: `send_request`, `is_retryable_transport_error`, `is_timeout_error`, and `close()` / `aclose()` plus context managers. A custom client that overrides `call` keeps working unchanged and opts out of the shared pipeline. `StreamedLog` classifies timeouts through the transport-neutral `is_timeout_error` hook instead of importing Impit.

No behavior change for the built-in clients: retry classification stays exactly as on master (every `impit.HTTPError` is transient). The classification fixes follow in #1012.

Split out of #1006.

*✍️ Drafted by Claude Code*
