### PR TITLE
test: Deflake webhook dispatches iterate test by polling for the dispatch

### DIFF
--- a/tests/integration/test_webhook.py
+++ b/tests/integration/test_webhook.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Iterator
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -259,24 +258,17 @@ async def test_webhook_dispatches_iterate(client: ApifyClient | ApifyClientAsync
     webhook_client = client.webhook(created_webhook.id)
 
     try:
-        # Generate at least one dispatch by hitting the test endpoint
-        await maybe_await(webhook_client.test())
+        # Generate a dispatch by hitting the test endpoint
+        dispatch = await maybe_await(webhook_client.test())
+        assert isinstance(dispatch, WebhookDispatch)
 
-        iterator = webhook_client.dispatches().iterate(limit=10)
-        collected: list[WebhookDispatch] = []
-        if is_async:
-            assert isinstance(iterator, AsyncIterator)
-            async for d in iterator:
-                assert isinstance(d, WebhookDispatch)
-                collected.append(d)
-        else:
-            assert isinstance(iterator, Iterator)
-            for d in iterator:
-                assert isinstance(d, WebhookDispatch)
-                collected.append(d)
-
-        assert len(collected) >= 1
-        for dispatch in collected:
-            assert dispatch.id is not None
+        # Poll until the dispatch appears in the listing - it is recorded asynchronously (eventual consistency)
+        collected = await collect_iterate_until_present(
+            lambda: webhook_client.dispatches().iterate(limit=10),
+            {dispatch.id},
+            item_type=WebhookDispatch,
+            is_async=is_async,
+        )
+        assert dispatch.id in {d.id for d in collected}
     finally:
         await maybe_await(webhook_client.delete())


### PR DESCRIPTION
`test_webhook_dispatches_iterate` drained `dispatches().iterate()` once, right after `webhook_client.test()`. The dispatch is recorded asynchronously, so under load the listing can still be empty (`total=0`) and the test fails with `assert 0 >= 1` ([failed run](https://github.com/apify/apify-client-python/actions/runs/33614701601/job/100197733391)). The sibling `test_webhook_dispatches` failed the same way twice before and got a poll in #1004; the iterate variant did not.

The test now keeps the dispatch returned by `test()` and drains the iterator via `collect_iterate_until_present` until that ID shows up, then asserts membership, which is stricter than the previous "at least one dispatch" check.

*✍️ Drafted by Claude Code*
