### PR TITLE
fix: Add the description field to Actor task models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,7 +245,7 @@ keep_model_order = true
 # workflow committing nothing unless the models changed. A local regeneration that only moves this line is that
 # same case - drop it rather than committing it alone.
 [tool.apify.openapi-spec]
-version = "v2-2026-08-30T172245Z"
+version = "v2-2026-08-31T125154Z"
 
 [tool.uv]
 # Minimal defense against supply-chain atatcks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,9 @@ use_field_description = true
 use_union_operator = true
 capitalise_enum_members = true
 collapse_root_models = true
+# Folds a schema that only aliases another one (a `$ref` plus a description) into the referenced model, so a
+# bundler hoisting such an alias into its own component can't turn an enum-typed field into a `RootModel` wrapper.
+collapse_root_models_name_strategy = "child"
 set_default_enum_member = true
 use_annotated = true
 wrap_string_literal = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,8 +222,6 @@ use_field_description = true
 use_union_operator = true
 capitalise_enum_members = true
 collapse_root_models = true
-# Folds a schema that only aliases another one (a `$ref` plus a description) into the referenced model, so a
-# bundler hoisting such an alias into its own component can't turn an enum-typed field into a `RootModel` wrapper.
 collapse_root_models_name_strategy = "child"
 set_default_enum_member = true
 use_annotated = true

--- a/src/apify_client/_models.py
+++ b/src/apify_client/_models.py
@@ -872,6 +872,7 @@ class CreateTaskRequest(BaseModel):
     options: TaskOptions | None = None
     input: TaskInput | list[TaskInput] | None = None
     title: str | None = None
+    description: str | None = None
     actor_standby: ActorStandby | None = None
     public_config: TaskPublicConfig | None = None
     """
@@ -1473,7 +1474,7 @@ class HeadRequest(BaseModel):
     """
     The URL of the request.
     """
-    method: HttpMethod | None = None
+    method: RequestMethod | None = None
     retry_count: Annotated[int | None, Field(examples=[0])] = None
     """
     The number of times this request has been retried.
@@ -1892,7 +1893,7 @@ class LockedHeadRequest(BaseModel):
     """
     The URL of the request.
     """
-    method: HttpMethod | None = None
+    method: RequestMethod | None = None
     retry_count: Annotated[int | None, Field(examples=[0])] = None
     """
     The number of times this request has been retried.
@@ -2432,7 +2433,7 @@ class RequestBase(BaseModel):
     """
     The URL of the request.
     """
-    method: HttpMethod | None = None
+    method: RequestMethod | None = None
     retry_count: Annotated[int | None, Field(examples=[0])] = None
     """
     The number of times this request has been retried.
@@ -2500,7 +2501,7 @@ class RequestDraft(BaseModel):
     """
     The URL of the request.
     """
-    method: HttpMethod | None = None
+    method: RequestMethod | None = None
 
 
 @docs_group('Models')
@@ -2561,6 +2562,14 @@ class RequestLockInfo(BaseModel):
     lock_expires_at: Annotated[AwareDatetime, Field(examples=['2022-06-14T23:00:00.000Z'])]
     """
     The timestamp when the lock on this request expires.
+    """
+
+
+@docs_group('Models')
+class RequestMethod(RootModel[HttpMethod]):
+    root: HttpMethod
+    """
+    The HTTP method of the request.
     """
 
 
@@ -3505,6 +3514,7 @@ class Task(BaseModel):
     options: TaskOptions | None = None
     input: TaskInput | list[TaskInput] | None = None
     title: str | None = None
+    description: str | None = None
     actor_standby: ActorStandby | None = None
     standby_url: AnyUrl | None = None
     is_public: Annotated[bool | None, Field(examples=[False])] = None
@@ -3869,6 +3879,7 @@ class UpdateTaskRequest(BaseModel):
     options: TaskOptions | None = None
     input: TaskInput | list[TaskInput] | None = None
     title: str | None = None
+    description: str | None = None
     actor_standby: ActorStandby | None = None
     public_config: TaskPublicConfig | None = None
     """

--- a/src/apify_client/_models.py
+++ b/src/apify_client/_models.py
@@ -1474,7 +1474,7 @@ class HeadRequest(BaseModel):
     """
     The URL of the request.
     """
-    method: RequestMethod | None = None
+    method: HttpMethod | None = None
     retry_count: Annotated[int | None, Field(examples=[0])] = None
     """
     The number of times this request has been retried.
@@ -1893,7 +1893,7 @@ class LockedHeadRequest(BaseModel):
     """
     The URL of the request.
     """
-    method: RequestMethod | None = None
+    method: HttpMethod | None = None
     retry_count: Annotated[int | None, Field(examples=[0])] = None
     """
     The number of times this request has been retried.
@@ -2433,7 +2433,7 @@ class RequestBase(BaseModel):
     """
     The URL of the request.
     """
-    method: RequestMethod | None = None
+    method: HttpMethod | None = None
     retry_count: Annotated[int | None, Field(examples=[0])] = None
     """
     The number of times this request has been retried.
@@ -2501,7 +2501,7 @@ class RequestDraft(BaseModel):
     """
     The URL of the request.
     """
-    method: RequestMethod | None = None
+    method: HttpMethod | None = None
 
 
 @docs_group('Models')
@@ -2562,14 +2562,6 @@ class RequestLockInfo(BaseModel):
     lock_expires_at: Annotated[AwareDatetime, Field(examples=['2022-06-14T23:00:00.000Z'])]
     """
     The timestamp when the lock on this request expires.
-    """
-
-
-@docs_group('Models')
-class RequestMethod(RootModel[HttpMethod]):
-    root: HttpMethod
-    """
-    The HTTP method of the request.
     """
 
 

--- a/src/apify_client/_typeddicts.py
+++ b/src/apify_client/_typeddicts.py
@@ -18,6 +18,9 @@ class RequestBaseDict(TypedDict):
     The URL of the request.
     """
     method: NotRequired[Literal['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH']]
+    """
+    The HTTP method of the request.
+    """
     retry_count: NotRequired[int]
     """
     The number of times this request has been retried.
@@ -60,6 +63,9 @@ class RequestBaseCamelDict(TypedDict):
     The URL of the request.
     """
     method: NotRequired[Literal['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH']]
+    """
+    The HTTP method of the request.
+    """
     retryCount: NotRequired[int]
     """
     The number of times this request has been retried.


### PR DESCRIPTION
Regenerates the models from the [published OpenAPI specification](https://docs.apify.com/api/openapi.json), version `v2-2026-08-30T172245Z` -> `v2-2026-08-31T125154Z` (the stamp lags its content by one deploy; the content is from 2026-09-02).

- Adds the `description` field to `Task`, `CreateTaskRequest`, and `UpdateTaskRequest` (apify/apify-docs#2922).
- Sets `collapse_root_models_name_strategy = "child"` for datamodel-codegen. apify/apify-docs#2938 bumped `@redocly/cli` 2.26.0 -> 2.49.0, and its bundler now keeps the shared `RequestMethod` alias (a `$ref` to `HttpMethod` plus a description) as a separate component instead of collapsing it. datamodel-codegen turned that into a `RequestMethod(RootModel[HttpMethod])` wrapper, so `request.method` no longer compared equal to plain strings and the request queue integration tests failed. With the option the alias folds back into `HttpMethod`, and the generated models are identical to the previous bundler's output.

> Generated by the [Regenerate models](https://github.com/apify/apify-client-python/actions/workflows/on_schedule_regenerate_models.yaml) workflow.

*✍️ Drafted by Claude Code*
