### PR TITLE
refactor: Remove the unused retry classification helper

### DIFF
--- a/src/apify_client/_utils/errors.py
+++ b/src/apify_client/_utils/errors.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import impit
-
-from apify_client.errors import InvalidResponseBodyError, NotFoundError
+from apify_client.errors import NotFoundError
 
 if TYPE_CHECKING:
     from apify_client.errors import ApifyApiError
@@ -33,19 +31,3 @@ def catch_not_found_for_resource_or_throw(exc: ApifyApiError, resource_id: str |
     if resource_id is None:
         raise exc
     catch_not_found_or_throw(exc)
-
-
-def is_retryable_error(exc: Exception) -> bool:
-    """Check if the given error is retryable.
-
-    All `impit.HTTPError` subclasses are considered retryable because they represent transport-level failures
-    (network issues, timeouts, protocol errors, body decoding errors) that are typically transient. HTTP status
-    code errors are handled separately in `_make_request` based on the response status code, not here.
-    """
-    return isinstance(
-        exc,
-        (
-            InvalidResponseBodyError,
-            impit.HTTPError,
-        ),
-    )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -11,14 +11,13 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock
 
-import impit
 import pytest
 
 from apify_client._models import WebhookCondition, WebhookCreate
 from apify_client._resource_clients._resource_client import ResourceClientBase
 from apify_client._utils.crypto import create_hmac_signature, create_storage_content_signature, encode_base62
 from apify_client._utils.encoding import encode_key_value_store_record_value, encode_webhooks_to_base64
-from apify_client._utils.errors import catch_not_found_or_throw, is_retryable_error
+from apify_client._utils.errors import catch_not_found_or_throw
 from apify_client._utils.http import (
     is_compressible_content_type,
     response_to_dict,
@@ -26,7 +25,7 @@ from apify_client._utils.http import (
     to_safe_id,
 )
 from apify_client._utils.try_import import FailedImport, try_import
-from apify_client.errors import ApifyApiError, InvalidResponseBodyError
+from apify_client.errors import ApifyApiError
 
 if TYPE_CHECKING:
     from apify_client._typeddicts import WebhookRepresentationDict
@@ -185,36 +184,6 @@ def test_encode_webhooks_to_base64_from_dicts() -> None:
     )
 
     assert result == result_from_models
-
-
-@pytest.mark.parametrize(
-    'exc',
-    [
-        InvalidResponseBodyError(impit.Response(status_code=200)),
-        impit.HTTPError('generic http error'),
-        impit.NetworkError('network error'),
-        impit.TimeoutException('timeout'),
-        impit.RemoteProtocolError('remote protocol error'),
-        impit.ReadError('read error'),
-        impit.ConnectError('connect error'),
-        impit.WriteError('write error'),
-        impit.DecodingError('decoding error'),
-    ],
-)
-def test__is_retryable_error(exc: Exception) -> None:
-    assert is_retryable_error(exc) is True
-
-
-@pytest.mark.parametrize(
-    'exc',
-    [
-        Exception('generic exception'),
-        ValueError('value error'),
-        RuntimeError('runtime error'),
-    ],
-)
-def test__is_not_retryable_error(exc: Exception) -> None:
-    assert is_retryable_error(exc) is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`_utils/errors.py::is_retryable_error` is a stale copy of `http_clients/_impit.py::_is_retryable_error`. No production code calls it — only its own tests did — and it sits in a private module, so nothing depends on it. Once #1019 narrows the real policy, keeping a second copy that still claims every `impit.HTTPError` is transient is actively misleading.

Removes the function, its two test cases, and the imports they alone needed.

Split out of #1006.

*✍️ Drafted by Claude Code*
