### PR TITLE
test: Add the required unique_key when building a Request without an ID

### DIFF
--- a/tests/unit/test_url_path_encoding.py
+++ b/tests/unit/test_url_path_encoding.py
@@ -419,7 +419,9 @@ def test_update_request_without_an_id_is_rejected_sync(*, api_url: str) -> None:
     client = ApifyClient(token='test_token', api_url=api_url)
 
     with pytest.raises(ValueError, match='must have an ID'):
-        client.request_queue(_QUEUE_ID).update_request(Request(url='https://example.com'))
+        client.request_queue(_QUEUE_ID).update_request(
+            Request(url='https://example.com', unique_key='https://example.com')
+        )
 
 
 async def test_update_request_without_an_id_is_rejected_async(*, api_url: str) -> None:
@@ -427,4 +429,6 @@ async def test_update_request_without_an_id_is_rejected_async(*, api_url: str) -
     client = ApifyClientAsync(token='test_token', api_url=api_url)
 
     with pytest.raises(ValueError, match='must have an ID'):
-        await client.request_queue(_QUEUE_ID).update_request(Request(url='https://example.com'))
+        await client.request_queue(_QUEUE_ID).update_request(
+            Request(url='https://example.com', unique_key='https://example.com')
+        )


### PR DESCRIPTION
Master CI is red on every type-check and unit-test job: https://github.com/apify/apify-client-python/actions/runs/32821686073

Two PRs that each passed CI on their own conflict semantically once merged together:

- #1030 made `unique_key` a required field on `RequestBase`.
- #1025 added two tests that build `Request(url='https://example.com')` to assert `update_request` rejects a request with no ID.

In that order, the `Request` constructor now raises a pydantic `ValidationError` for the missing `uniqueKey` before `update_request` is ever reached — so `ty` reported 2 `missing-argument` diagnostics and both tests failed on the wrong exception.

Supplying the now-required `unique_key` makes the tests exercise what they were written for (the missing ID), not model validation.

*✍️ Drafted by Claude Code*
