### PR TITLE
fix: Prevent losing a status message when redirecting Actor run logs

### DIFF
--- a/src/apify_client/_resource_clients/actor.py
+++ b/src/apify_client/_resource_clients/actor.py
@@ -371,9 +371,8 @@ class ActorClient(ResourceClient):
         if logger == 'default':
             logger = None
 
-        # Both helpers redirect into the same named logger and each rebuilds it from scratch, so they have to be
-        # constructed before either one starts polling - otherwise the streamed log reconfigures the logger that the
-        # status watcher thread is already writing into, and a status message emitted right then is lost.
+        # Each helper rebuilds the shared redirect logger, so both must exist before either starts polling; otherwise
+        # the streamed log reconfigures a logger the status watcher thread is already writing into.
         status_redirector = run_client.get_status_message_watcher(to_logger=logger)
         streamed_log = run_client.get_streamed_log(to_logger=logger)
 

--- a/src/apify_client/_resource_clients/actor.py
+++ b/src/apify_client/_resource_clients/actor.py
@@ -371,7 +371,13 @@ class ActorClient(ResourceClient):
         if logger == 'default':
             logger = None
 
-        with run_client.get_status_message_watcher(to_logger=logger), run_client.get_streamed_log(to_logger=logger):
+        # Both helpers redirect into the same named logger and each rebuilds it from scratch, so they have to be
+        # constructed before either one starts polling - otherwise the streamed log reconfigures the logger that the
+        # status watcher thread is already writing into, and a status message emitted right then is lost.
+        status_redirector = run_client.get_status_message_watcher(to_logger=logger)
+        streamed_log = run_client.get_streamed_log(to_logger=logger)
+
+        with status_redirector, streamed_log:
             return run_client.wait_for_finish(wait_duration=wait_duration)
 
     def build(

--- a/src/apify_client/_resource_clients/actor.py
+++ b/src/apify_client/_resource_clients/actor.py
@@ -371,8 +371,9 @@ class ActorClient(ResourceClient):
         if logger == 'default':
             logger = None
 
-        # Each helper rebuilds the shared redirect logger, so both must exist before either starts polling; otherwise
-        # the streamed log reconfigures a logger the status watcher thread is already writing into.
+        # With the default logger, each helper rebuilds the same redirect logger from scratch, so both must exist before
+        # either starts polling; otherwise the streamed log reconfigures a logger the status watcher thread is already
+        # writing into.
         status_redirector = run_client.get_status_message_watcher(to_logger=logger)
         streamed_log = run_client.get_streamed_log(to_logger=logger)
 
@@ -873,6 +874,9 @@ class ActorClientAsync(ResourceClientAsync):
         if logger == 'default':
             logger = None
 
+        # With the default logger, each helper rebuilds the same redirect logger from scratch, so both must exist before
+        # either starts polling; otherwise the streamed log reconfigures a logger the status watcher task is already
+        # writing into.
         status_redirector = await run_client.get_status_message_watcher(to_logger=logger)
         streamed_log = await run_client.get_streamed_log(to_logger=logger)
 

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -404,7 +404,7 @@ def test_actor_call_sync_does_not_reconfigure_logger_used_by_running_watcher(
         if next(create_calls) >= 2:
             logger_rebuilt.set()
             if watcher_started.is_set():
-                watcher_logged.wait(timeout=5)
+                assert watcher_logged.wait(timeout=5)
         return to_logger
 
     original_log_run_data = StatusMessageWatcherBase._log_run_data

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -381,12 +381,10 @@ def test_actor_call_sync_does_not_reconfigure_logger_used_by_running_watcher(
     httpserver: HTTPServer,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """No status message is lost when `call` builds the streamed log while the status watcher already runs.
-
-    Both helpers redirect into the same named logger, and building either one reconfigures that logger from scratch.
-    The events below pin the damaging interleaving so the outcome does not depend on thread scheduling: the watcher
-    holds its first message until the logger has just been rebuilt, and a rebuild that finds the watcher already
-    running keeps the half-configured logger in place until that message has been emitted into it."""
+    """No status message is lost when `call` builds the streamed log while the status watcher already runs."""
+    # The events pin the damaging interleaving instead of relying on thread scheduling: the watcher holds its first
+    # message until the logger has been rebuilt, and a rebuild that finds the watcher already running returns only
+    # after that message has been logged - i.e. before `StreamedLog.__init__` re-enables propagation.
     watcher_started = threading.Event()
     logger_rebuilt = threading.Event()
     watcher_logged = threading.Event()

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import itertools
 import json
 import logging
 import threading
@@ -14,7 +15,8 @@ from werkzeug import Request, Response
 
 from apify_client import ApifyClient, ApifyClientAsync
 from apify_client._logging import LoggerOnce, RedirectLogFormatter
-from apify_client._status_message_watcher import StatusMessageWatcherBase
+from apify_client._resource_clients import run as run_module
+from apify_client._status_message_watcher import StatusMessageWatcher, StatusMessageWatcherBase
 from apify_client._streamed_log import StreamedLog, StreamedLogAsync, StreamedLogBase
 
 if TYPE_CHECKING:
@@ -24,6 +26,7 @@ if TYPE_CHECKING:
     from pytest_httpserver import HTTPServer
 
     from apify_client._literals import ActorJobStatus
+    from apify_client._models import Run
     from apify_client.http_clients import HttpClient, HttpClientAsync
 
 _MOCKED_RUN_ID = 'mocked_run_id'
@@ -370,6 +373,65 @@ def test_actor_call_redirect_logs_to_default_logger_sync(
     assert {(record.message, record.levelno) for record in caplog.records} == set(
         _EXPECTED_MESSAGES_AND_LEVELS_WITH_STATUS_MESSAGES
     )
+
+
+@pytest.mark.usefixtures('mock_api', 'propagate_stream_logs', 'reduce_final_timeout_for_status_message_redirector')
+def test_actor_call_sync_does_not_reconfigure_logger_used_by_running_watcher(
+    caplog: LogCaptureFixture,
+    httpserver: HTTPServer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No status message is lost when `call` builds the streamed log while the status watcher already runs.
+
+    Both helpers redirect into the same named logger, and building either one reconfigures that logger from scratch.
+    The events below pin the damaging interleaving so the outcome does not depend on thread scheduling: the watcher
+    holds its first message until the logger has just been rebuilt, and a rebuild that finds the watcher already
+    running keeps the half-configured logger in place until that message has been emitted into it."""
+    watcher_started = threading.Event()
+    logger_rebuilt = threading.Event()
+    watcher_logged = threading.Event()
+
+    original_start = StatusMessageWatcher.start
+
+    def recording_start(self: StatusMessageWatcher) -> threading.Thread:
+        thread = original_start(self)
+        watcher_started.set()
+        return thread
+
+    original_create_redirect_logger = run_module.create_redirect_logger
+    create_calls = itertools.count(1)
+
+    def instrumented_create_redirect_logger(name: str) -> logging.Logger:
+        to_logger = original_create_redirect_logger(name)
+        if next(create_calls) >= 2:
+            logger_rebuilt.set()
+            if watcher_started.is_set():
+                watcher_logged.wait(timeout=5)
+        return to_logger
+
+    original_log_run_data = StatusMessageWatcherBase._log_run_data
+
+    def gated_log_run_data(self: StatusMessageWatcherBase, run_data: Run | None) -> bool:
+        logger_rebuilt.wait(timeout=5)
+        more_data_expected = original_log_run_data(self, run_data)
+        watcher_logged.set()
+        return more_data_expected
+
+    monkeypatch.setattr(StatusMessageWatcher, 'start', recording_start)
+    monkeypatch.setattr(run_module, 'create_redirect_logger', instrumented_create_redirect_logger)
+    monkeypatch.setattr(StatusMessageWatcherBase, '_log_run_data', gated_log_run_data)
+
+    api_url = httpserver.url_for('/').removesuffix('/')
+
+    logger_name = f'apify.{_MOCKED_ACTOR_NAME} runId:{_MOCKED_RUN_ID}'
+    actor_client = ApifyClient(token='mocked_token', api_url=api_url).actor(actor_id=_MOCKED_ACTOR_ID)
+
+    with caplog.at_level(logging.DEBUG, logger=logger_name):
+        actor_client.call()
+
+    assert ('Status: RUNNING, Message: Initial message', logging.INFO) in {
+        (record.message, record.levelno) for record in caplog.records
+    }
 
 
 @pytest.mark.usefixtures('mock_api', 'propagate_stream_logs')


### PR DESCRIPTION
### What

`ActorClient.call` built its two log redirectors inside a single `with` statement:

```python
with run_client.get_status_message_watcher(to_logger=logger), run_client.get_streamed_log(to_logger=logger):
```

`with A(), B():` enters `A` before constructing `B`, so the status watcher's polling thread was already running - and already logging into `apify.<actor> runId:<id>` - when `get_streamed_log` called `create_redirect_logger` on that same logger. That call reconfigures the logger from scratch (`propagate = False`, `removeHandler`, `addHandler`), so a status message emitted in that window went to a logger that was mid-rebuild and was dropped.

Both redirectors are now constructed before either one starts polling, which is what the async `call` already did.

### Why

This surfaced as a flaky unit test - [CI run 32853344220](https://github.com/apify/apify-client-python/actions/runs/32853344220/job/97819276512), `test_actor_call_redirect_logs_to_default_logger_sync` on `ubuntu-latest` / 3.13. `Status: RUNNING, Message: Initial message` appeared in captured stderr but not in `caplog`, i.e. the record reached the logger's own handler while `propagate` was `False`. Only the sync test ever flaked, because the async `call` constructs both redirectors up front and so has no such window.

The nondeterminism is in the client, not in the test: under real usage the same window can silently drop a status message.

### Test

The new test pins the damaging interleaving with two events instead of relying on thread scheduling, so it is deterministic in both directions - it fails on `master` and passes with this change, at the same runtime either way.

Verification: the new test fails without the `actor.py` change and passes with it; full unit suite (911 passed), lint, type check and docstring check all pass. The original flake does not reproduce naturally on an 8-core machine (0 failures in 40 x `tests/unit/test_logging.py` under `--numprocesses=16` before the change), which is why the regression test forces the interleaving rather than hammering for it.

*✍️ Drafted by Claude Code*
