### PR TITLE
fix: Name the extra to install in optional-dependency import errors

### DIFF
--- a/src/apify_client/_utils/try_import.py
+++ b/src/apify_client/_utils/try_import.py
@@ -19,11 +19,12 @@ class ImportState:
 
 
 @contextmanager
-def try_import(module_name: str, *symbol_names: str, dependency_name: str) -> Iterator[ImportState]:
+def try_import(module_name: str, *symbol_names: str, dependency_name: str, extra_name: str) -> Iterator[ImportState]:
     """Context manager to attempt importing symbols into a module.
 
-    If the named optional dependency is missing, the symbols are replaced with `FailedImport` objects. Import errors
-    caused by the importing module itself or by another dependency are propagated instead of being masked.
+    If the named optional dependency is missing, the symbols are replaced with `FailedImport` objects whose message
+    names the extra that installs it. Import errors caused by the importing module itself or by another dependency
+    are propagated instead of being masked.
     """
     state = ImportState()
     try:
@@ -32,8 +33,12 @@ def try_import(module_name: str, *symbol_names: str, dependency_name: str) -> It
         if exc.name != dependency_name:
             raise
         state.available = False
+        message = (
+            f"{exc.args[0]}. Install the optional '{extra_name}' extra to use it: "
+            f"pip install 'apify-client[{extra_name}]'"
+        )
         for symbol_name in symbol_names:
-            setattr(sys.modules[module_name], symbol_name, FailedImport(exc.args[0]))
+            setattr(sys.modules[module_name], symbol_name, FailedImport(message))
 
 
 def install_import_hook(module_name: str) -> None:

--- a/src/apify_client/http_clients/__init__.py
+++ b/src/apify_client/http_clients/__init__.py
@@ -13,6 +13,7 @@ with _try_import(
     'HttpxHttpClient',
     'HttpxHttpClientAsync',
     dependency_name='httpx2',
+    extra_name='httpx',
 ) as _httpx_import:
     from apify_client.http_clients._httpx import HttpxHttpClient, HttpxHttpClientAsync
 

--- a/src/apify_client/http_compressors/__init__.py
+++ b/src/apify_client/http_compressors/__init__.py
@@ -9,7 +9,7 @@ _install_import_hook(__name__)
 
 # `brotli` is an optional extra, so it's wrapped in try_import. Accessing `BrotliHttpCompressor`
 # without the extra installed raises a clear ImportError instead of failing at package import time.
-with _try_import(__name__, 'BrotliHttpCompressor', dependency_name='brotli') as _brotli_import:
+with _try_import(__name__, 'BrotliHttpCompressor', dependency_name='brotli', extra_name='brotli') as _brotli_import:
     from apify_client.http_compressors._brotli import BrotliHttpCompressor
 
 if _brotli_import.available:

--- a/tests/unit/test_pluggable_http_client.py
+++ b/tests/unit/test_pluggable_http_client.py
@@ -395,6 +395,7 @@ def test_httpx_clients_raise_clear_error_when_extra_missing() -> None:
                 getattr(module, name)
             except ImportError as exc:
                 assert "No module named 'httpx2'" in str(exc)
+                assert "pip install 'apify-client[httpx]'" in str(exc)
             else:
                 raise AssertionError(f'{name} did not raise ImportError')
         """

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -42,7 +42,7 @@ def test_try_import_only_handles_the_named_missing_dependency() -> None:
     try:
         with (
             pytest.raises(ModuleNotFoundError, match='broken-transitive'),
-            try_import(module_name, 'OptionalSymbol', dependency_name='optional-package'),
+            try_import(module_name, 'OptionalSymbol', dependency_name='optional-package', extra_name='optional-extra'),
         ):
             raise ModuleNotFoundError('broken-transitive', name='broken-transitive')
         assert not hasattr(sys.modules[module_name], 'OptionalSymbol')
@@ -51,14 +51,20 @@ def test_try_import_only_handles_the_named_missing_dependency() -> None:
 
 
 def test_try_import_records_the_named_missing_dependency() -> None:
-    """A genuinely missing optional dependency is converted to a failed-import placeholder."""
+    """A genuinely missing optional dependency becomes a failed-import placeholder that names the extra to install."""
     module_name = 'test_missing_optional_import_module'
     sys.modules[module_name] = ModuleType(module_name)
     try:
-        with try_import(module_name, 'OptionalSymbol', dependency_name='optional-package') as state:
+        with try_import(
+            module_name, 'OptionalSymbol', dependency_name='optional-package', extra_name='optional-extra'
+        ) as state:
             raise ModuleNotFoundError("No module named 'optional-package'", name='optional-package')
         assert state.available is False
         assert isinstance(sys.modules[module_name].OptionalSymbol, FailedImport)
+        assert sys.modules[module_name].OptionalSymbol.message == (
+            "No module named 'optional-package'. Install the optional 'optional-extra' extra to use it: "
+            "pip install 'apify-client[optional-extra]'"
+        )
     finally:
         del sys.modules[module_name]
 


### PR DESCRIPTION
Accessing a symbol guarded by `try_import` without its extra installed raises an `ImportError` that now also names the extra to install:

```
No module named 'httpx2'. Install the optional 'httpx' extra to use it: pip install 'apify-client[httpx]'
```

`try_import` takes `extra_name` next to `dependency_name`, and both guarded sites (`httpx`, `brotli`) pass it.

*✍️ Drafted by Claude Code*
