### PR TITLE
fix: percent-encode caller-supplied URL path segments

### DIFF
--- a/src/apify_client/_resource_clients/_resource_client.py
+++ b/src/apify_client/_resource_clients/_resource_client.py
@@ -11,7 +11,7 @@ from apify_client._consts import DEFAULT_WAIT_FOR_FINISH, DEFAULT_WAIT_WHEN_JOB_
 from apify_client._docs import docs_group
 from apify_client._logging import WithLogDetailsClient
 from apify_client._utils.errors import catch_not_found_for_resource_or_throw, catch_not_found_or_throw
-from apify_client._utils.http import response_to_dict, to_safe_id
+from apify_client._utils.http import response_to_dict, to_path_segment, to_safe_id
 from apify_client._utils.time import to_seconds
 from apify_client.errors import ApifyApiError
 
@@ -75,7 +75,7 @@ class ResourceClientBase(metaclass=WithLogDetailsClient):
         """Build the full resource URL from base URL, path, and optional ID."""
         url = f'{self._base_url}/{self._resource_path}'
         if self._resource_id is not None:
-            url = f'{url}/{to_safe_id(self._resource_id)}'
+            url = f'{url}/{to_path_segment(to_safe_id(self._resource_id))}'
         return url
 
     @cached_property

--- a/src/apify_client/_resource_clients/key_value_store.py
+++ b/src/apify_client/_resource_clients/key_value_store.py
@@ -18,7 +18,7 @@ from apify_client._resource_clients._resource_client import ResourceClient, Reso
 from apify_client._utils.crypto import create_hmac_signature, create_storage_content_signature
 from apify_client._utils.encoding import encode_key_value_store_record_value
 from apify_client._utils.errors import catch_not_found_or_throw
-from apify_client._utils.http import response_to_dict
+from apify_client._utils.http import response_to_dict, to_path_segment
 from apify_client.errors import ApifyApiError, InvalidResponseBodyError
 
 if TYPE_CHECKING:
@@ -239,7 +239,7 @@ class KeyValueStoreClient(ResourceClient):
         """
         try:
             response = self._http_client.call(
-                url=self._build_url(f'records/{key}'),
+                url=self._build_url(f'records/{to_path_segment(key)}'),
                 method='GET',
                 params=self._build_params(signature=signature, attachment=True),
                 timeout=timeout,
@@ -270,7 +270,7 @@ class KeyValueStoreClient(ResourceClient):
         """
         try:
             response = self._http_client.call(
-                url=self._build_url(f'records/{key}'),
+                url=self._build_url(f'records/{to_path_segment(key)}'),
                 method='HEAD',
                 params=self._build_params(),
                 timeout=timeout,
@@ -298,7 +298,7 @@ class KeyValueStoreClient(ResourceClient):
         """
         try:
             response = self._http_client.call(
-                url=self._build_url(f'records/{key}'),
+                url=self._build_url(f'records/{to_path_segment(key)}'),
                 method='GET',
                 params=self._build_params(signature=signature, attachment=True),
                 timeout=timeout,
@@ -334,7 +334,7 @@ class KeyValueStoreClient(ResourceClient):
         response = None
         try:
             response = self._http_client.call(
-                url=self._build_url(f'records/{key}'),
+                url=self._build_url(f'records/{to_path_segment(key)}'),
                 method='GET',
                 params=self._build_params(signature=signature, attachment=True),
                 stream=True,
@@ -390,7 +390,7 @@ class KeyValueStoreClient(ResourceClient):
             headers['content-encoding'] = content_encoding
 
         self._http_client.call(
-            url=self._build_url(f'records/{key}'),
+            url=self._build_url(f'records/{to_path_segment(key)}'),
             method='PUT',
             params=self._build_params(),
             data=value,
@@ -408,7 +408,7 @@ class KeyValueStoreClient(ResourceClient):
             timeout: Timeout for the API HTTP request.
         """
         self._http_client.call(
-            url=self._build_url(f'records/{key}'),
+            url=self._build_url(f'records/{to_path_segment(key)}'),
             method='DELETE',
             params=self._build_params(),
             timeout=timeout,
@@ -437,7 +437,7 @@ class KeyValueStoreClient(ResourceClient):
         if metadata and metadata.url_signing_secret_key:
             request_params['signature'] = create_hmac_signature(metadata.url_signing_secret_key, key)
 
-        return self._build_public_url(f'records/{key}', request_params)
+        return self._build_public_url(f'records/{to_path_segment(key)}', request_params)
 
     def create_keys_public_url(
         self,
@@ -666,7 +666,7 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
         """
         try:
             response = await self._http_client.call(
-                url=self._build_url(f'records/{key}'),
+                url=self._build_url(f'records/{to_path_segment(key)}'),
                 method='GET',
                 params=self._build_params(signature=signature, attachment=True),
                 timeout=timeout,
@@ -697,7 +697,7 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
         """
         try:
             response = await self._http_client.call(
-                url=self._build_url(f'records/{key}'),
+                url=self._build_url(f'records/{to_path_segment(key)}'),
                 method='HEAD',
                 params=self._build_params(),
                 timeout=timeout,
@@ -727,7 +727,7 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
         """
         try:
             response = await self._http_client.call(
-                url=self._build_url(f'records/{key}'),
+                url=self._build_url(f'records/{to_path_segment(key)}'),
                 method='GET',
                 params=self._build_params(signature=signature, attachment=True),
                 timeout=timeout,
@@ -763,7 +763,7 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
         response = None
         try:
             response = await self._http_client.call(
-                url=self._build_url(f'records/{key}'),
+                url=self._build_url(f'records/{to_path_segment(key)}'),
                 method='GET',
                 params=self._build_params(signature=signature, attachment=True),
                 stream=True,
@@ -819,7 +819,7 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
             headers['content-encoding'] = content_encoding
 
         await self._http_client.call(
-            url=self._build_url(f'records/{key}'),
+            url=self._build_url(f'records/{to_path_segment(key)}'),
             method='PUT',
             params=self._build_params(),
             data=value,
@@ -837,7 +837,7 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
             timeout: Timeout for the API HTTP request.
         """
         await self._http_client.call(
-            url=self._build_url(f'records/{key}'),
+            url=self._build_url(f'records/{to_path_segment(key)}'),
             method='DELETE',
             params=self._build_params(),
             timeout=timeout,
@@ -866,7 +866,7 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
         if metadata and metadata.url_signing_secret_key:
             request_params['signature'] = create_hmac_signature(metadata.url_signing_secret_key, key)
 
-        return self._build_public_url(f'records/{key}', request_params)
+        return self._build_public_url(f'records/{to_path_segment(key)}', request_params)
 
     async def create_keys_public_url(
         self,

--- a/src/apify_client/_resource_clients/key_value_store.py
+++ b/src/apify_client/_resource_clients/key_value_store.py
@@ -430,14 +430,18 @@ class KeyValueStoreClient(ResourceClient):
         if self._resource_id is None:
             raise ValueError('resource_id cannot be None when generating a public URL')
 
+        # Encode the key first, so a key that cannot address a record is refused before spending a request.
+        record_path = f'records/{to_path_segment(key)}'
+
         metadata = self.get(timeout=timeout)
 
         request_params = self._build_params()
 
+        # The signature covers the raw key, which is what the API sees once it decodes the path segment.
         if metadata and metadata.url_signing_secret_key:
             request_params['signature'] = create_hmac_signature(metadata.url_signing_secret_key, key)
 
-        return self._build_public_url(f'records/{to_path_segment(key)}', request_params)
+        return self._build_public_url(record_path, request_params)
 
     def create_keys_public_url(
         self,
@@ -859,14 +863,18 @@ class KeyValueStoreClientAsync(ResourceClientAsync):
         if self._resource_id is None:
             raise ValueError('resource_id cannot be None when generating a public URL')
 
+        # Encode the key first, so a key that cannot address a record is refused before spending a request.
+        record_path = f'records/{to_path_segment(key)}'
+
         metadata = await self.get(timeout=timeout)
 
         request_params = self._build_params()
 
+        # The signature covers the raw key, which is what the API sees once it decodes the path segment.
         if metadata and metadata.url_signing_secret_key:
             request_params['signature'] = create_hmac_signature(metadata.url_signing_secret_key, key)
 
-        return self._build_public_url(f'records/{to_path_segment(key)}', request_params)
+        return self._build_public_url(record_path, request_params)
 
     async def create_keys_public_url(
         self,

--- a/src/apify_client/_resource_clients/request_queue.py
+++ b/src/apify_client/_resource_clients/request_queue.py
@@ -38,7 +38,7 @@ from apify_client._models import (
 from apify_client._pagination import DEFAULT_CHUNK_SIZE, get_cursor_iterator, get_cursor_iterator_async
 from apify_client._resource_clients._resource_client import ResourceClient, ResourceClientAsync
 from apify_client._utils.errors import catch_not_found_or_throw
-from apify_client._utils.http import response_to_dict
+from apify_client._utils.http import response_to_dict, to_path_segment
 from apify_client._utils.time import to_seconds
 from apify_client.errors import ApifyApiError
 
@@ -275,7 +275,7 @@ class RequestQueueClient(ResourceClient):
         """
         try:
             response = self._http_client.call(
-                url=self._build_url(f'requests/{request_id}'),
+                url=self._build_url(f'requests/{to_path_segment(request_id)}'),
                 method='GET',
                 params=self._build_params(),
                 timeout=timeout,
@@ -310,10 +310,13 @@ class RequestQueueClient(ResourceClient):
         if not isinstance(request, Request):
             request = Request.model_validate(request)
 
+        if request.id is None:
+            raise ValueError('The request to update must have an ID.')
+
         request_params = self._build_params(forefront=forefront, clientKey=self.client_key)
 
         response = self._http_client.call(
-            url=self._build_url(f'requests/{request.id}'),
+            url=self._build_url(f'requests/{to_path_segment(request.id)}'),
             method='PUT',
             json=request.model_dump(by_alias=True, exclude_none=True),
             params=request_params,
@@ -337,7 +340,7 @@ class RequestQueueClient(ResourceClient):
         )
 
         self._http_client.call(
-            url=self._build_url(f'requests/{request_id}'),
+            url=self._build_url(f'requests/{to_path_segment(request_id)}'),
             method='DELETE',
             params=request_params,
             timeout=timeout,
@@ -368,7 +371,7 @@ class RequestQueueClient(ResourceClient):
         )
 
         response = self._http_client.call(
-            url=self._build_url(f'requests/{request_id}/lock'),
+            url=self._build_url(f'requests/{to_path_segment(request_id)}/lock'),
             method='PUT',
             params=request_params,
             timeout=timeout,
@@ -396,7 +399,7 @@ class RequestQueueClient(ResourceClient):
         request_params = self._build_params(clientKey=self.client_key, forefront=forefront)
 
         self._http_client.call(
-            url=self._build_url(f'requests/{request_id}/lock'),
+            url=self._build_url(f'requests/{to_path_segment(request_id)}/lock'),
             method='DELETE',
             params=request_params,
             timeout=timeout,
@@ -802,7 +805,7 @@ class RequestQueueClientAsync(ResourceClientAsync):
         """
         try:
             response = await self._http_client.call(
-                url=self._build_url(f'requests/{request_id}'),
+                url=self._build_url(f'requests/{to_path_segment(request_id)}'),
                 method='GET',
                 params=self._build_params(),
                 timeout=timeout,
@@ -835,10 +838,13 @@ class RequestQueueClientAsync(ResourceClientAsync):
         if not isinstance(request, Request):
             request = Request.model_validate(request)
 
+        if request.id is None:
+            raise ValueError('The request to update must have an ID.')
+
         request_params = self._build_params(forefront=forefront, clientKey=self.client_key)
 
         response = await self._http_client.call(
-            url=self._build_url(f'requests/{request.id}'),
+            url=self._build_url(f'requests/{to_path_segment(request.id)}'),
             method='PUT',
             json=request.model_dump(by_alias=True, exclude_none=True),
             params=request_params,
@@ -860,7 +866,7 @@ class RequestQueueClientAsync(ResourceClientAsync):
         request_params = self._build_params(clientKey=self.client_key)
 
         await self._http_client.call(
-            url=self._build_url(f'requests/{request_id}'),
+            url=self._build_url(f'requests/{to_path_segment(request_id)}'),
             method='DELETE',
             params=request_params,
             timeout=timeout,
@@ -891,7 +897,7 @@ class RequestQueueClientAsync(ResourceClientAsync):
         )
 
         response = await self._http_client.call(
-            url=self._build_url(f'requests/{request_id}/lock'),
+            url=self._build_url(f'requests/{to_path_segment(request_id)}/lock'),
             method='PUT',
             params=request_params,
             timeout=timeout,
@@ -919,7 +925,7 @@ class RequestQueueClientAsync(ResourceClientAsync):
         request_params = self._build_params(clientKey=self.client_key, forefront=forefront)
 
         await self._http_client.call(
-            url=self._build_url(f'requests/{request_id}/lock'),
+            url=self._build_url(f'requests/{to_path_segment(request_id)}/lock'),
             method='DELETE',
             params=request_params,
             timeout=timeout,

--- a/src/apify_client/_resource_clients/request_queue.py
+++ b/src/apify_client/_resource_clients/request_queue.py
@@ -300,12 +300,15 @@ class RequestQueueClient(ResourceClient):
         https://docs.apify.com/api/v2#/reference/request-queues/request/update-request
 
         Args:
-            request: The updated request.
+            request: The updated request. It must carry the ID of the request to update.
             forefront: Whether to put the updated request in the beginning or the end of the queue.
             timeout: Timeout for the API HTTP request.
 
         Returns:
             The updated request.
+
+        Raises:
+            ValueError: If the request carries no ID.
         """
         if not isinstance(request, Request):
             request = Request.model_validate(request)
@@ -828,12 +831,15 @@ class RequestQueueClientAsync(ResourceClientAsync):
         https://docs.apify.com/api/v2#/reference/request-queues/request/update-request
 
         Args:
-            request: The updated request.
+            request: The updated request. It must carry the ID of the request to update.
             forefront: Whether to put the updated request in the beginning or the end of the queue.
             timeout: Timeout for the API HTTP request.
 
         Returns:
             The updated request.
+
+        Raises:
+            ValueError: If the request carries no ID.
         """
         if not isinstance(request, Request):
             request = Request.model_validate(request)

--- a/src/apify_client/_utils/http.py
+++ b/src/apify_client/_utils/http.py
@@ -38,15 +38,14 @@ def to_path_segment(value: str) -> str:
         value: The value to place in a single path segment, for example a key-value store record key.
 
     Returns:
-        The value with every character that has a meaning in a URL percent-encoded.
+        The percent-encoded value, which a URL parser can only read as one path segment.
 
     Raises:
         ValueError: If the value is empty, `.` or `..`, none of which can be carried in a path segment at all.
     """
     # Encoding cannot save these three: an empty value leaves nothing but the separator, and a URL parser
-    # resolves a dot segment against the segment before it - after decoding, so `%2E%2E` is resolved just like
-    # `..`. Either way the request lands on the parent endpoint - for a record key that is the store itself,
-    # where the same call reads, rewrites or deletes the whole store instead of one record.
+    # resolves a dot segment after percent-decoding, so `%2E%2E` collapses just like `..`. Either way the
+    # request lands on a parent endpoint, where `..` makes the same verb act on the whole resource.
     if value in {'', '.', '..'}:
         raise ValueError(f'"{value}" cannot be used as a URL path segment.')
 

--- a/src/apify_client/_utils/http.py
+++ b/src/apify_client/_utils/http.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import warnings
 from typing import TYPE_CHECKING
+from urllib.parse import quote
 
 from apify_client._consts import (
     ALREADY_COMPRESSED_MEDIA_TYPE_PREFIXES,
@@ -25,6 +26,31 @@ def to_safe_id(id: str) -> str:
         The resource identifier with `/` characters replaced by `~`.
     """
     return id.replace('/', '~')
+
+
+def to_path_segment(value: str) -> str:
+    """Percent-encode a caller-supplied value so it stays a single URL path segment.
+
+    Without this, a value carrying `/`, `?` or `#` would restructure the URL it is interpolated into: it could
+    reach a different endpoint, append its own query parameters, or be silently truncated at a fragment.
+
+    Args:
+        value: The value to place in a single path segment, for example a key-value store record key.
+
+    Returns:
+        The value with every character that has a meaning in a URL percent-encoded.
+
+    Raises:
+        ValueError: If the value is empty, `.` or `..`, none of which can be carried in a path segment at all.
+    """
+    # Encoding cannot save these three: an empty value leaves nothing but the separator, and a URL parser
+    # resolves a dot segment against the segment before it - after decoding, so `%2E%2E` is resolved just like
+    # `..`. Either way the request lands on the parent endpoint - for a record key that is the store itself,
+    # where the same call reads, rewrites or deletes the whole store instead of one record.
+    if value in {'', '.', '..'}:
+        raise ValueError(f'"{value}" cannot be used as a URL path segment.')
+
+    return quote(value, safe='')
 
 
 def is_compressible_content_type(content_type: str | None) -> bool:

--- a/tests/unit/test_url_path_encoding.py
+++ b/tests/unit/test_url_path_encoding.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+from werkzeug import Response
+
+from apify_client import ApifyClient, ApifyClientAsync
+from apify_client._models import Request
+
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
+    from werkzeug import Request as WerkzeugRequest
+
+_KVS_ID = 'test_kvs_id'
+_QUEUE_ID = 'test_queue_id'
+_PUBLIC_URL = 'https://public.example.com'
+
+# Caller-supplied segments that must not be able to steer the request off its endpoint. Each case is
+# (raw value, the percent-encoded form the value has to arrive as).
+_HOSTILE_SEGMENTS = [
+    pytest.param('../../actor-runs/VICTIM/abort', '..%2F..%2Factor-runs%2FVICTIM%2Fabort', id='traversal'),
+    pytest.param('foo?injected=1', 'foo%3Finjected%3D1', id='query injection'),
+    pytest.param('foo#frag', 'foo%23frag', id='fragment'),
+    pytest.param('a/b', 'a%2Fb', id='slash'),
+    pytest.param('a b', 'a%20b', id='space'),
+    pytest.param('INPUT.json', 'INPUT.json', id='plain key with a dot'),
+]
+
+# The same for resource IDs, which `to_safe_id` first turns into their single-segment form: a `username/name`
+# reference becomes `username~name`, and the tilde must survive the encoding untouched.
+_HOSTILE_RESOURCE_IDS = [
+    pytest.param('foo?injected=1', 'foo%3Finjected%3D1', id='query injection'),
+    pytest.param('foo#frag', 'foo%23frag', id='fragment'),
+    pytest.param('a b', 'a%20b', id='space'),
+    pytest.param('username/name', 'username~name', id='username-prefixed ID'),
+]
+
+_DEGENERATE_SEGMENTS = [
+    pytest.param('', id='empty'),
+    pytest.param('.', id='current'),
+    pytest.param('..', id='parent'),
+]
+
+
+@pytest.fixture
+def api_url(httpserver: HTTPServer) -> str:
+    """The base URL of the mock server, in the form the clients expect."""
+    return httpserver.url_for('/').removesuffix('/')
+
+
+@pytest.fixture
+def captured_targets(httpserver: HTTPServer) -> list[str]:
+    """Answer any GET with a 404 and collect the raw request targets the client sent.
+
+    The raw target is read from `RAW_URI` rather than from `Request.path`, which is already percent-decoded and
+    so cannot tell an encoded separator apart from a literal one.
+    """
+    targets: list[str] = []
+
+    def capture_request(request: WerkzeugRequest) -> Response:
+        targets.append(request.environ['RAW_URI'])
+        return Response(status=404, response='{"error": {"type": "record-not-found"}}')
+
+    httpserver.expect_request(re.compile('.*'), method='GET').respond_with_handler(capture_request)
+    return targets
+
+
+@pytest.mark.parametrize(('key', 'encoded_key'), _HOSTILE_SEGMENTS)
+def test_get_record_encodes_key_into_a_single_path_segment_sync(
+    *,
+    api_url: str,
+    captured_targets: list[str],
+    key: str,
+    encoded_key: str,
+) -> None:
+    """A record key cannot escape its path segment, inject query params, or be truncated by a fragment."""
+    client = ApifyClient(token='test_token', api_url=api_url)
+
+    assert client.key_value_store(_KVS_ID).get_record(key) is None
+
+    assert captured_targets == [f'/v2/key-value-stores/{_KVS_ID}/records/{encoded_key}?attachment=true']
+
+
+@pytest.mark.parametrize(('key', 'encoded_key'), _HOSTILE_SEGMENTS)
+async def test_get_record_encodes_key_into_a_single_path_segment_async(
+    *,
+    api_url: str,
+    captured_targets: list[str],
+    key: str,
+    encoded_key: str,
+) -> None:
+    """A record key cannot escape its path segment, inject query params, or be truncated by a fragment."""
+    client = ApifyClientAsync(token='test_token', api_url=api_url)
+
+    assert await client.key_value_store(_KVS_ID).get_record(key) is None
+
+    assert captured_targets == [f'/v2/key-value-stores/{_KVS_ID}/records/{encoded_key}?attachment=true']
+
+
+@pytest.mark.parametrize(('request_id', 'encoded_request_id'), _HOSTILE_SEGMENTS)
+def test_get_request_encodes_request_id_into_a_single_path_segment_sync(
+    *,
+    api_url: str,
+    captured_targets: list[str],
+    request_id: str,
+    encoded_request_id: str,
+) -> None:
+    """A request ID cannot escape the request-queue namespace it belongs to."""
+    client = ApifyClient(token='test_token', api_url=api_url)
+
+    assert client.request_queue(_QUEUE_ID).get_request(request_id) is None
+
+    assert captured_targets == [f'/v2/request-queues/{_QUEUE_ID}/requests/{encoded_request_id}']
+
+
+@pytest.mark.parametrize(('request_id', 'encoded_request_id'), _HOSTILE_SEGMENTS)
+async def test_get_request_encodes_request_id_into_a_single_path_segment_async(
+    *,
+    api_url: str,
+    captured_targets: list[str],
+    request_id: str,
+    encoded_request_id: str,
+) -> None:
+    """A request ID cannot escape the request-queue namespace it belongs to."""
+    client = ApifyClientAsync(token='test_token', api_url=api_url)
+
+    assert await client.request_queue(_QUEUE_ID).get_request(request_id) is None
+
+    assert captured_targets == [f'/v2/request-queues/{_QUEUE_ID}/requests/{encoded_request_id}']
+
+
+@pytest.mark.parametrize(('request_id', 'encoded_request_id'), _HOSTILE_SEGMENTS)
+def test_delete_request_lock_encodes_request_id_into_a_single_path_segment(
+    *,
+    api_url: str,
+    httpserver: HTTPServer,
+    request_id: str,
+    encoded_request_id: str,
+) -> None:
+    """The encoding also covers a path that continues past the caller-supplied segment."""
+    targets: list[str] = []
+
+    def capture_request(request: WerkzeugRequest) -> Response:
+        targets.append(request.environ['RAW_URI'])
+        return Response(status=204)
+
+    httpserver.expect_request(re.compile('.*'), method='DELETE').respond_with_handler(capture_request)
+    client = ApifyClient(token='test_token', api_url=api_url)
+
+    client.request_queue(_QUEUE_ID).delete_request_lock(request_id)
+
+    assert targets == [f'/v2/request-queues/{_QUEUE_ID}/requests/{encoded_request_id}/lock']
+
+
+@pytest.mark.parametrize('key', _DEGENERATE_SEGMENTS)
+def test_degenerate_key_is_rejected_before_the_request_sync(
+    *,
+    api_url: str,
+    captured_targets: list[str],
+    key: str,
+) -> None:
+    """An empty or dot key survives any encoding and lands on the store endpoint, so it is refused instead."""
+    client = ApifyClient(token='test_token', api_url=api_url)
+
+    with pytest.raises(ValueError, match='cannot be used as a URL path segment'):
+        client.key_value_store(_KVS_ID).get_record(key)
+
+    assert captured_targets == []
+
+
+@pytest.mark.parametrize('key', _DEGENERATE_SEGMENTS)
+async def test_degenerate_key_is_rejected_before_the_request_async(
+    *,
+    api_url: str,
+    captured_targets: list[str],
+    key: str,
+) -> None:
+    """An empty or dot key survives any encoding and lands on the store endpoint, so it is refused instead."""
+    client = ApifyClientAsync(token='test_token', api_url=api_url)
+
+    with pytest.raises(ValueError, match='cannot be used as a URL path segment'):
+        await client.key_value_store(_KVS_ID).get_record(key)
+
+    assert captured_targets == []
+
+
+@pytest.mark.parametrize(('key', 'encoded_key'), _HOSTILE_SEGMENTS)
+def test_record_public_url_encodes_key_into_a_single_path_segment_sync(
+    *,
+    api_url: str,
+    captured_targets: list[str],
+    key: str,
+    encoded_key: str,
+) -> None:
+    """The shareable record URL carries the key encoded, so it addresses the record and nothing else."""
+    client = ApifyClient(token='test_token', api_url=api_url, api_public_url=_PUBLIC_URL)
+
+    public_url = client.key_value_store(_KVS_ID).get_record_public_url(key)
+
+    assert captured_targets == [f'/v2/key-value-stores/{_KVS_ID}']
+    assert public_url == f'{_PUBLIC_URL}/v2/key-value-stores/{_KVS_ID}/records/{encoded_key}'
+
+
+@pytest.mark.parametrize(('key', 'encoded_key'), _HOSTILE_SEGMENTS)
+async def test_record_public_url_encodes_key_into_a_single_path_segment_async(
+    *,
+    api_url: str,
+    captured_targets: list[str],
+    key: str,
+    encoded_key: str,
+) -> None:
+    """The shareable record URL carries the key encoded, so it addresses the record and nothing else."""
+    client = ApifyClientAsync(token='test_token', api_url=api_url, api_public_url=_PUBLIC_URL)
+
+    public_url = await client.key_value_store(_KVS_ID).get_record_public_url(key)
+
+    assert captured_targets == [f'/v2/key-value-stores/{_KVS_ID}']
+    assert public_url == f'{_PUBLIC_URL}/v2/key-value-stores/{_KVS_ID}/records/{encoded_key}'
+
+
+@pytest.mark.parametrize(('resource_id', 'encoded_resource_id'), _HOSTILE_RESOURCE_IDS)
+def test_resource_id_is_encoded_into_a_single_path_segment(
+    *,
+    api_url: str,
+    captured_targets: list[str],
+    resource_id: str,
+    encoded_resource_id: str,
+) -> None:
+    """A resource ID cannot inject query parameters, truncate the URL at a fragment, or escape the path."""
+    client = ApifyClient(token='test_token', api_url=api_url)
+
+    assert client.dataset(resource_id).get() is None
+
+    assert captured_targets == [f'/v2/datasets/{encoded_resource_id}']
+
+
+@pytest.mark.parametrize('resource_id', _DEGENERATE_SEGMENTS)
+def test_degenerate_resource_id_is_rejected_before_the_request(
+    *,
+    api_url: str,
+    captured_targets: list[str],
+    resource_id: str,
+) -> None:
+    """An empty or dot resource ID would address the whole collection, so it is refused instead."""
+    client = ApifyClient(token='test_token', api_url=api_url)
+
+    with pytest.raises(ValueError, match='cannot be used as a URL path segment'):
+        client.dataset(resource_id).get()
+
+    assert captured_targets == []
+
+
+def test_update_request_without_an_id_is_rejected_sync(*, api_url: str) -> None:
+    """A request carrying no ID cannot address a queue record, so the update is refused before it is sent."""
+    client = ApifyClient(token='test_token', api_url=api_url)
+
+    with pytest.raises(ValueError, match='must have an ID'):
+        client.request_queue(_QUEUE_ID).update_request(Request(url='https://example.com'))
+
+
+async def test_update_request_without_an_id_is_rejected_async(*, api_url: str) -> None:
+    """A request carrying no ID cannot address a queue record, so the update is refused before it is sent."""
+    client = ApifyClientAsync(token='test_token', api_url=api_url)
+
+    with pytest.raises(ValueError, match='must have an ID'):
+        await client.request_queue(_QUEUE_ID).update_request(Request(url='https://example.com'))

--- a/tests/unit/test_url_path_encoding.py
+++ b/tests/unit/test_url_path_encoding.py
@@ -8,6 +8,7 @@ from werkzeug import Response
 
 from apify_client import ApifyClient, ApifyClientAsync
 from apify_client._models import Request
+from apify_client._utils.crypto import create_hmac_signature
 
 if TYPE_CHECKING:
     from pytest_httpserver import HTTPServer
@@ -17,20 +18,21 @@ _KVS_ID = 'test_kvs_id'
 _QUEUE_ID = 'test_queue_id'
 _PUBLIC_URL = 'https://public.example.com'
 
-# Caller-supplied segments that must not be able to steer the request off its endpoint. Each case is
-# (raw value, the percent-encoded form the value has to arrive as).
-_HOSTILE_SEGMENTS = [
+# Caller-supplied segments that must not be able to steer the request off its endpoint, plus an ordinary
+# value that has to survive untouched. Each case is (raw value, the percent-encoded form it has to arrive as).
+_SEGMENT_CASES = [
     pytest.param('../../actor-runs/VICTIM/abort', '..%2F..%2Factor-runs%2FVICTIM%2Fabort', id='traversal'),
     pytest.param('foo?injected=1', 'foo%3Finjected%3D1', id='query injection'),
     pytest.param('foo#frag', 'foo%23frag', id='fragment'),
     pytest.param('a/b', 'a%2Fb', id='slash'),
     pytest.param('a b', 'a%20b', id='space'),
-    pytest.param('INPUT.json', 'INPUT.json', id='plain key with a dot'),
+    pytest.param('INPUT.json', 'INPUT.json', id='ordinary value'),
 ]
 
 # The same for resource IDs, which `to_safe_id` first turns into their single-segment form: a `username/name`
 # reference becomes `username~name`, and the tilde must survive the encoding untouched.
-_HOSTILE_RESOURCE_IDS = [
+_RESOURCE_ID_CASES = [
+    pytest.param('../../actor-runs/VICTIM/abort', '..~..~actor-runs~VICTIM~abort', id='traversal'),
     pytest.param('foo?injected=1', 'foo%3Finjected%3D1', id='query injection'),
     pytest.param('foo#frag', 'foo%23frag', id='fragment'),
     pytest.param('a b', 'a%20b', id='space'),
@@ -51,6 +53,28 @@ def api_url(httpserver: HTTPServer) -> str:
 
 
 @pytest.fixture
+def kvs_signing_key(httpserver: HTTPServer) -> str:
+    """Answer the store metadata call with a URL signing key, and return that key."""
+    signing_key = 'test_signing_key'
+    httpserver.expect_request(f'/v2/key-value-stores/{_KVS_ID}', method='GET').respond_with_json(
+        {
+            'data': {
+                'id': _KVS_ID,
+                'name': 'name',
+                'userId': 'user_id',
+                'createdAt': '2025-09-11T08:48:51.806Z',
+                'modifiedAt': '2025-09-11T08:48:51.806Z',
+                'accessedAt': '2025-09-11T08:48:51.806Z',
+                'stats': {'readCount': 0, 'writeCount': 0, 'deleteCount': 0, 'listCount': 0, 'storageBytes': 0},
+                'generalAccess': 'FOLLOW_USER_SETTING',
+                'urlSigningSecretKey': signing_key,
+            }
+        }
+    )
+    return signing_key
+
+
+@pytest.fixture
 def captured_targets(httpserver: HTTPServer) -> list[str]:
     """Answer any GET with a 404 and collect the raw request targets the client sent.
 
@@ -67,7 +91,20 @@ def captured_targets(httpserver: HTTPServer) -> list[str]:
     return targets
 
 
-@pytest.mark.parametrize(('key', 'encoded_key'), _HOSTILE_SEGMENTS)
+@pytest.fixture
+def captured_delete_targets(httpserver: HTTPServer) -> list[str]:
+    """Answer any DELETE with a 204 and collect the raw request targets the client sent."""
+    targets: list[str] = []
+
+    def capture_request(request: WerkzeugRequest) -> Response:
+        targets.append(request.environ['RAW_URI'])
+        return Response(status=204)
+
+    httpserver.expect_request(re.compile('.*'), method='DELETE').respond_with_handler(capture_request)
+    return targets
+
+
+@pytest.mark.parametrize(('key', 'encoded_key'), _SEGMENT_CASES)
 def test_get_record_encodes_key_into_a_single_path_segment_sync(
     *,
     api_url: str,
@@ -83,7 +120,7 @@ def test_get_record_encodes_key_into_a_single_path_segment_sync(
     assert captured_targets == [f'/v2/key-value-stores/{_KVS_ID}/records/{encoded_key}?attachment=true']
 
 
-@pytest.mark.parametrize(('key', 'encoded_key'), _HOSTILE_SEGMENTS)
+@pytest.mark.parametrize(('key', 'encoded_key'), _SEGMENT_CASES)
 async def test_get_record_encodes_key_into_a_single_path_segment_async(
     *,
     api_url: str,
@@ -99,7 +136,39 @@ async def test_get_record_encodes_key_into_a_single_path_segment_async(
     assert captured_targets == [f'/v2/key-value-stores/{_KVS_ID}/records/{encoded_key}?attachment=true']
 
 
-@pytest.mark.parametrize(('request_id', 'encoded_request_id'), _HOSTILE_SEGMENTS)
+@pytest.mark.parametrize(('key', 'encoded_key'), _SEGMENT_CASES)
+def test_delete_record_encodes_key_into_a_single_path_segment_sync(
+    *,
+    api_url: str,
+    captured_delete_targets: list[str],
+    key: str,
+    encoded_key: str,
+) -> None:
+    """A key cannot steer a record delete at another endpoint, where the same verb removes the whole store."""
+    client = ApifyClient(token='test_token', api_url=api_url)
+
+    client.key_value_store(_KVS_ID).delete_record(key)
+
+    assert captured_delete_targets == [f'/v2/key-value-stores/{_KVS_ID}/records/{encoded_key}']
+
+
+@pytest.mark.parametrize(('key', 'encoded_key'), _SEGMENT_CASES)
+async def test_delete_record_encodes_key_into_a_single_path_segment_async(
+    *,
+    api_url: str,
+    captured_delete_targets: list[str],
+    key: str,
+    encoded_key: str,
+) -> None:
+    """A key cannot steer a record delete at another endpoint, where the same verb removes the whole store."""
+    client = ApifyClientAsync(token='test_token', api_url=api_url)
+
+    await client.key_value_store(_KVS_ID).delete_record(key)
+
+    assert captured_delete_targets == [f'/v2/key-value-stores/{_KVS_ID}/records/{encoded_key}']
+
+
+@pytest.mark.parametrize(('request_id', 'encoded_request_id'), _SEGMENT_CASES)
 def test_get_request_encodes_request_id_into_a_single_path_segment_sync(
     *,
     api_url: str,
@@ -115,7 +184,7 @@ def test_get_request_encodes_request_id_into_a_single_path_segment_sync(
     assert captured_targets == [f'/v2/request-queues/{_QUEUE_ID}/requests/{encoded_request_id}']
 
 
-@pytest.mark.parametrize(('request_id', 'encoded_request_id'), _HOSTILE_SEGMENTS)
+@pytest.mark.parametrize(('request_id', 'encoded_request_id'), _SEGMENT_CASES)
 async def test_get_request_encodes_request_id_into_a_single_path_segment_async(
     *,
     api_url: str,
@@ -131,27 +200,36 @@ async def test_get_request_encodes_request_id_into_a_single_path_segment_async(
     assert captured_targets == [f'/v2/request-queues/{_QUEUE_ID}/requests/{encoded_request_id}']
 
 
-@pytest.mark.parametrize(('request_id', 'encoded_request_id'), _HOSTILE_SEGMENTS)
-def test_delete_request_lock_encodes_request_id_into_a_single_path_segment(
+@pytest.mark.parametrize(('request_id', 'encoded_request_id'), _SEGMENT_CASES)
+def test_delete_request_lock_encodes_request_id_into_a_single_path_segment_sync(
     *,
     api_url: str,
-    httpserver: HTTPServer,
+    captured_delete_targets: list[str],
     request_id: str,
     encoded_request_id: str,
 ) -> None:
     """The encoding also covers a path that continues past the caller-supplied segment."""
-    targets: list[str] = []
-
-    def capture_request(request: WerkzeugRequest) -> Response:
-        targets.append(request.environ['RAW_URI'])
-        return Response(status=204)
-
-    httpserver.expect_request(re.compile('.*'), method='DELETE').respond_with_handler(capture_request)
     client = ApifyClient(token='test_token', api_url=api_url)
 
     client.request_queue(_QUEUE_ID).delete_request_lock(request_id)
 
-    assert targets == [f'/v2/request-queues/{_QUEUE_ID}/requests/{encoded_request_id}/lock']
+    assert captured_delete_targets == [f'/v2/request-queues/{_QUEUE_ID}/requests/{encoded_request_id}/lock']
+
+
+@pytest.mark.parametrize(('request_id', 'encoded_request_id'), _SEGMENT_CASES)
+async def test_delete_request_lock_encodes_request_id_into_a_single_path_segment_async(
+    *,
+    api_url: str,
+    captured_delete_targets: list[str],
+    request_id: str,
+    encoded_request_id: str,
+) -> None:
+    """The encoding also covers a path that continues past the caller-supplied segment."""
+    client = ApifyClientAsync(token='test_token', api_url=api_url)
+
+    await client.request_queue(_QUEUE_ID).delete_request_lock(request_id)
+
+    assert captured_delete_targets == [f'/v2/request-queues/{_QUEUE_ID}/requests/{encoded_request_id}/lock']
 
 
 @pytest.mark.parametrize('key', _DEGENERATE_SEGMENTS)
@@ -186,7 +264,39 @@ async def test_degenerate_key_is_rejected_before_the_request_async(
     assert captured_targets == []
 
 
-@pytest.mark.parametrize(('key', 'encoded_key'), _HOSTILE_SEGMENTS)
+@pytest.mark.parametrize('key', _DEGENERATE_SEGMENTS)
+def test_degenerate_key_is_rejected_before_deleting_a_record_sync(
+    *,
+    api_url: str,
+    captured_delete_targets: list[str],
+    key: str,
+) -> None:
+    """A dot key would turn a record delete into a delete of the whole store, so it never reaches the wire."""
+    client = ApifyClient(token='test_token', api_url=api_url)
+
+    with pytest.raises(ValueError, match='cannot be used as a URL path segment'):
+        client.key_value_store(_KVS_ID).delete_record(key)
+
+    assert captured_delete_targets == []
+
+
+@pytest.mark.parametrize('key', _DEGENERATE_SEGMENTS)
+async def test_degenerate_key_is_rejected_before_deleting_a_record_async(
+    *,
+    api_url: str,
+    captured_delete_targets: list[str],
+    key: str,
+) -> None:
+    """A dot key would turn a record delete into a delete of the whole store, so it never reaches the wire."""
+    client = ApifyClientAsync(token='test_token', api_url=api_url)
+
+    with pytest.raises(ValueError, match='cannot be used as a URL path segment'):
+        await client.key_value_store(_KVS_ID).delete_record(key)
+
+    assert captured_delete_targets == []
+
+
+@pytest.mark.parametrize(('key', 'encoded_key'), _SEGMENT_CASES)
 def test_record_public_url_encodes_key_into_a_single_path_segment_sync(
     *,
     api_url: str,
@@ -203,7 +313,7 @@ def test_record_public_url_encodes_key_into_a_single_path_segment_sync(
     assert public_url == f'{_PUBLIC_URL}/v2/key-value-stores/{_KVS_ID}/records/{encoded_key}'
 
 
-@pytest.mark.parametrize(('key', 'encoded_key'), _HOSTILE_SEGMENTS)
+@pytest.mark.parametrize(('key', 'encoded_key'), _SEGMENT_CASES)
 async def test_record_public_url_encodes_key_into_a_single_path_segment_async(
     *,
     api_url: str,
@@ -220,7 +330,59 @@ async def test_record_public_url_encodes_key_into_a_single_path_segment_async(
     assert public_url == f'{_PUBLIC_URL}/v2/key-value-stores/{_KVS_ID}/records/{encoded_key}'
 
 
-@pytest.mark.parametrize(('resource_id', 'encoded_resource_id'), _HOSTILE_RESOURCE_IDS)
+def test_record_public_url_signs_the_raw_key_sync(*, api_url: str, kvs_signing_key: str) -> None:
+    """The signature covers the raw key the API decodes the path back into, not the encoded form in the path."""
+    client = ApifyClient(token='test_token', api_url=api_url, api_public_url=_PUBLIC_URL)
+
+    public_url = client.key_value_store(_KVS_ID).get_record_public_url('a/b')
+
+    signature = create_hmac_signature(kvs_signing_key, 'a/b')
+    assert public_url == f'{_PUBLIC_URL}/v2/key-value-stores/{_KVS_ID}/records/a%2Fb?signature={signature}'
+
+
+async def test_record_public_url_signs_the_raw_key_async(*, api_url: str, kvs_signing_key: str) -> None:
+    """The signature covers the raw key the API decodes the path back into, not the encoded form in the path."""
+    client = ApifyClientAsync(token='test_token', api_url=api_url, api_public_url=_PUBLIC_URL)
+
+    public_url = await client.key_value_store(_KVS_ID).get_record_public_url('a/b')
+
+    signature = create_hmac_signature(kvs_signing_key, 'a/b')
+    assert public_url == f'{_PUBLIC_URL}/v2/key-value-stores/{_KVS_ID}/records/a%2Fb?signature={signature}'
+
+
+@pytest.mark.parametrize('key', _DEGENERATE_SEGMENTS)
+def test_degenerate_key_is_rejected_before_the_public_url_metadata_call_sync(
+    *,
+    api_url: str,
+    captured_targets: list[str],
+    key: str,
+) -> None:
+    """A key that cannot be carried in a path segment is refused without spending an authenticated request."""
+    client = ApifyClient(token='test_token', api_url=api_url, api_public_url=_PUBLIC_URL)
+
+    with pytest.raises(ValueError, match='cannot be used as a URL path segment'):
+        client.key_value_store(_KVS_ID).get_record_public_url(key)
+
+    assert captured_targets == []
+
+
+@pytest.mark.parametrize('key', _DEGENERATE_SEGMENTS)
+async def test_degenerate_key_is_rejected_before_the_public_url_metadata_call_async(
+    *,
+    api_url: str,
+    captured_targets: list[str],
+    key: str,
+) -> None:
+    """A key that cannot be carried in a path segment is refused without spending an authenticated request."""
+    client = ApifyClientAsync(token='test_token', api_url=api_url, api_public_url=_PUBLIC_URL)
+
+    with pytest.raises(ValueError, match='cannot be used as a URL path segment'):
+        await client.key_value_store(_KVS_ID).get_record_public_url(key)
+
+    assert captured_targets == []
+
+
+@pytest.mark.parametrize(('resource_id', 'encoded_resource_id'), _RESOURCE_ID_CASES)
 def test_resource_id_is_encoded_into_a_single_path_segment(
     *,
     api_url: str,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -22,6 +22,7 @@ from apify_client._utils.http import (
     is_compressible_content_type,
     response_to_dict,
     response_to_list,
+    to_path_segment,
     to_safe_id,
 )
 from apify_client._utils.try_import import FailedImport, try_import
@@ -67,6 +68,27 @@ def test_to_safe_id() -> None:
     assert to_safe_id('abc/def') == 'abc~def'
     assert to_safe_id('abc~def') == 'abc~def'
     assert to_safe_id('user/resource/extra') == 'user~resource~extra'
+
+
+def test_to_path_segment() -> None:
+    """Every character with a meaning in a URL is percent-encoded, and an ordinary value is left alone."""
+    assert to_path_segment('abc') == 'abc'
+    assert to_path_segment('INPUT.json') == 'INPUT.json'
+    assert to_path_segment('a/b') == 'a%2Fb'
+    assert to_path_segment('a?b=c') == 'a%3Fb%3Dc'
+    assert to_path_segment('a#b') == 'a%23b'
+    assert to_path_segment('a b') == 'a%20b'
+    # `~` is unreserved, so a `username/name` ID mapped by `to_safe_id` survives unchanged.
+    assert to_path_segment('user~resource') == 'user~resource'
+
+
+@pytest.mark.parametrize(
+    'value', [pytest.param('', id='empty'), pytest.param('.', id='current'), pytest.param('..', id='parent')]
+)
+def test_to_path_segment_rejects_degenerate_values(value: str) -> None:
+    """An empty or dot value cannot address anything inside a path segment, so it is refused outright."""
+    with pytest.raises(ValueError, match='cannot be used as a URL path segment'):
+        to_path_segment(value)
 
 
 def test_encode_webhooks_to_base64() -> None:


### PR DESCRIPTION
Caller-supplied values were interpolated into the request path with a plain f-string, so they could restructure the URL. Reproduced against a mock server, reading the raw request line:

```
key='../../actor-runs/VICTIM/abort'    -> /v2/key-value-stores/actor-runs/VICTIM/abort
request_id='../../../datasets/V/items' -> /v2/datasets/V/items
key='foo?injected=1'                   -> /v2/.../records/foo?injected=1?attachment=true
key='foo#frag'                         -> /v2/.../records/foo   (fragment dropped, wrong record, no error)
```

Requests carry the caller's token, so traversal acts with full privileges. The `#` case is a plain correctness bug: any app forwarding user strings as record keys silently reads the wrong one.

## Fix

New `to_path_segment()` in `_utils/http.py`, applied to the caller-supplied segment at every `records/{key}` and `requests/{request_id}` call site, plus `resource_id` in `ResourceClientBase._resource_url`. `_build_url` itself is untouched, so literal paths like `requests/batch` keep their separator.

The API routes these as a single Express param (`records/:recordKey`) and decodes it once, so percent-encoding is what it expects — an unencoded `/` never matched. Signatures stay over the raw key, which is what the server verifies against (`key_value_stores.ts:503` HMACs the decoded `req.params.recordKey`).

## Behavior change

`''`, `.` and `..` now raise `ValueError`. Encoding cannot protect them — a URL parser resolves dot segments *after* decoding, so `records/%2E%2E` collapses exactly like `records/..`. They previously reached the parent endpoint, where the same verb means something else:

- `delete_record('..')` → `DELETE /v2/key-value-stores/{id}`, deleting the whole store
- `get_record('..')` returned store metadata as record content
- `client.dataset('..')` → `GET /v2/`

Also newly rejected: a non-`str` key, previously coerced by the f-string. A caller who pre-encoded keys as a workaround now gets double encoding — but such keys never resolved anyway, since the platform's key charset forbids both `/` and `%`.

*✍️ Drafted by Claude Code*
