### PR TITLE
fix: Drop pricing_infos from CreateActorRequest and clarify apify_margin_percentage docs

### DIFF
--- a/src/apify_client/_models.py
+++ b/src/apify_client/_models.py
@@ -735,9 +735,10 @@ class CommonActorPricingInfo(BaseModel):
         populate_by_name=True,
         alias_generator=to_camel,
     )
-    apify_margin_percentage: float
+    apify_margin_percentage: Annotated[float, Field(examples=[0.2])]
     """
-    In [0, 1], fraction of pricePerUnitUsd that goes to Apify
+    Apify's share of the revenue generated under this pricing info record, as a fraction between 0 and 1. Set by the Apify platform.
+
     """
     created_at: AwareDatetime
     """
@@ -792,18 +793,6 @@ class CreateActorRequest(BaseModel):
     """
     An array of `Version` objects. Each object represents a specific version of the Actor's source code: its location, builds, and environment configuration.
     """
-    pricing_infos: (
-        list[
-            Annotated[
-                PayPerEventActorPricingInfo
-                | PricePerDatasetItemActorPricingInfo
-                | FlatPricePerMonthActorPricingInfo
-                | FreeActorPricingInfo,
-                Field(discriminator='pricing_model'),
-            ]
-        ]
-        | None
-    ) = None
     categories: Annotated[list[str] | None, Field(examples=[['SOCIAL_MEDIA']])] = None
     """
     A list of categories that best define the Actor. Reflected in Apify Store's search and filtering options.
@@ -920,6 +909,10 @@ class CurrentPricingInfo(BaseModel):
     )
     pricing_model: Annotated[str, Field(examples=['FREE'])]
     apify_margin_percentage: Annotated[float | None, Field(examples=[0.2])] = None
+    """
+    Apify's share of the revenue generated under this pricing info record, as a fraction between 0 and 1. Set by the Apify platform.
+
+    """
     created_at: Annotated[AwareDatetime | None, Field(examples=['2023-01-01T00:00:00.000Z'])] = None
     started_at: Annotated[AwareDatetime | None, Field(examples=['2023-01-01T00:00:00.000Z'])] = None
     notified_about_change_at: Annotated[AwareDatetime | None, Field(examples=[None])] = None


### PR DESCRIPTION
- Regenerates the Pydantic models, TypedDicts, and literal aliases from the [published OpenAPI specification](https://docs.apify.com/api/openapi.json), and records its version in `pyproject.toml`.
- Specification version: `v2-2026-08-24T085852Z` - **unchanged**, which doesn't rule out a specification change: the published stamp can lag its content by a deploy. Only the diff tells.

> [!IMPORTANT]
> Retitle this pull request to `fix:` or `feat:` when the diff is user-facing, so that it lands in the changelog and triggers a release - `chore:` does neither.

> Generated by the [Regenerate models](https://github.com/apify/apify-client-python/actions/workflows/on_schedule_regenerate_models.yaml) workflow.