### PR TITLE
fix: Loosen StoreListActor.picture_url to str and add new API error type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,7 +258,7 @@ keep_model_order = true
 # workflow committing nothing unless the models changed. A local regeneration that only moves this line is that
 # same case - drop it rather than committing it alone.
 [tool.apify.openapi-spec]
-version = "v2-2026-08-24T085852Z"
+version = "v2-2026-08-27T071624Z"
 
 [tool.uv]
 # Minimal defense against supply-chain atatcks.

--- a/src/apify_client/_literals.py
+++ b/src/apify_client/_literals.py
@@ -99,6 +99,7 @@ ErrorType = (
         'cannot-override-paid-actor-trial',
         'cannot-permanently-delete-subscription',
         'cannot-publish-actor',
+        'cannot-publish-actor-task',
         'cannot-reduce-last-full-token',
         'cannot-reimburse-more-than-original-charge',
         'cannot-reimburse-non-rental-charge',

--- a/src/apify_client/_models.py
+++ b/src/apify_client/_models.py
@@ -295,6 +295,7 @@ class ActorNotice(Enum):
     NONE = 'NONE'
     RESIDENTIAL_PROXY_REQUIRED = 'RESIDENTIAL_PROXY_REQUIRED'
     UNDER_MAINTENANCE = 'UNDER_MAINTENANCE'
+    NONE_TYPE_NONE = None
 
 
 @docs_group('Models')
@@ -3437,7 +3438,7 @@ class StoreListActor(BaseModel):
     description: Annotated[str | None, Field(examples=['My public actor!'])] = None
     categories: Annotated[list[str] | None, Field(examples=[['MARKETING', 'LEAD_GENERATION']])] = None
     notice: ActorNotice | None = None
-    picture_url: Annotated[AnyUrl | None, Field(examples=['https://...'])] = None
+    picture_url: Annotated[str | None, Field(examples=['https://...'])] = None
     user_picture_url: Annotated[AnyUrl | None, Field(examples=['https://...'])] = None
     url: Annotated[AnyUrl | None, Field(examples=['https://...'])] = None
     stats: ActorStats


### PR DESCRIPTION
Regenerates the Pydantic models, TypedDicts, and literal aliases from the [published OpenAPI specification](https://docs.apify.com/api/openapi.json) (`v2-2026-08-24T085852Z` -> `v2-2026-08-27T071624Z`), picking up the spec fixes from apify/apify-docs#2859.

- `StoreListActor.picture_url` is now `str | None` instead of `AnyUrl | None`. The API doesn't guarantee an RFC 3986 URI here - legacy Actors can carry an empty or malformed `pictureUrl` - so such Store items no longer fail validation.
- `ErrorType` gains `cannot-publish-actor-task`, returned with 400 by `POST /v2/actor-tasks` and `PUT /v2/actor-tasks/{actorTaskId}`.
- `ActorNotice` gains a `NONE_TYPE_NONE = None` member. The spec now lists `null` in the enum (the API does return `notice: null`); since the field is typed `ActorNotice | None`, `None` still validates to plain `None`, so this is cosmetic.

*✍️ Drafted by Claude Code*