### PR TITLE
test: Rebalance parallel test scheduling and trim the slowest tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,10 @@ known-local-folder = ["apify_client"]
 max-branches = 18
 
 [tool.pytest.ini_options]
-addopts = "-r a --verbose"
+# `--dist worksteal` lets an idle xdist worker take over tests still queued on a busy one. The default `load`
+# scheduler hands every worker a fixed chunk of consecutive tests and never reassigns them, so a worker that
+# draws several slow tests becomes the critical path while the others sit idle.
+addopts = "-r a --verbose --dist worksteal"
 asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "auto"
 pythonpath = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,9 +187,6 @@ known-local-folder = ["apify_client"]
 max-branches = 18
 
 [tool.pytest.ini_options]
-# `--dist worksteal` lets an idle xdist worker take over tests still queued on a busy one. The default `load`
-# scheduler hands every worker a fixed chunk of consecutive tests and never reassigns them, so a worker that
-# draws several slow tests becomes the critical path while the others sit idle.
 addopts = "-r a --verbose --dist worksteal"
 asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "auto"

--- a/tests/integration/test_build.py
+++ b/tests/integration/test_build.py
@@ -185,17 +185,18 @@ async def test_build_delete_and_abort(client: ApifyClient | ApifyClientAsync) ->
     actor_client = client.actor(created_actor.id)
 
     try:
-        # Build both versions - we need 2 builds because we can't delete the default build
+        # Both versions are built because the default build cannot be deleted. `build` returns as soon as the
+        # build is queued, so starting both before awaiting either lets the platform run them concurrently.
         first_build = await maybe_await(actor_client.build(version_number='0.1'))
         assert isinstance(first_build, Build)
-        first_build_client = client.build(first_build.id)
-        await maybe_await(first_build_client.wait_for_finish())
-
         second_build = await maybe_await(actor_client.build(version_number='0.2'))
         assert isinstance(second_build, Build)
+
+        first_build_client = client.build(first_build.id)
         second_build_client = client.build(second_build.id)
 
-        # Wait for the second build to finish
+        await maybe_await(first_build_client.wait_for_finish())
+
         finished_build = await maybe_await(second_build_client.wait_for_finish())
         assert isinstance(finished_build, Build)
         assert finished_build.status in ('SUCCEEDED', 'FAILED')

--- a/tests/integration/test_request_queue.py
+++ b/tests/integration/test_request_queue.py
@@ -573,26 +573,23 @@ async def test_request_queue_unlock_requests(client: ApifyClient | ApifyClientAs
 
         await ensure_queue_is_populated(rq_client, expected_count=5)
 
-        result = await maybe_await(rq_client.list_and_lock_head(limit=3, lock_duration=timedelta(seconds=60)))
-        assert isinstance(result, LockedRequestQueueHead)
-        lock_response = result
+        lock_response = await maybe_await(rq_client.list_and_lock_head(limit=3, lock_duration=timedelta(seconds=60)))
+        assert isinstance(lock_response, LockedRequestQueueHead)
         assert len(lock_response.items) == 3
-        locked_ids = {item.id for item in lock_response.items}
 
-        # Locks are acknowledged before they are visible to subsequent reads, so unlocking immediately can
-        # see fewer locks than were just acquired. Since locked requests are excluded from the queue head,
-        # poll `list_head` until the locked IDs disappear from it (best-effort mitigation of the race).
-        async def all_locks_visible() -> bool:
-            head = await maybe_await(rq_client.list_head(limit=5))
-            assert isinstance(head, RequestQueueHead)
-            return locked_ids.isdisjoint(item.id for item in head.items)
+        # Locks are acknowledged before they are all visible to `unlock_requests`, so a single call can report
+        # fewer locks than were just acquired. Each call unlocks whatever is visible to it, so the counts are
+        # accumulated until every lock is accounted for.
+        unlocked_counts: list[int] = []
 
-        await poll_until_condition(all_locks_visible)
+        async def unlocked_so_far() -> int:
+            unlock_response = await maybe_await(rq_client.unlock_requests())
+            assert isinstance(unlock_response, UnlockRequestsResult)
+            unlocked_counts.append(unlock_response.unlocked_count)
+            return sum(unlocked_counts)
 
-        # Unlock all requests
-        unlock_response = await maybe_await(rq_client.unlock_requests())
-        assert isinstance(unlock_response, UnlockRequestsResult)
-        assert unlock_response.unlocked_count == 3
+        unlocked_total = await poll_until_condition(unlocked_so_far, lambda total: total == 3)
+        assert unlocked_total == 3
     finally:
         await maybe_await(rq_client.delete())
 


### PR DESCRIPTION
The integration test job grew from ~3.5 min to ~6.3 min when the suite started running across both built-in HTTP transports. Almost none of that was extra work: with 806 tests the suite is only 1432 worker-seconds, which is ~90s on 16 workers. The job took 353s because one worker held the critical path while the other 15 sat idle.

xdist's default `load` scheduler seeds every worker with a chunk of `items_per_node // 4` consecutive tests and never reassigns them. With 806 tests that chunk is 12, and one worker drew the `test_build.py` block holding all four variants of `test_build_delete_and_abort` (~87s each), which it then ran back to back: 88s, 170s, 261s, 350s. Every other worker was finished by 170s. The same thing happened before the transport matrix, with 2 variants instead of 4 - so the old 3.5 min was already this one test.

Three changes:

1. `--dist worksteal` in `addopts`, so an idle worker takes over tests still queued on a busy one. Measured on the unit suite at identical concurrency: `1558 passed in 40.65s` -> `1558 passed in 15.58s`. `--dist` is inert without `-n`, so single-file runs are unaffected.
2. `test_build_delete_and_abort` starts both Actor builds before awaiting either. `build()` returns as soon as the build is queued, so the platform can run them concurrently instead of the test serializing two ~40s builds.
3. `test_request_queue_unlock_requests` polled `list_head` until the locked IDs disappeared from it, which `list_head` does not reflect - so every variant burned the full 30s deadline and then discarded the poll result. It now polls the outcome it cares about, accumulating `unlocked_count` across `unlock_requests()` calls until all three locks are accounted for, and asserts that total.

Simulated against the per-test durations reconstructed from the CI logs: 353s -> 100s with change 1 alone, -> 72s with all three.

Change 2 only pays off if the platform builds two versions of the same Actor concurrently. If it serializes them per Actor the test still passes, it just stays at ~90s and the job lands nearer 2 min than 1.5.

*✍️ Drafted by Claude Code*
