### PR TITLE
refactor: Rename the HTTPX extra and clients to httpx2

### DIFF
--- a/.rules.md
+++ b/.rules.md
@@ -63,7 +63,7 @@ Docstrings are written on sync clients and **automatically copied** to async cli
 - `HttpClient`/`HttpClientAsync` — base classes in `http_clients/_base.py` holding the shared request pipeline (retries,
   timeouts, API errors); transports implement the `send_request`, error-classification, and lifecycle hooks
 - `ImpitHttpClient`/`ImpitHttpClientAsync` — default implementation (Rust-based Impit)
-- `HttpxHttpClient`/`HttpxHttpClientAsync` — built-in alternative behind the `httpx` optional extra
+- `Httpx2HttpClient`/`Httpx2HttpClientAsync` — built-in alternative behind the `httpx2` optional extra
 - `HttpResponse` — Protocol (not a concrete class) for response objects
 - Users can plug in custom HTTP clients via `ApifyClient.with_custom_http_client()`
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@
     ```
 
     [Impit](https://github.com/apify/impit) is the default HTTP client and is installed automatically. To use the
-    built-in [HTTPX](https://github.com/pydantic/httpx2) client instead, install its optional extra and pass
-    `http_client=Httpx2HttpClient()` to `ApifyClient.with_custom_http_client()`. The extra installs `httpx2`,
-    Pydantic's maintained continuation of HTTPX:
+    built-in [HTTPX](https://github.com/pydantic/httpx2) client instead, install the optional `httpx2` extra, which
+    provides Pydantic's maintained continuation of HTTPX, and pass `http_client=Httpx2HttpClient()` to
+    `ApifyClient.with_custom_http_client()`:
 
     ```bash
     pip install "apify-client[httpx2]"

--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@
 
     [Impit](https://github.com/apify/impit) is the default HTTP client and is installed automatically. To use the
     built-in [HTTPX](https://github.com/pydantic/httpx2) client instead, install its optional extra and pass
-    `http_client=HttpxHttpClient()` to `ApifyClient.with_custom_http_client()`. The extra installs `httpx2`,
+    `http_client=Httpx2HttpClient()` to `ApifyClient.with_custom_http_client()`. The extra installs `httpx2`,
     Pydantic's maintained continuation of HTTPX:
 
     ```bash
-    pip install "apify-client[httpx]"
+    pip install "apify-client[httpx2]"
     # or
-    uv add "apify-client[httpx]"
+    uv add "apify-client[httpx2]"
     ```
 
 - From [conda-forge](https://anaconda.org/conda-forge/apify-client), it can be installed with [conda](https://docs.conda.io/en/latest/):

--- a/docs/01_introduction/index.mdx
+++ b/docs/01_introduction/index.mdx
@@ -63,12 +63,12 @@ For better request-body compression, opt in to `brotli`, which compresses better
 
 For details, see [HTTP compression](../02_concepts/13_http_compression.mdx).
 
-The client uses [Impit](https://github.com/apify/impit) as its default HTTP transport. To use the built-in [HTTPX](https://github.com/pydantic/httpx2) transport, install the optional `httpx` extra. The extra installs `httpx2`, Pydantic's maintained continuation of HTTPX:
+The client uses [Impit](https://github.com/apify/impit) as its default HTTP transport. To use the built-in [HTTPX](https://github.com/pydantic/httpx2) transport, install the optional `httpx2` extra. The extra installs `httpx2`, Pydantic's maintained continuation of HTTPX:
 
 <Tabs>
     <TabItem value="PyPI" label="PyPI" default>
         ```bash
-        pip install "apify-client[httpx]"
+        pip install "apify-client[httpx2]"
         ```
     </TabItem>
     <TabItem value="conda-forge" label="conda-forge">

--- a/docs/01_introduction/index.mdx
+++ b/docs/01_introduction/index.mdx
@@ -63,7 +63,7 @@ For better request-body compression, opt in to `brotli`, which compresses better
 
 For details, see [HTTP compression](../02_concepts/13_http_compression.mdx).
 
-The client uses [Impit](https://github.com/apify/impit) as its default HTTP transport. To use the built-in [HTTPX](https://github.com/pydantic/httpx2) transport, install the optional `httpx2` extra. The extra installs `httpx2`, Pydantic's maintained continuation of HTTPX:
+The client uses [Impit](https://github.com/apify/impit) as its default HTTP transport. To use the built-in [HTTPX](https://github.com/pydantic/httpx2) transport, install the optional `httpx2` extra, which provides Pydantic's maintained continuation of HTTPX:
 
 <Tabs>
     <TabItem value="PyPI" label="PyPI" default>

--- a/docs/02_concepts/10_custom_http_clients.mdx
+++ b/docs/02_concepts/10_custom_http_clients.mdx
@@ -49,7 +49,7 @@ You can configure the default client through the <ApiLink to="class/ApifyClient"
 
 The package also provides <ApiLink to="class/Httpx2HttpClient">`Httpx2HttpClient`</ApiLink> and <ApiLink to="class/Httpx2HttpClientAsync">`Httpx2HttpClientAsync`</ApiLink>. They use the same request preparation, compression, retry policy, timeout tiers and growth, error handling, logging, and statistics as the default Impit clients, with [HTTPX](https://github.com/pydantic/httpx2) as the transport.
 
-HTTPX is an optional dependency. Install `apify-client[httpx2]`, then pass the appropriate client to <ApiLink to="class/ApifyClient#with_custom_http_client">`ApifyClient.with_custom_http_client`</ApiLink>. The extra installs `httpx2`, Pydantic's maintained continuation of HTTPX. Impit remains the default even when the `httpx2` extra is installed.
+HTTPX is an optional dependency provided by the `httpx2` package, Pydantic's maintained continuation of HTTPX. Install `apify-client[httpx2]`, then pass the appropriate client to <ApiLink to="class/ApifyClient#with_custom_http_client">`ApifyClient.with_custom_http_client`</ApiLink>. Impit remains the default even when the extra is installed.
 
 ```bash
 pip install "apify-client[httpx2]"

--- a/docs/02_concepts/10_custom_http_clients.mdx
+++ b/docs/02_concepts/10_custom_http_clients.mdx
@@ -11,8 +11,8 @@ import ApiLink from '@theme/ApiLink';
 
 import DefaultHttpClientAsyncExample from '!!raw-loader!./code/10_default_http_client_async.py';
 import DefaultHttpClientSyncExample from '!!raw-loader!./code/10_default_http_client_sync.py';
-import HttpxHttpClientAsyncExample from '!!raw-loader!./code/10_httpx_client_async.py';
-import HttpxHttpClientSyncExample from '!!raw-loader!./code/10_httpx_client_sync.py';
+import Httpx2HttpClientAsyncExample from '!!raw-loader!./code/10_httpx2_client_async.py';
+import Httpx2HttpClientSyncExample from '!!raw-loader!./code/10_httpx2_client_sync.py';
 
 import ArchitectureImportsExample from '!!raw-loader!./code/10_architecture_imports.py';
 
@@ -47,30 +47,30 @@ You can configure the default client through the <ApiLink to="class/ApifyClient"
 
 ## Built-in HTTPX client
 
-The package also provides <ApiLink to="class/HttpxHttpClient">`HttpxHttpClient`</ApiLink> and <ApiLink to="class/HttpxHttpClientAsync">`HttpxHttpClientAsync`</ApiLink>. They use the same request preparation, compression, retry policy, timeout tiers and growth, error handling, logging, and statistics as the default Impit clients, with [HTTPX](https://github.com/pydantic/httpx2) as the transport.
+The package also provides <ApiLink to="class/Httpx2HttpClient">`Httpx2HttpClient`</ApiLink> and <ApiLink to="class/Httpx2HttpClientAsync">`Httpx2HttpClientAsync`</ApiLink>. They use the same request preparation, compression, retry policy, timeout tiers and growth, error handling, logging, and statistics as the default Impit clients, with [HTTPX](https://github.com/pydantic/httpx2) as the transport.
 
-HTTPX is an optional dependency. Install `apify-client[httpx]`, then pass the appropriate client to <ApiLink to="class/ApifyClient#with_custom_http_client">`ApifyClient.with_custom_http_client`</ApiLink>. The extra installs `httpx2`, Pydantic's maintained continuation of HTTPX. Impit remains the default even when the HTTPX extra is installed.
+HTTPX is an optional dependency. Install `apify-client[httpx2]`, then pass the appropriate client to <ApiLink to="class/ApifyClient#with_custom_http_client">`ApifyClient.with_custom_http_client`</ApiLink>. The extra installs `httpx2`, Pydantic's maintained continuation of HTTPX. Impit remains the default even when the `httpx2` extra is installed.
 
 ```bash
-pip install "apify-client[httpx]"
+pip install "apify-client[httpx2]"
 # or
-uv add "apify-client[httpx]"
+uv add "apify-client[httpx2]"
 ```
 
 <Tabs>
-    <TabItem value="HttpxAsyncExample" label="Async client" default>
+    <TabItem value="Httpx2AsyncExample" label="Async client" default>
         <CodeBlock className="language-python">
-            {HttpxHttpClientAsyncExample}
+            {Httpx2HttpClientAsyncExample}
         </CodeBlock>
     </TabItem>
-    <TabItem value="HttpxSyncExample" label="Sync client">
+    <TabItem value="Httpx2SyncExample" label="Sync client">
         <CodeBlock className="language-python">
-            {HttpxHttpClientSyncExample}
+            {Httpx2HttpClientSyncExample}
         </CodeBlock>
     </TabItem>
 </Tabs>
 
-Configure retries, timeout tiers, default headers, and compression on the HTTPX client instance. The token passed to `with_custom_http_client` is applied automatically unless the HTTP client already has an `Authorization` header. The examples use the clients as context managers so their connection pools are closed deterministically. If a context manager doesn't fit your application's lifecycle, call `close()` on `HttpxHttpClient` or `await aclose()` on `HttpxHttpClientAsync` during shutdown.
+Configure retries, timeout tiers, default headers, and compression on the HTTPX client instance. The token passed to `with_custom_http_client` is applied automatically unless the HTTP client already has an `Authorization` header. The examples use the clients as context managers so their connection pools are closed deterministically. If a context manager doesn't fit your application's lifecycle, call `close()` on `Httpx2HttpClient` or `await aclose()` on `Httpx2HttpClientAsync` during shutdown.
 
 Timeout values are passed to the selected transport. Impit enforces them as a deadline for the whole request, body included. HTTPX applies them to each socket operation instead, so a response whose body arrives slowly keeps resetting the timeout and can outlast both the requested timeout and `timeout_max`. The `no_timeout` option disables HTTPX's timeouts.
 

--- a/docs/02_concepts/code/10_httpx2_client_async.py
+++ b/docs/02_concepts/code/10_httpx2_client_async.py
@@ -1,13 +1,13 @@
 import asyncio
 
 from apify_client import ApifyClientAsync
-from apify_client.http_clients import HttpxHttpClientAsync
+from apify_client.http_clients import Httpx2HttpClientAsync
 
 TOKEN = 'MY-APIFY-TOKEN'
 
 
 async def main() -> None:
-    async with HttpxHttpClientAsync() as http_client:
+    async with Httpx2HttpClientAsync() as http_client:
         client = ApifyClientAsync.with_custom_http_client(
             token=TOKEN,
             http_client=http_client,

--- a/docs/02_concepts/code/10_httpx2_client_sync.py
+++ b/docs/02_concepts/code/10_httpx2_client_sync.py
@@ -1,11 +1,11 @@
 from apify_client import ApifyClient
-from apify_client.http_clients import HttpxHttpClient
+from apify_client.http_clients import Httpx2HttpClient
 
 TOKEN = 'MY-APIFY-TOKEN'
 
 
 def main() -> None:
-    with HttpxHttpClient() as http_client:
+    with Httpx2HttpClient() as http_client:
         client = ApifyClient.with_custom_http_client(
             token=TOKEN,
             http_client=http_client,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 
 [project.optional-dependencies]
 brotli = ["brotli>=1.0.9"]
-httpx = ["httpx2>=2.0.0"]
+httpx2 = ["httpx2>=2.0.0"]
 
 [project.urls]
 "Apify Homepage" = "https://apify.com"

--- a/src/apify_client/http_clients/__init__.py
+++ b/src/apify_client/http_clients/__init__.py
@@ -5,9 +5,8 @@ from apify_client.http_clients._impit import ImpitHttpClient, ImpitHttpClientAsy
 
 _install_import_hook(__name__)
 
-# The HTTPX clients depend on `httpx2`, installed by the optional `httpx2` extra, so the import is wrapped in
-# try_import. Accessing them without the extra installed raises a clear ImportError instead of failing at package
-# import time.
+# `httpx2` is an optional extra, so the import is wrapped in try_import. Accessing the HTTPX clients without the
+# extra installed raises a clear ImportError instead of failing at package import time.
 with _try_import(
     __name__,
     'Httpx2HttpClient',

--- a/src/apify_client/http_clients/__init__.py
+++ b/src/apify_client/http_clients/__init__.py
@@ -5,17 +5,17 @@ from apify_client.http_clients._impit import ImpitHttpClient, ImpitHttpClientAsy
 
 _install_import_hook(__name__)
 
-# The HTTPX clients depend on `httpx2`, installed by the optional `httpx` extra, so the import is wrapped in
+# The HTTPX clients depend on `httpx2`, installed by the optional `httpx2` extra, so the import is wrapped in
 # try_import. Accessing them without the extra installed raises a clear ImportError instead of failing at package
 # import time.
 with _try_import(
     __name__,
-    'HttpxHttpClient',
-    'HttpxHttpClientAsync',
+    'Httpx2HttpClient',
+    'Httpx2HttpClientAsync',
     dependency_name='httpx2',
-    extra_name='httpx',
-) as _httpx_import:
-    from apify_client.http_clients._httpx import HttpxHttpClient, HttpxHttpClientAsync
+    extra_name='httpx2',
+) as _httpx2_import:
+    from apify_client.http_clients._httpx2 import Httpx2HttpClient, Httpx2HttpClientAsync
 
 __all__ = [
     'HttpClient',
@@ -25,8 +25,8 @@ __all__ = [
     'ImpitHttpClientAsync',
 ]
 
-if _httpx_import.available:
+if _httpx2_import.available:
     __all__ += [
-        'HttpxHttpClient',
-        'HttpxHttpClientAsync',
+        'Httpx2HttpClient',
+        'Httpx2HttpClientAsync',
     ]

--- a/src/apify_client/http_clients/_httpx2.py
+++ b/src/apify_client/http_clients/_httpx2.py
@@ -48,8 +48,8 @@ class Httpx2HttpClient(HttpClient):
     whose body arrives slowly keeps resetting it and can outlast both the requested timeout and `timeout_max`. The
     default Impit client enforces the same value as a deadline for the whole request, body included.
 
-    Requires the `httpx2` extra: `pip install "apify-client[httpx2]"`. That extra installs `httpx2`, Pydantic's
-    maintained continuation of HTTPX, which this module imports under the `httpx` name.
+    Requires the `httpx2` extra: `pip install "apify-client[httpx2]"`. The `httpx2` package is Pydantic's maintained
+    continuation of HTTPX, which this module imports under the `httpx` name.
     """
 
     def __init__(
@@ -152,8 +152,8 @@ class Httpx2HttpClientAsync(HttpClientAsync):
     whose body arrives slowly keeps resetting it and can outlast both the requested timeout and `timeout_max`. The
     default Impit client enforces the same value as a deadline for the whole request, body included.
 
-    Requires the `httpx2` extra: `pip install "apify-client[httpx2]"`. That extra installs `httpx2`, Pydantic's
-    maintained continuation of HTTPX, which this module imports under the `httpx` name.
+    Requires the `httpx2` extra: `pip install "apify-client[httpx2]"`. The `httpx2` package is Pydantic's maintained
+    continuation of HTTPX, which this module imports under the `httpx` name.
     """
 
     def __init__(

--- a/src/apify_client/http_clients/_httpx2.py
+++ b/src/apify_client/http_clients/_httpx2.py
@@ -38,7 +38,7 @@ _PERMANENT_ERRORS = (
 
 
 @docs_group('HTTP clients')
-class HttpxHttpClient(HttpClient):
+class Httpx2HttpClient(HttpClient):
     """Synchronous HTTP client for the Apify API built on top of [HTTPX](https://github.com/pydantic/httpx2).
 
     This client wraps `httpx.Client` and adds automatic retries with exponential backoff for rate-limited
@@ -48,7 +48,7 @@ class HttpxHttpClient(HttpClient):
     whose body arrives slowly keeps resetting it and can outlast both the requested timeout and `timeout_max`. The
     default Impit client enforces the same value as a deadline for the whole request, body included.
 
-    Requires the `httpx` extra: `pip install "apify-client[httpx]"`. That extra installs `httpx2`, Pydantic's
+    Requires the `httpx2` extra: `pip install "apify-client[httpx2]"`. That extra installs `httpx2`, Pydantic's
     maintained continuation of HTTPX, which this module imports under the `httpx` name.
     """
 
@@ -142,7 +142,7 @@ class HttpxHttpClient(HttpClient):
 
 
 @docs_group('HTTP clients')
-class HttpxHttpClientAsync(HttpClientAsync):
+class Httpx2HttpClientAsync(HttpClientAsync):
     """Asynchronous HTTP client for the Apify API built on top of [HTTPX](https://github.com/pydantic/httpx2).
 
     This client wraps `httpx.AsyncClient` and adds automatic retries with exponential backoff for rate-limited
@@ -152,7 +152,7 @@ class HttpxHttpClientAsync(HttpClientAsync):
     whose body arrives slowly keeps resetting it and can outlast both the requested timeout and `timeout_max`. The
     default Impit client enforces the same value as a deadline for the whole request, body included.
 
-    Requires the `httpx` extra: `pip install "apify-client[httpx]"`. That extra installs `httpx2`, Pydantic's
+    Requires the `httpx2` extra: `pip install "apify-client[httpx2]"`. That extra installs `httpx2`, Pydantic's
     maintained continuation of HTTPX, which this module imports under the `httpx` name.
     """
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,8 +19,8 @@ from apify_client import ApifyClient, ApifyClientAsync
 from apify_client._consts import DEFAULT_API_URL
 from apify_client._utils.crypto import create_hmac_signature, create_storage_content_signature
 from apify_client.http_clients import (
-    HttpxHttpClient,
-    HttpxHttpClientAsync,
+    Httpx2HttpClient,
+    Httpx2HttpClientAsync,
     ImpitHttpClient,
     ImpitHttpClientAsync,
 )
@@ -109,7 +109,7 @@ def test_kvs_of_another_user(api_token_2: str) -> Generator[KvsFixture]:
 @pytest.fixture(
     params=[
         pytest.param(HttpClientClasses(sync=ImpitHttpClient, async_=ImpitHttpClientAsync), id='impit'),
-        pytest.param(HttpClientClasses(sync=HttpxHttpClient, async_=HttpxHttpClientAsync), id='httpx'),
+        pytest.param(HttpClientClasses(sync=Httpx2HttpClient, async_=Httpx2HttpClientAsync), id='httpx2'),
     ]
 )
 def http_client_classes(request: pytest.FixtureRequest) -> HttpClientClasses:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -11,8 +11,8 @@ from apify_client import ApifyClient, ApifyClientAsync
 from apify_client.http_clients import (
     HttpClient,
     HttpClientAsync,
-    HttpxHttpClient,
-    HttpxHttpClientAsync,
+    Httpx2HttpClient,
+    Httpx2HttpClientAsync,
     ImpitHttpClient,
     ImpitHttpClientAsync,
 )
@@ -54,7 +54,7 @@ def async_client(httpserver: HTTPServer) -> ApifyClientAsync:
 @pytest.fixture(
     params=[
         pytest.param(HttpClientClasses(sync=ImpitHttpClient, async_=ImpitHttpClientAsync), id='impit'),
-        pytest.param(HttpClientClasses(sync=HttpxHttpClient, async_=HttpxHttpClientAsync), id='httpx'),
+        pytest.param(HttpClientClasses(sync=Httpx2HttpClient, async_=Httpx2HttpClientAsync), id='httpx2'),
     ]
 )
 def http_client_classes(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> HttpClientClasses:

--- a/tests/unit/test_client_headers.py
+++ b/tests/unit/test_client_headers.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 import httpx2 as httpx
 from werkzeug import Request, Response
 
-from apify_client.http_clients import HttpxHttpClient, HttpxHttpClientAsync, ImpitHttpClient, ImpitHttpClientAsync
+from apify_client.http_clients import Httpx2HttpClient, Httpx2HttpClientAsync, ImpitHttpClient, ImpitHttpClientAsync
 
 if TYPE_CHECKING:
     from pytest_httpserver import HTTPServer
@@ -192,7 +192,7 @@ def test_httpx_does_not_reuse_server_cookies(httpserver: HTTPServer) -> None:
     httpserver.expect_request('/set-cookie').respond_with_data('ok', headers={'Set-Cookie': 'session=secret'})
     httpserver.expect_request('/echo-cookie').respond_with_handler(_echo_cookie_handler)
 
-    with HttpxHttpClient() as client:
+    with Httpx2HttpClient() as client:
         client.call(method='GET', url=httpserver.url_for('/set-cookie'))
         assert len(client._httpx_client.cookies) == 0
         response = client.call(method='GET', url=httpserver.url_for('/echo-cookie'))
@@ -205,7 +205,7 @@ async def test_httpx_async_does_not_reuse_server_cookies(httpserver: HTTPServer)
     httpserver.expect_request('/set-cookie').respond_with_data('ok', headers={'Set-Cookie': 'session=secret'})
     httpserver.expect_request('/echo-cookie').respond_with_handler(_echo_cookie_handler)
 
-    async with HttpxHttpClientAsync() as client:
+    async with Httpx2HttpClientAsync() as client:
         await client.call(method='GET', url=httpserver.url_for('/set-cookie'))
         assert len(client._httpx_async_client.cookies) == 0
         response = await client.call(method='GET', url=httpserver.url_for('/echo-cookie'))
@@ -217,7 +217,7 @@ def test_httpx_drops_cookies_left_in_the_shared_jar(httpserver: HTTPServer) -> N
     """A cookie another in-flight request left in the shared jar must not ride along on the next request."""
     httpserver.expect_request('/echo-cookie').respond_with_handler(_echo_cookie_handler)
 
-    with HttpxHttpClient() as client:
+    with Httpx2HttpClient() as client:
         client._httpx_client.cookies.set('session', 'secret', domain=httpserver.host)
         response = client.call(method='GET', url=httpserver.url_for('/echo-cookie'))
 
@@ -228,7 +228,7 @@ async def test_httpx_async_drops_cookies_left_in_the_shared_jar(httpserver: HTTP
     """The asynchronous pool, where concurrent requests really do share one jar, drops leftover cookies too."""
     httpserver.expect_request('/echo-cookie').respond_with_handler(_echo_cookie_handler)
 
-    async with HttpxHttpClientAsync() as client:
+    async with Httpx2HttpClientAsync() as client:
         client._httpx_async_client.cookies.set('session', 'secret', domain=httpserver.host)
         response = await client.call(method='GET', url=httpserver.url_for('/echo-cookie'))
 
@@ -244,7 +244,7 @@ def test_httpx_does_not_carry_server_cookies_across_a_redirect(httpserver: HTTPS
     )
     httpserver.expect_request('/echo-cookie').respond_with_handler(_echo_cookie_handler)
 
-    with HttpxHttpClient() as client:
+    with Httpx2HttpClient() as client:
         response = client.call(method='GET', url=httpserver.url_for('/redirect'))
 
     assert response.json() == {'cookie': None}
@@ -259,7 +259,7 @@ async def test_httpx_async_does_not_carry_server_cookies_across_a_redirect(https
     )
     httpserver.expect_request('/echo-cookie').respond_with_handler(_echo_cookie_handler)
 
-    async with HttpxHttpClientAsync() as client:
+    async with Httpx2HttpClientAsync() as client:
         response = await client.call(method='GET', url=httpserver.url_for('/redirect'))
 
     assert response.json() == {'cookie': None}
@@ -269,7 +269,7 @@ def test_httpx_keeps_explicit_cookie_header(httpserver: HTTPServer) -> None:
     """Disabling the shared cookie jar must not remove a Cookie header explicitly supplied by the caller."""
     httpserver.expect_request('/echo-explicit-cookie').respond_with_handler(_echo_cookie_handler)
 
-    with HttpxHttpClient() as client:
+    with Httpx2HttpClient() as client:
         response = client.call(
             method='GET',
             url=httpserver.url_for('/echo-explicit-cookie'),
@@ -283,7 +283,7 @@ async def test_httpx_async_keeps_explicit_cookie_header(httpserver: HTTPServer) 
     """The asynchronous pool forwards an explicitly supplied Cookie header as well."""
     httpserver.expect_request('/echo-explicit-cookie').respond_with_handler(_echo_cookie_handler)
 
-    async with HttpxHttpClientAsync() as client:
+    async with Httpx2HttpClientAsync() as client:
         response = await client.call(
             method='GET',
             url=httpserver.url_for('/echo-explicit-cookie'),

--- a/tests/unit/test_client_timeouts.py
+++ b/tests/unit/test_client_timeouts.py
@@ -13,8 +13,8 @@ from apify_client._logging import LoggerOnce, logger_name
 from apify_client.http_clients import (
     HttpClient,
     HttpClientAsync,
-    HttpxHttpClient,
-    HttpxHttpClientAsync,
+    Httpx2HttpClient,
+    Httpx2HttpClientAsync,
     ImpitHttpClient,
     ImpitHttpClientAsync,
 )
@@ -238,7 +238,7 @@ async def test_no_timeout_mapping_for_async_impit_adapter() -> None:
 def test_no_timeout_mapping_for_sync_httpx_adapter(monkeypatch: pytest.MonkeyPatch) -> None:
     """The synchronous HTTPX adapter maps no-timeout to every HTTPX sub-timeout being unset."""
     # Only the transport call is stubbed, so the real `build_request` decides what `None` means to HTTPX.
-    with HttpxHttpClient() as client:
+    with Httpx2HttpClient() as client:
         send = Mock(return_value=successful_response())
         monkeypatch.setattr(client._httpx_client, 'send', send)
 
@@ -252,7 +252,7 @@ def test_no_timeout_mapping_for_sync_httpx_adapter(monkeypatch: pytest.MonkeyPat
 async def test_no_timeout_mapping_for_async_httpx_adapter(monkeypatch: pytest.MonkeyPatch) -> None:
     """The asynchronous HTTPX adapter maps no-timeout to every HTTPX sub-timeout being unset."""
     # Only the transport call is stubbed, so the real `build_request` decides what `None` means to HTTPX.
-    async with HttpxHttpClientAsync() as client:
+    async with Httpx2HttpClientAsync() as client:
         send = AsyncMock(return_value=successful_response())
         monkeypatch.setattr(client._httpx_async_client, 'send', send)
 

--- a/tests/unit/test_http_clients.py
+++ b/tests/unit/test_http_clients.py
@@ -22,8 +22,8 @@ from apify_client.http_clients import (
     HttpClient,
     HttpClientAsync,
     HttpResponse,
-    HttpxHttpClient,
-    HttpxHttpClientAsync,
+    Httpx2HttpClient,
+    Httpx2HttpClientAsync,
     ImpitHttpClient,
     ImpitHttpClientAsync,
 )
@@ -269,7 +269,7 @@ async def test_http_client_async_creates_async_impit_client() -> None:
 
 def test_http_client_creates_sync_httpx_client() -> None:
     """The synchronous HTTPX adapter creates the underlying HTTPX client, and the close hook closes its pool."""
-    client = HttpxHttpClient(token='test_token_123')
+    client = Httpx2HttpClient(token='test_token_123')
 
     assert isinstance(client._httpx_client, httpx.Client)
     client.close()
@@ -278,7 +278,7 @@ def test_http_client_creates_sync_httpx_client() -> None:
 
 async def test_http_client_async_creates_async_httpx_client() -> None:
     """The asynchronous HTTPX adapter creates the underlying HTTPX client, and the close hook closes its pool."""
-    client = HttpxHttpClientAsync(token='test_token_123')
+    client = Httpx2HttpClientAsync(token='test_token_123')
 
     assert isinstance(client._httpx_async_client, httpx.AsyncClient)
     await client.aclose()
@@ -430,7 +430,7 @@ async def test_async_http_client_classifies_timeout_errors() -> None:
 )
 def test_httpx_is_retryable_transport_error(exc: Exception) -> None:
     """A transient HTTPX transport failure is classified as retryable."""
-    with HttpxHttpClient() as client:
+    with Httpx2HttpClient() as client:
         assert client.is_retryable_transport_error(exc)
 
 
@@ -457,13 +457,13 @@ def test_httpx_is_retryable_transport_error(exc: Exception) -> None:
 )
 def test_httpx_is_not_retryable_transport_error(exc: Exception) -> None:
     """A transport failure a retry cannot fix, and anything outside HTTPX's hierarchy, is not retried."""
-    with HttpxHttpClient() as client:
+    with Httpx2HttpClient() as client:
         assert not client.is_retryable_transport_error(exc)
 
 
 def test_sync_httpx_client_classifies_timeout_errors() -> None:
     """The built-in synchronous HTTPX client exposes transport-neutral timeout classification."""
-    with HttpxHttpClient() as client:
+    with Httpx2HttpClient() as client:
         assert client.is_timeout_error(TimeoutError('test'))
         assert client.is_timeout_error(httpx.TimeoutException('test'))
         assert not client.is_timeout_error(ValueError('test'))
@@ -471,7 +471,7 @@ def test_sync_httpx_client_classifies_timeout_errors() -> None:
 
 async def test_async_httpx_client_classifies_timeout_errors() -> None:
     """The built-in asynchronous HTTPX client exposes transport-neutral timeout classification."""
-    async with HttpxHttpClientAsync() as client:
+    async with Httpx2HttpClientAsync() as client:
         assert client.is_timeout_error(TimeoutError('test'))
         assert client.is_timeout_error(httpx.TimeoutException('test'))
         assert not client.is_timeout_error(ValueError('test'))
@@ -516,7 +516,7 @@ def test_transient_transport_error_is_retried() -> None:
 
 def test_httpx_permanent_transport_error_is_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
     """The HTTPX adapter feeds the same fail-fast classification into the shared pipeline."""
-    with HttpxHttpClient(token='test_token', min_delay_between_retries=timedelta(0)) as client:
+    with Httpx2HttpClient(token='test_token', min_delay_between_retries=timedelta(0)) as client:
         send = Mock(side_effect=httpx.UnsupportedProtocol('unsupported scheme'))
         monkeypatch.setattr(client._httpx_client, 'send', send)
 
@@ -528,7 +528,7 @@ def test_httpx_permanent_transport_error_is_not_retried(monkeypatch: pytest.Monk
 
 async def test_httpx_permanent_transport_error_is_not_retried_async(monkeypatch: pytest.MonkeyPatch) -> None:
     """The asynchronous HTTPX adapter applies the same policy, failing on the first attempt."""
-    async with HttpxHttpClientAsync(token='test_token', min_delay_between_retries=timedelta(0)) as client:
+    async with Httpx2HttpClientAsync(token='test_token', min_delay_between_retries=timedelta(0)) as client:
         send = AsyncMock(side_effect=httpx.UnsupportedProtocol('unsupported scheme'))
         monkeypatch.setattr(client._httpx_async_client, 'send', send)
 
@@ -540,7 +540,7 @@ async def test_httpx_permanent_transport_error_is_not_retried_async(monkeypatch:
 
 def test_httpx_transient_transport_error_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
     """The HTTPX adapter keeps a transient transport failure inside the shared retry loop."""
-    with HttpxHttpClient(token='test_token', max_retries=2, min_delay_between_retries=timedelta(0)) as client:
+    with Httpx2HttpClient(token='test_token', max_retries=2, min_delay_between_retries=timedelta(0)) as client:
         send = Mock(side_effect=httpx.TimeoutException('timeout'))
         monkeypatch.setattr(client._httpx_client, 'send', send)
 
@@ -553,7 +553,7 @@ def test_httpx_transient_transport_error_is_retried(monkeypatch: pytest.MonkeyPa
 
 async def test_httpx_transient_transport_error_is_retried_async(monkeypatch: pytest.MonkeyPatch) -> None:
     """The asynchronous HTTPX adapter keeps a transient transport failure inside the shared retry loop too."""
-    async with HttpxHttpClientAsync(
+    async with Httpx2HttpClientAsync(
         token='test_token', max_retries=2, min_delay_between_retries=timedelta(0)
     ) as client:
         send = AsyncMock(side_effect=httpx.TimeoutException('timeout'))

--- a/tests/unit/test_pluggable_http_client.py
+++ b/tests/unit/test_pluggable_http_client.py
@@ -356,8 +356,8 @@ def test_public_exports() -> None:
         'HttpClient',
         'HttpClientAsync',
         'HttpResponse',
-        'HttpxHttpClient',
-        'HttpxHttpClientAsync',
+        'Httpx2HttpClient',
+        'Httpx2HttpClientAsync',
         'ImpitHttpClient',
         'ImpitHttpClientAsync',
     ):
@@ -373,13 +373,13 @@ def test_httpx_clients_raise_clear_error_when_extra_missing() -> None:
         """
         import sys
 
-        class BlockHttpx:
+        class BlockHttpx2:
             def find_spec(self, name, *_args):
                 if name == 'httpx2' or name.startswith('httpx2.'):
                     raise ModuleNotFoundError(f"No module named '{name}'", name='httpx2')
                 return None
 
-        sys.meta_path.insert(0, BlockHttpx())
+        sys.meta_path.insert(0, BlockHttpx2())
 
         import apify_client.http_clients as module
         assert module.HttpClient is not None
@@ -388,14 +388,14 @@ def test_httpx_clients_raise_clear_error_when_extra_missing() -> None:
         namespace = {}
         exec('from apify_client.http_clients import *', namespace)
         assert namespace['HttpClient'] is module.HttpClient
-        assert 'HttpxHttpClient' not in namespace
+        assert 'Httpx2HttpClient' not in namespace
 
-        for name in ('HttpxHttpClient', 'HttpxHttpClientAsync'):
+        for name in ('Httpx2HttpClient', 'Httpx2HttpClientAsync'):
             try:
                 getattr(module, name)
             except ImportError as exc:
                 assert "No module named 'httpx2'" in str(exc)
-                assert "pip install 'apify-client[httpx]'" in str(exc)
+                assert "pip install 'apify-client[httpx2]'" in str(exc)
             else:
                 raise AssertionError(f'{name} did not raise ImportError')
         """

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ dependencies = [
 brotli = [
     { name = "brotli" },
 ]
-httpx = [
+httpx2 = [
     { name = "httpx2" },
 ]
 
@@ -85,13 +85,13 @@ dev = [
 requires-dist = [
     { name = "brotli", marker = "extra == 'brotli'", specifier = ">=1.0.9" },
     { name = "colorama", specifier = ">=0.4.0" },
-    { name = "httpx2", marker = "extra == 'httpx'", specifier = ">=2.0.0" },
+    { name = "httpx2", marker = "extra == 'httpx2'", specifier = ">=2.0.0" },
     { name = "impit", specifier = "~=0.14.0" },
     { name = "more-itertools", specifier = ">=10.0.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.11.0" },
     { name = "typing-extensions", specifier = ">=4.6.0" },
 ]
-provides-extras = ["brotli", "httpx"]
+provides-extras = ["brotli", "httpx2"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Renames the optional extra `httpx` to `httpx2`, and `HttpxHttpClient` / `HttpxHttpClientAsync` to `Httpx2HttpClient` / `Httpx2HttpClientAsync`, along with the private module, the docs examples, and the test ids. Once httpx releases 1.0 with a new API, an extra named `httpx` that installs `httpx2` would confuse users (see https://github.com/apify/apify-client-python/pull/1046#issuecomment-5508233212).

Neither name has shipped in a stable release, so nothing is breaking. Kept as is: the `import httpx2 as httpx` alias inside the module, "HTTPX" as the library name in prose, and the historical v2 upgrade note.

Follows up on #1046.

*✍️ Drafted by Claude Code*
