### PR TITLE
fix: accept task input lists, omitted run and private user fields, and datetime usage dates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,7 +258,7 @@ keep_model_order = true
 # workflow committing nothing unless the models changed. A local regeneration that only moves this line is that
 # same case - drop it rather than committing it alone.
 [tool.apify.openapi-spec]
-version = "v2-2026-08-27T071624Z"
+version = "v2-2026-08-30T172245Z"
 
 [tool.uv]
 # Minimal defense against supply-chain atatcks.

--- a/src/apify_client/_models.py
+++ b/src/apify_client/_models.py
@@ -870,7 +870,7 @@ class CreateTaskRequest(BaseModel):
     act_id: Annotated[str, Field(examples=['asADASadYvn4mBZmm'])]
     name: Annotated[str | None, Field(examples=['my-task'])] = None
     options: TaskOptions | None = None
-    input: TaskInput | None = None
+    input: TaskInput | list[TaskInput] | None = None
     title: str | None = None
     actor_standby: ActorStandby | None = None
     public_config: TaskPublicConfig | None = None
@@ -941,7 +941,7 @@ class DailyServiceUsages(BaseModel):
         populate_by_name=True,
         alias_generator=to_camel,
     )
-    date: Annotated[str, Field(examples=['2022-10-02T00:00:00.000Z'])]
+    date: Annotated[AwareDatetime, Field(examples=['2022-10-02T00:00:00.000Z'])]
     service_usage: dict[str, UsageItem]
     total_usage_credits_usd: Annotated[float, Field(examples=[0.0474385791970591])]
 
@@ -2925,7 +2925,7 @@ class Run(BaseModel):
     """
     Exit code of the Actor run process.
     """
-    general_access: GeneralAccess
+    general_access: GeneralAccess | None = None
     """
     General access level for the Actor run.
     """
@@ -3503,7 +3503,7 @@ class Task(BaseModel):
     removed_at: AwareDatetime | None = None
     stats: TaskStats | None = None
     options: TaskOptions | None = None
-    input: TaskInput | None = None
+    input: TaskInput | list[TaskInput] | None = None
     title: str | None = None
     actor_standby: ActorStandby | None = None
     standby_url: AnyUrl | None = None
@@ -3867,7 +3867,7 @@ class UpdateTaskRequest(BaseModel):
     )
     name: Annotated[str | None, Field(examples=['my-task'])] = None
     options: TaskOptions | None = None
-    input: TaskInput | None = None
+    input: TaskInput | list[TaskInput] | None = None
     title: str | None = None
     actor_standby: ActorStandby | None = None
     public_config: TaskPublicConfig | None = None
@@ -3925,10 +3925,10 @@ class UserPrivateInfo(BaseModel):
     profile: Profile | None = None
     email: Annotated[EmailStr | None, Field(examples=['bob@example.com'])] = None
     proxy: Proxy | None = None
-    plan: Plan
-    effective_platform_features: EffectivePlatformFeatures
+    plan: Plan | None = None
+    effective_platform_features: EffectivePlatformFeatures | None = None
     created_at: Annotated[AwareDatetime | None, Field(examples=['2022-11-29T14:48:29.381Z'])] = None
-    is_paying: Annotated[bool, Field(examples=[True])]
+    is_paying: Annotated[bool | None, Field(examples=[True])] = None
 
 
 @docs_group('Models')


### PR DESCRIPTION
Regenerates the models from the [published OpenAPI specification](https://docs.apify.com/api/openapi.json) (`v2-2026-08-27T071624Z` -> `v2-2026-08-30T172245Z`), which now describes the API's actual behavior after apify/apify-docs#2932. User-facing changes:

- `Task.input`, `CreateTaskRequest.input`, and `UpdateTaskRequest.input` also accept a list of objects, which the API stores and returns.
- `DailyServiceUsages.date` is a timezone-aware `datetime` instead of `str`.
- `Run.general_access` is optional - the API omits it for a run that follows the owner's account setting.
- `UserPrivateInfo.plan`, `effective_platform_features`, and `is_paying` are optional - `GET /v2/users/{userId}` responses don't carry them.

Previously, responses with any of these shapes failed model validation.

Closes #1040 (a manual test run of the same regeneration against a pre-merge bundle of the spec).

> Generated by the [Regenerate models](https://github.com/apify/apify-client-python/actions/workflows/on_schedule_regenerate_models.yaml) workflow.
